### PR TITLE
Upgrade typescript to 3.9

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ts-mockito": "^2.5.0",
     "typedoc": "^0.17.6",
     "typedoc-plugin-lerna-packages": "^0.3.0",
-    "typescript": "^3.8.3",
+    "typescript": "^3.9.2",
     "uuid": "^7.0.3"
   },
   "dependencies": {

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -49,10 +49,10 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
       .whereRaw('?? = ANY(?)', [tableField, tableValues as any[]]);
   }
 
-  private applyQueryModifiersToQuery<T extends any>(
-    query: T,
+  private applyQueryModifiersToQuery(
+    query: Knex.QueryBuilder,
     querySelectionModifiers: TableQuerySelectionModifiers
-  ): T {
+  ): Knex.QueryBuilder {
     const { orderBy, offset, limit } = querySelectionModifiers;
 
     let ret = query;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8579,10 +8579,10 @@ typedoc@^0.17.6:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.10.1"
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 uglify-js@^3.1.4:
   version "3.9.1"


### PR DESCRIPTION
# Why

Release notes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#breaking-changes

For this project, the changes that affect us are:
- speed improvements
- Type Parameters That Extend any No Longer Act as any

# How

Upgrade in package.json

# Test Plan

`yarn test`
`yarn integration`
`yarn typedoc` (depends on typescript)