### PR TITLE
Add loadByIDNullableAsync loader method

### DIFF
--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -85,6 +85,16 @@ export default class EnforcingEntityLoader<
 
   /**
    * Enforcing version of entity loader method by the same name.
+   * @throws {@link EntityNotAuthorizedError} when viewer is not authorized to view the returned entity
+   * @throws when multiple entities are found matching the condition
+   */
+  async loadByIDNullableAsync(id: TID): Promise<TEntity | null> {
+    const entityResult = await this.entityLoader.loadByIDNullableAsync(id);
+    return entityResult ? entityResult.enforceValue() : null;
+  }
+
+  /**
+   * Enforcing version of entity loader method by the same name.
    * @throws {@link EntityNotAuthorizedError} when viewer is not authorized to view one or more of the returned entities
    */
   async loadManyByIDsAsync(ids: readonly TID[]): Promise<ReadonlyMap<TID, TEntity>> {

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -136,6 +136,15 @@ export default class EntityLoader<
   }
 
   /**
+   * Load an entity by a specified ID, or return null if non-existent.
+   * @param id - ID of the entity
+   * @returns entity result for matching ID, or null if no entity exists for ID.
+   */
+  async loadByIDNullableAsync(id: TID): Promise<Result<TEntity> | null> {
+    return await this.loadByFieldEqualingAsync(this.entityConfiguration.idField, id as any);
+  }
+
+  /**
    * Loads many entities for a list of IDs.
    * @param viewerContext - viewer context of loading user
    * @param ids - IDs of the entities to load

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -149,6 +149,41 @@ describe(EnforcingEntityLoader, () => {
     });
   });
 
+  describe('loadByIDNullableAsync', () => {
+    it('throws when result is unsuccessful', async () => {
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const rejection = new Error();
+      when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(rejection));
+      const entityLoader = instance(entityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      await expect(enforcingEntityLoader.loadByIDNullableAsync(anything())).rejects.toThrow(
+        rejection
+      );
+    });
+
+    it('returns value when result is successful', async () => {
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const resolved = {};
+      when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(resolved));
+      const entityLoader = instance(entityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      await expect(enforcingEntityLoader.loadByIDNullableAsync(anything())).resolves.toEqual(
+        resolved
+      );
+    });
+
+    it('returns null when non-existent object', async () => {
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const resolved = null;
+      when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(resolved));
+      const entityLoader = instance(entityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      await expect(enforcingEntityLoader.loadByIDNullableAsync(anything())).resolves.toEqual(
+        resolved
+      );
+    });
+  });
+
   describe('loadManyByIDsAsync', () => {
     it('throws when result is unsuccessful', async () => {
       const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
@@ -241,5 +276,20 @@ describe(EnforcingEntityLoader, () => {
         enforcingEntityLoader.loadManyByRawWhereClauseAsync(anything(), anything(), anything())
       ).resolves.toEqual([resolved]);
     });
+  });
+
+  it('has the same method names as EntityLoader', () => {
+    const enforcingLoaderProperties = Object.getOwnPropertyNames(EnforcingEntityLoader.prototype);
+    const loaderProperties = Object.getOwnPropertyNames(EntityLoader.prototype);
+
+    // ensure known differences still exist for sanity check
+    const knownLoaderOnlyDifferences = ['enforcing', 'invalidateFieldsAsync'];
+    expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));
+
+    const loaderPropertiesWithoutKnownDifferences = loaderProperties.filter(
+      (p) => !knownLoaderOnlyDifferences.includes(p)
+    );
+
+    expect(enforcingLoaderProperties).toEqual(loaderPropertiesWithoutKnownDifferences);
   });
 });

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -76,6 +76,9 @@ describe(EntityLoader, () => {
     await expect(entityLoader.loadByFieldEqualingAsync('stringField', 'huh')).rejects.toThrowError(
       'loadByFieldEqualing: Multiple entities of type TestEntity found for stringField=huh'
     );
+
+    await expect(entityLoader.loadByIDNullableAsync('fake')).resolves.toBeNull();
+    await expect(entityLoader.loadByIDNullableAsync('hello')).resolves.not.toBeNull();
   });
 
   it('loads entities with loadManyByFieldEqualityConjunction', async () => {


### PR DESCRIPTION
# Why

One common use case we're noticing is wanting to check if an ID corresponds to one table or another (only useful for UUID primary key tables).

Another use case is determining whether an ID that should exist truly does (loading permalink page). While this can be handled cleanly with a good error boundary, it still makes sense to have this API available when preferred.

Closes #12.

# How

Add method, enforcing method, and tests. Also add test to ensure consistent API between loader and enforcing loader.

# Test Plan

Run tests.
