### PR TITLE
Add links to doc site in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Entity is a privacy-aware data layer for defining, caching, and authorizing acce
 
 ## Getting Started
 
-The best place get started is by checking out the [example application](packages/entity-example).
+- [Example application](packages/entity-example)
+- [Documentation](https://expo.github.io/entity/)
+
 
 ## Background
 

--- a/packages/entity-cache-adapter-redis/README.md
+++ b/packages/entity-cache-adapter-redis/README.md
@@ -1,6 +1,8 @@
-# @expo/entity-cache-adapter-redis
+# `@expo/entity-cache-adapter-redis`
 
-[https://github.com/luin/ioredis](ioredis) cache adapter for @expo/entity.
+[ioredis](https://github.com/luin/ioredis) cache adapter for `@expo/entity`.
+
+[Documentation](https://expo.github.io/entity/modules/_expo_entity_cache_adapter_redis.html)
 
 ## Usage
 

--- a/packages/entity-database-adapter-knex/README.md
+++ b/packages/entity-database-adapter-knex/README.md
@@ -1,6 +1,8 @@
-# @expo/entity-database-adapter-knex
+# `@expo/entity-database-adapter-knex`
 
-[http://knexjs.org/](Knex) database adapter for @expo/entity. Currently only used with Postgres client.
+[Knex](http://knexjs.org/) database adapter for `@expo/entity`. Currently only used with Postgres client.
+
+[Documentation](https://expo.github.io/entity/modules/_expo_entity_database_adapter_knex.html)
 
 ## Usage
 

--- a/packages/entity/README.md
+++ b/packages/entity/README.md
@@ -1,6 +1,6 @@
-# @expo/entity
+# `@expo/entity`
 
-> Note: Documentation is a work-in-progress, but all concepts are documented in source code JSDoc.
+[Documentation](https://expo.github.io/entity/modules/_expo_entity.html)
 
 ## Core Overview
 


### PR DESCRIPTION
# Why

For those browsing the github, having links to documentation can be helpful.

# Test Plan

Preview readme markdown.
