### PR TITLE
Add ability to check update and delete policies outside of mutation

### DIFF
--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -78,6 +78,27 @@ export default abstract class ReadonlyEntity<TFields, TID, TViewerContext extend
   }
 
   /**
+   * Get the regular (non-transactional) query context for this entity.
+   * @param viewerContext - viewer context of calling user
+   */
+  static getRegularEntityQueryContext<
+    TMFields,
+    TMID,
+    TMViewerContext extends ViewerContext,
+    TMViewerContext2 extends TMViewerContext,
+    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+  >(
+    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    viewerContext: TMViewerContext2
+  ): EntityQueryContext {
+    return viewerContext
+      .getViewerScopedEntityCompanionForClass(this)
+      .getQueryContextProvider()
+      .getRegularEntityQueryContext();
+  }
+
+  /**
    * Start a transaction and execute the provided transaction-scoped closure within the transaction.
    * @param viewerContext - viewer context of calling user
    * @param transactionScope - async callback to execute within the transaction

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -1,0 +1,163 @@
+import Entity from '../Entity';
+import {
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  EntityCompanionDefinition,
+} from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField } from '../EntityFields';
+import { CreateMutator, UpdateMutator } from '../EntityMutator';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import ViewerContext from '../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
+import AlwaysDenyPrivacyPolicyRule from '../rules/AlwaysDenyPrivacyPolicyRule';
+import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
+import { createUnitTestEntityCompanionProvider } from '../testfixtures/createUnitTestEntityCompanionProvider';
+
+describe(Entity, () => {
+  describe('creator', () => {
+    it('creates a new CreateMutator', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      expect(SimpleTestEntity.creator(viewerContext)).toBeInstanceOf(CreateMutator);
+    });
+  });
+
+  describe('updater', () => {
+    it('creates a new UpdateMutator', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity(viewerContext, data);
+      expect(SimpleTestEntity.updater(testEntity)).toBeInstanceOf(UpdateMutator);
+    });
+  });
+
+  describe('canViewerUpdate', () => {
+    it('appropriately executes update privacy policy', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestDenyDeleteEntity(viewerContext, data);
+      const canViewerUpdate = await SimpleTestDenyDeleteEntity.canViewerUpdate(testEntity);
+      expect(canViewerUpdate).toBe(true);
+    });
+
+    it('denies when policy denies', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestDenyUpdateEntity(viewerContext, data);
+      const canViewerUpdate = await SimpleTestDenyUpdateEntity.canViewerUpdate(testEntity);
+      expect(canViewerUpdate).toBe(false);
+    });
+  });
+
+  describe('canViewerDelete', () => {
+    it('appropriately executes update privacy policy', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestDenyUpdateEntity(viewerContext, data);
+      const canViewerDelete = await SimpleTestDenyUpdateEntity.canViewerDelete(testEntity);
+      expect(canViewerDelete).toBe(true);
+    });
+
+    it('denies when policy denies', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestDenyDeleteEntity(viewerContext, data);
+      const canViewerDelete = await SimpleTestDenyDeleteEntity.canViewerDelete(testEntity);
+      expect(canViewerDelete).toBe(false);
+    });
+  });
+});
+
+type TestEntityFields = {
+  id: string;
+};
+
+const testEntityConfiguration = new EntityConfiguration<TestEntityFields>({
+  idField: 'id',
+  tableName: 'blah',
+  schema: {
+    id: new UUIDField({
+      columnName: 'custom_id',
+    }),
+  },
+});
+
+class SimpleTestDenyUpdateEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  TestEntityFields,
+  string,
+  ViewerContext,
+  SimpleTestDenyUpdateEntity
+> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysDenyPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+class SimpleTestDenyDeleteEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  TestEntityFields,
+  string,
+  ViewerContext,
+  SimpleTestDenyDeleteEntity
+> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysDenyPrivacyPolicyRule()];
+}
+
+class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestEntityFields,
+    string,
+    ViewerContext,
+    SimpleTestDenyUpdateEntity,
+    SimpleTestDenyUpdateEntityPrivacyPolicy
+  > {
+    return simpleTestDenyUpdateEntityCompanion;
+  }
+}
+
+const simpleTestDenyUpdateEntityCompanion = {
+  entityClass: SimpleTestDenyUpdateEntity,
+  entityConfiguration: testEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: SimpleTestDenyUpdateEntityPrivacyPolicy,
+};
+
+class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestEntityFields,
+    string,
+    ViewerContext,
+    SimpleTestDenyDeleteEntity,
+    SimpleTestDenyDeleteEntityPrivacyPolicy
+  > {
+    return simpleTestDenyDeleteEntityCompanion;
+  }
+}
+
+const simpleTestDenyDeleteEntityCompanion = {
+  entityClass: SimpleTestDenyDeleteEntity,
+  entityConfiguration: testEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: SimpleTestDenyDeleteEntityPrivacyPolicy,
+};

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -1,30 +1,37 @@
 import { instance, mock } from 'ts-mockito';
 
 import EntityAssociationLoader from '../EntityAssociationLoader';
+import EntityLoader from '../EntityLoader';
+import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
+import { createUnitTestEntityCompanionProvider } from '../testfixtures/createUnitTestEntityCompanionProvider';
 
 describe(ReadonlyEntity, () => {
-  it('returns correct ID', () => {
-    const viewerContext = instance(mock(ViewerContext));
-    const data = {
-      id: 'what',
-    };
-    const testEntity = new SimpleTestEntity(viewerContext, data);
-    expect(testEntity.getID()).toEqual('what');
+  describe('getID', () => {
+    it('returns correct value', () => {
+      const viewerContext = instance(mock(ViewerContext));
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity(viewerContext, data);
+      expect(testEntity.getID()).toEqual('what');
+    });
   });
 
-  it('returns correct toString', () => {
-    const viewerContext = instance(mock(ViewerContext));
-    const data = {
-      id: 'what',
-    };
-    const testEntity = new SimpleTestEntity(viewerContext, data);
-    expect(testEntity.toString()).toEqual('SimpleTestEntity[what]');
+  describe('toString', () => {
+    it('returns correct value', () => {
+      const viewerContext = instance(mock(ViewerContext));
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity(viewerContext, data);
+      expect(testEntity.toString()).toEqual('SimpleTestEntity[what]');
+    });
   });
 
-  it('cannot create instance without ID', () => {
+  it('cannot be created without an ID', () => {
     const viewerContext = instance(mock(ViewerContext));
     const dataWithoutID = {};
     expect(() => {
@@ -51,12 +58,47 @@ describe(ReadonlyEntity, () => {
     expect(testEntity.getAllFields()).toEqual(data);
   });
 
-  it('returns a new association loader', () => {
-    const viewerContext = instance(mock(ViewerContext));
-    const data = {
-      id: 'what',
-    };
-    const testEntity = new SimpleTestEntity(viewerContext, data);
-    expect(testEntity.associationLoader()).toBeInstanceOf(EntityAssociationLoader);
+  describe('associationLoader', () => {
+    it('returns a new association loader', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity(viewerContext, data);
+      expect(testEntity.associationLoader()).toBeInstanceOf(EntityAssociationLoader);
+    });
+  });
+
+  describe('getRegularEntityQueryContext', () => {
+    it('creates a new regular query context', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const queryContext = SimpleTestEntity.getRegularEntityQueryContext(viewerContext);
+      expect(queryContext).toBeInstanceOf(EntityQueryContext);
+      expect(queryContext.isInTransaction()).toBe(false);
+    });
+  });
+
+  describe('runInTransactionAsync', () => {
+    it('creates a new transactional query context', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const didCreateTransaction = await SimpleTestEntity.runInTransactionAsync(
+        viewerContext,
+        async (queryContext) => {
+          return queryContext.isInTransaction();
+        }
+      );
+      expect(didCreateTransaction).toBe(true);
+    });
+  });
+
+  describe('loader', () => {
+    it('creates a new EntityLoader', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      expect(SimpleTestEntity.loader(viewerContext)).toBeInstanceOf(EntityLoader);
+    });
   });
 });

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -47,14 +47,8 @@ export { default as AlwaysSkipPrivacyPolicyRule } from './rules/AlwaysSkipPrivac
 export { default as PrivacyPolicyRule } from './rules/PrivacyPolicyRule';
 export * from './rules/PrivacyPolicyRule';
 export * from './testfixtures/PrivacyPolicyRuleTestUtils';
-export { default as SimpleTestEntity } from './testfixtures/SimpleTestEntity';
 export * from './testfixtures/StubCacheAdapter';
 export { default as StubDatabaseAdapter } from './testfixtures/StubDatabaseAdapter';
 export { default as StubQueryContextProvider } from './testfixtures/StubQueryContextProvider';
-export { default as TestEntity } from './testfixtures/TestEntity';
-export * from './testfixtures/TestEntity';
-export { default as TestEntity2 } from './testfixtures/TestEntity2';
-export * from './testfixtures/TestEntity2';
-export { default as TestViewerContext } from './testfixtures/TestViewerContext';
 export * from './testfixtures/createUnitTestEntityCompanionProvider';
 export * from './utils/collections/maps';


### PR DESCRIPTION
# Why

Closes #21. 

# How

Add a set of new static methods that we've found would be useful in expo server.

# Test Plan

Run new tests.
