### PR TITLE
Add more documentation to privacy policy classes

### DIFF
--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -40,7 +40,7 @@ export enum EntityAuthorizationAction {
  *
  * @remarks
  *
- * A privacy policy declares lists of privacy rules for create, read, update, and delete actions
+ * A privacy policy declares lists of {@link PrivacyPolicyRule} for create, read, update, and delete actions
  * for an entity and provides logic for authorizing an entity against rules.
  *
  * Evaluation of a list of rules is performed according the following example. This allows constructing of
@@ -105,6 +105,7 @@ export default abstract class EntityPrivacyPolicy<
   /**
    * Authorize an entity against creation policy.
    * @param viewerContext - viewer context of user creating the entity
+   * @param queryContext - query context in which to perform the create authorization
    * @param entity - entity to authorize
    * @returns entity if authorized
    * @throws {@link EntityNotAuthorizedError} when not authorized
@@ -126,6 +127,7 @@ export default abstract class EntityPrivacyPolicy<
   /**
    * Authorize an entity against read policy.
    * @param viewerContext - viewer context of user reading the entity
+   * @param queryContext - query context in which to perform the read authorization
    * @param entity - entity to authorize
    * @returns entity if authorized
    * @throws {@link EntityNotAuthorizedError} when not authorized
@@ -147,6 +149,7 @@ export default abstract class EntityPrivacyPolicy<
   /**
    * Authorize an entity against update policy.
    * @param viewerContext - viewer context of user updating the entity
+   * @param queryContext - query context in which to perform the update authorization
    * @param entity - entity to authorize
    * @returns entity if authorized
    * @throws {@link EntityNotAuthorizedError} when not authorized
@@ -168,6 +171,7 @@ export default abstract class EntityPrivacyPolicy<
   /**
    * Authorize an entity against deletion policy.
    * @param viewerContext - viewer context of user deleting the entity
+   * @param queryContext - query context in which to perform the delete authorization
    * @param entity - entity to authorize
    * @returns entity if authorized
    * @throws {@link EntityNotAuthorizedError} when not authorized

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -46,7 +46,7 @@ export { default as AlwaysDenyPrivacyPolicyRule } from './rules/AlwaysDenyPrivac
 export { default as AlwaysSkipPrivacyPolicyRule } from './rules/AlwaysSkipPrivacyPolicyRule';
 export { default as PrivacyPolicyRule } from './rules/PrivacyPolicyRule';
 export * from './rules/PrivacyPolicyRule';
-export * from './rules/PrivacyPolicyRuleTestUtils';
+export * from './testfixtures/PrivacyPolicyRuleTestUtils';
 export { default as SimpleTestEntity } from './testfixtures/SimpleTestEntity';
 export * from './testfixtures/StubCacheAdapter';
 export { default as StubDatabaseAdapter } from './testfixtures/StubDatabaseAdapter';

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -3,6 +3,9 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
 
+/**
+ * Privacy policy rule that always allows.
+ */
 export default class AlwaysAllowPrivacyPolicyRule<
   TFields,
   TID,

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -3,6 +3,9 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
 
+/**
+ * Privacy policy rule that always denies.
+ */
 export default class AlwaysDenyPrivacyPolicyRule<
   TFields,
   TID,

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -3,6 +3,9 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
 
+/**
+ * A no-op policy rule that always skips.
+ */
 export default class AlwaysSkipPrivacyPolicyRule<
   TFields,
   TID,

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -3,11 +3,38 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 
 export enum RuleEvaluationResult {
+  /**
+   * Deny viewer access to the entity.
+   */
   DENY = -1,
+
+  /**
+   * Defer entity viewer access to subsequent rule in the privacy policy.
+   */
   SKIP = 0,
+
+  /**
+   * Allow viewer access to the entity.
+   */
   ALLOW = 1,
 }
 
+/**
+ * A single unit of which declarative privacy policies are composed, allowing for simple
+ * expression and testing of authorization logic.
+ *
+ * @remarks
+ *
+ * Each rule is responsible for returning a ruling of ALLOW, DENY, or SKIP for a condition
+ * that it is checking for. While rules can return any of these, it is most common for
+ * rules to return ALLOW or SKIP, explicitly authorizing or deferring authorization to the next
+ * rule in the privacy policy. If all rules in the policy SKIP, the policy is denied.
+ *
+ * Returning DENY from a rule is useful in a few notable cases:
+ * - Preventing a CRUD action on an entity ({@link AlwaysDenyPrivacyPolicyRule})
+ * - Blocking. For example, a user blocks another user from seeing their posts, and the rule
+ *   would be named something like `DenyIfViewerHasBeenBlockedPrivacyPolicyRule`.
+ */
 export default abstract class PrivacyPolicyRule<
   TFields,
   TID,

--- a/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
@@ -2,8 +2,8 @@ import { mock, instance, anything } from 'ts-mockito';
 
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../testfixtures/PrivacyPolicyRuleTestUtils';
 import AlwaysAllowPrivacyPolicyRule from '../AlwaysAllowPrivacyPolicyRule';
-import { describePrivacyPolicyRule } from '../PrivacyPolicyRuleTestUtils';
 
 describePrivacyPolicyRule(new AlwaysAllowPrivacyPolicyRule(), {
   allowCases: [

--- a/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
@@ -2,8 +2,8 @@ import { mock, instance, anything } from 'ts-mockito';
 
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../testfixtures/PrivacyPolicyRuleTestUtils';
 import AlwaysDenyPrivacyPolicyRule from '../AlwaysDenyPrivacyPolicyRule';
-import { describePrivacyPolicyRule } from '../PrivacyPolicyRuleTestUtils';
 
 describePrivacyPolicyRule(new AlwaysDenyPrivacyPolicyRule(), {
   denyCases: [

--- a/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
@@ -2,8 +2,8 @@ import { mock, instance, anything } from 'ts-mockito';
 
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../testfixtures/PrivacyPolicyRuleTestUtils';
 import AlwaysSkipPrivacyPolicyRule from '../AlwaysSkipPrivacyPolicyRule';
-import { describePrivacyPolicyRule } from '../PrivacyPolicyRuleTestUtils';
 
 describePrivacyPolicyRule(new AlwaysSkipPrivacyPolicyRule(), {
   skipCases: [

--- a/packages/entity/src/testfixtures/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/testfixtures/PrivacyPolicyRuleTestUtils.ts
@@ -1,7 +1,7 @@
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
-import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
+import PrivacyPolicyRule, { RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
 
 export interface Case<
   TFields,


### PR DESCRIPTION
# Why

This adds more documentation to the privacy policy classes included with the library.

Closes #20.

# Test Plan

Run tests to ensure file rename is okay.
