### PR TITLE
docs: update privacy policy documentation to indicate fallthrough behavior

### DIFF
--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -50,9 +50,10 @@ export enum EntityAuthorizationAction {
  *
  * ```
  * foreach rule in rules:
- *   authorized if rule allows
+ *   return authorized if rule allows
+ *   return not authorized if rule denies
  *   continue to next rule if rule skips
- *   not authorized if rule denies
+ * return not authorized if all rules skip
  * ```
  */
 export default abstract class EntityPrivacyPolicy<


### PR DESCRIPTION
# Why

As suggested by @jkhales, this clarifies the fallthrough behavior in the documentation. This was already documented in `EntityPrivacyPolicyRule` documentation but should be documented here as well.

Closes https://github.com/expo/entity/issues/40.