### PR TITLE
feat!: add support for entities sharing the same table

### DIFF
--- a/packages/entity-cache-adapter-redis/src/RedisCacheAdapter.ts
+++ b/packages/entity-cache-adapter-redis/src/RedisCacheAdapter.ts
@@ -156,10 +156,7 @@ export default class RedisCacheAdapter<TFields> extends EntityCacheAdapter<TFiel
   ): string {
     return this.context.makeKeyFn(
       this.context.cacheKeyPrefix,
-      this.entityConfiguration.tableName,
-      `v${this.entityConfiguration.cacheKeyVersion}`,
-      fieldName as string,
-      String(fieldValue)
+      ...this.getCacheKeyParts(fieldName, fieldValue)
     );
   }
 }

--- a/packages/entity/src/EntityCacheAdapter.ts
+++ b/packages/entity/src/EntityCacheAdapter.ts
@@ -7,7 +7,7 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
  * cached, fetched from cache, and removed from cache (invalidated).
  */
 export default abstract class EntityCacheAdapter<TFields> {
-  constructor(protected readonly entityConfiguration: EntityConfiguration<TFields>) {}
+  constructor(private readonly entityConfiguration: EntityConfiguration<TFields>) {}
 
   /**
    * Transformer definitions for field types. Used to modify values as they are read from or written to
@@ -15,6 +15,18 @@ export default abstract class EntityCacheAdapter<TFields> {
    * If a field type is not present in the map, then fields of that type will not be transformed.
    */
   public abstract getFieldTransformerMap(): FieldTransformerMap;
+
+  protected getCacheKeyParts<N extends keyof TFields>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>
+  ): string[] {
+    return [
+      this.entityConfiguration.cacheName,
+      `v${this.entityConfiguration.cacheKeyVersion}`,
+      fieldName as string,
+      String(fieldValue),
+    ];
+  }
 
   /**
    * Load many objects from cache.

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -10,8 +10,9 @@ export default class EntityConfiguration<TFields> {
   readonly tableName: string;
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly cacheKeyVersion: number;
+  readonly cacheName: string;
 
-  readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>;
+  readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>;
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
 
@@ -20,15 +21,18 @@ export default class EntityConfiguration<TFields> {
     tableName,
     schema,
     cacheKeyVersion = 0,
+    cacheName = tableName,
   }: {
     idField: keyof TFields;
     tableName: string;
-    schema: Record<keyof TFields, EntityFieldDefinition>;
+    schema: Record<keyof TFields, EntityFieldDefinition<any>>;
     cacheKeyVersion?: number;
+    cacheName?: string;
   }) {
     this.idField = idField;
     this.tableName = tableName;
     this.cacheKeyVersion = cacheKeyVersion;
+    this.cacheName = cacheName;
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups
@@ -43,7 +47,7 @@ export default class EntityConfiguration<TFields> {
   }
 
   private static computeCacheableKeys<TFields>(
-    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>
+    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>
   ): ReadonlySet<keyof TFields> {
     return reduceMap(
       schema,
@@ -58,7 +62,7 @@ export default class EntityConfiguration<TFields> {
   }
 
   private static computeEntityToDBFieldsKeyMapping<TFields>(
-    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>
+    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>
   ): ReadonlyMap<keyof TFields, string> {
     return mapMap(schema, (v) => v.columnName);
   }

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -5,6 +5,7 @@ import {
   transformDatabaseObjectToFields,
   transformFieldsToDatabaseObject,
   FieldTransformerMap,
+  validateFieldsForRead,
 } from './internal/EntityFieldTransformationUtils';
 
 interface SingleValueFieldEqualityCondition<TFields, N extends keyof TFields = keyof TFields> {
@@ -114,9 +115,11 @@ export default abstract class EntityDatabaseAdapter<TFields> {
       fieldColumn,
       fieldValues
     );
-    const objects = results.map((result) =>
-      transformDatabaseObjectToFields(this.entityConfiguration, this.fieldTransformerMap, result)
-    );
+    const objects = results
+      .map((result) =>
+        transformDatabaseObjectToFields(this.entityConfiguration, this.fieldTransformerMap, result)
+      )
+      .filter((result) => validateFieldsForRead(this.entityConfiguration, result));
 
     const objectMap = new Map();
     for (const fieldValue of fieldValues) {
@@ -176,9 +179,11 @@ export default abstract class EntityDatabaseAdapter<TFields> {
       this.convertToTableQueryModifiers(querySelectionModifiers)
     );
 
-    return results.map((result) =>
-      transformDatabaseObjectToFields(this.entityConfiguration, this.fieldTransformerMap, result)
-    );
+    return results
+      .map((result) =>
+        transformDatabaseObjectToFields(this.entityConfiguration, this.fieldTransformerMap, result)
+      )
+      .filter((result) => validateFieldsForRead(this.entityConfiguration, result));
   }
 
   protected abstract fetchManyByFieldEqualityConjunctionInternalAsync(
@@ -212,9 +217,11 @@ export default abstract class EntityDatabaseAdapter<TFields> {
       this.convertToTableQueryModifiers(querySelectionModifiers)
     );
 
-    return results.map((result) =>
-      transformDatabaseObjectToFields(this.entityConfiguration, this.fieldTransformerMap, result)
-    );
+    return results
+      .map((result) =>
+        transformDatabaseObjectToFields(this.entityConfiguration, this.fieldTransformerMap, result)
+      )
+      .filter((result) => validateFieldsForRead(this.entityConfiguration, result));
   }
 
   protected abstract fetchManyByRawWhereClauseInternalAsync(

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -1,6 +1,16 @@
-export abstract class EntityFieldDefinition {
+export interface FieldValidator<T> {
+  /**
+   * Validation to apply for this field when an entity is read from the database.
+   * Returning false will invalidate the entity load, making it as if the entry
+   * didn't exist.
+   */
+  read?: (value: T) => boolean;
+}
+
+export abstract class EntityFieldDefinition<T> {
   readonly columnName: string;
   readonly cache: boolean;
+  readonly validator: FieldValidator<T>;
   /**
    *
    * @param columnName - Column name in the database.
@@ -8,19 +18,30 @@ export abstract class EntityFieldDefinition {
    *              used to derive a cache key for the cache entry. If true, this column must be able uniquely
    *              identify the entity.
    */
-  constructor({ columnName, cache = false }: { columnName: string; cache?: boolean }) {
+  constructor({
+    columnName,
+    cache = false,
+    validator = {},
+  }: {
+    columnName: string;
+    cache?: boolean;
+    validator?: FieldValidator<T>;
+  }) {
     this.columnName = columnName;
     this.cache = cache;
+    this.validator = validator;
   }
 }
 
-export class StringField extends EntityFieldDefinition {}
+export class StringField extends EntityFieldDefinition<string> {}
 export class UUIDField extends StringField {}
-export class DateField extends EntityFieldDefinition {}
-export class BooleanField extends EntityFieldDefinition {}
-export class NumberField extends EntityFieldDefinition {}
-export class StringArrayField extends EntityFieldDefinition {}
-export class JSONObjectField extends EntityFieldDefinition {}
-export class EnumField extends EntityFieldDefinition {}
-export class JSONArrayField extends EntityFieldDefinition {}
-export class MaybeJSONArrayField extends EntityFieldDefinition {}
+export class DateField extends EntityFieldDefinition<Date> {}
+export class BooleanField extends EntityFieldDefinition<boolean> {}
+export class NumberField extends EntityFieldDefinition<number> {}
+export class StringArrayField extends EntityFieldDefinition<string[]> {}
+export class JSONObjectField<T extends object> extends EntityFieldDefinition<T> {}
+export class EnumField<T> extends EntityFieldDefinition<T> {}
+export class JSONArrayField<T> extends EntityFieldDefinition<T[]> {}
+export class MaybeJSONArrayField<TArray, TNotArray> extends EntityFieldDefinition<
+  TArray[] | TNotArray
+> {}

--- a/packages/entity/src/__tests__/EntityCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityCacheAdapter-test.ts
@@ -1,0 +1,55 @@
+import { mock, instance, when } from 'ts-mockito';
+
+import EntityCacheAdapter from '../EntityCacheAdapter';
+import EntityConfiguration from '../EntityConfiguration';
+import { FieldTransformerMap } from '../internal/EntityFieldTransformationUtils';
+
+describe(EntityCacheAdapter, () => {
+  class TestEntityCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+    public getFieldTransformerMap(): FieldTransformerMap {
+      throw new Error('Method not implemented.');
+    }
+    public loadManyAsync<N extends keyof TFields>(
+      _fieldName: N,
+      _fieldValues: readonly NonNullable<TFields[N]>[]
+    ): Promise<ReadonlyMap<NonNullable<TFields[N]>, import('..').CacheLoadResult>> {
+      throw new Error('Method not implemented.');
+    }
+    public cacheManyAsync<N extends keyof TFields>(
+      _fieldName: N,
+      _objectMap: ReadonlyMap<NonNullable<TFields[N]>, object>
+    ): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+    public cacheDBMissesAsync<N extends keyof TFields>(
+      _fieldName: N,
+      _fieldValues: readonly NonNullable<TFields[N]>[]
+    ): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+    public invalidateManyAsync<N extends keyof TFields>(
+      _fieldName: N,
+      _fieldValues: readonly NonNullable<TFields[N]>[]
+    ): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+  }
+
+  describe('getCacheKeyParts', () => {
+    it('returns expected key parts as strings', () => {
+      const configurationMock = mock(EntityConfiguration);
+      when(configurationMock.cacheName).thenReturn('blah');
+      when(configurationMock.cacheKeyVersion).thenReturn(10);
+
+      const testAdapter = new TestEntityCacheAdapter(instance(configurationMock));
+      expect(testAdapter['getCacheKeyParts']('hello', 'world')).toEqual([
+        'blah',
+        'v10',
+        'hello',
+        'world',
+      ]);
+
+      expect(testAdapter['getCacheKeyParts']('hello', 2)).toEqual(['blah', 'v10', 'hello', '2']);
+    });
+  });
+});

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -66,4 +66,34 @@ describe(EntityConfiguration, () => {
       expect(entityConfiguration.cacheKeyVersion).toEqual(100);
     });
   });
+
+  describe('cacheName', () => {
+    it('defaults to tableName', () => {
+      const entityConfiguration = new EntityConfiguration<Blah2T>({
+        idField: 'id',
+        tableName: 'blah',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+          }),
+        },
+      });
+      expect(entityConfiguration.cacheName).toEqual('blah');
+    });
+
+    it('sets to custom version', () => {
+      const entityConfiguration = new EntityConfiguration<Blah2T>({
+        idField: 'id',
+        tableName: 'blah',
+        cacheName: 'hello',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+          }),
+        },
+        cacheKeyVersion: 100,
+      });
+      expect(entityConfiguration.cacheName).toEqual('hello');
+    });
+  });
 });

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -1,6 +1,6 @@
 import { EntityFieldDefinition } from '../EntityFields';
 
-class TestFieldDefinition extends EntityFieldDefinition {}
+class TestFieldDefinition extends EntityFieldDefinition<any> {}
 
 describe(EntityFieldDefinition, () => {
   it('returns correct column name and defaults cache to false', () => {
@@ -11,5 +11,20 @@ describe(EntityFieldDefinition, () => {
     const fieldDefinition2 = new TestFieldDefinition({ columnName: 'wat', cache: true });
     expect(fieldDefinition2.columnName).toEqual('wat');
     expect(fieldDefinition2.cache).toEqual(true);
+  });
+
+  it('defaults validator to no-op', () => {
+    const fieldDefinition = new TestFieldDefinition({ columnName: 'wat', cache: true });
+    expect(fieldDefinition.validator).toEqual({});
+
+    const fn = (): boolean => false;
+    const fieldDefinition2 = new TestFieldDefinition({
+      columnName: 'wat',
+      cache: true,
+      validator: {
+        read: fn,
+      },
+    });
+    expect(fieldDefinition2.validator.read).toEqual(fn);
   });
 });

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
@@ -1,0 +1,187 @@
+import Entity from '../../Entity';
+import {
+  EntityCompanionDefinition,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+} from '../../EntityCompanionProvider';
+import EntityConfiguration from '../../EntityConfiguration';
+import { EntityNotFoundError } from '../../EntityErrors';
+import { UUIDField, EnumField, StringField } from '../../EntityFields';
+import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
+import ViewerContext from '../../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { InMemoryFullCacheStubCacheAdapter } from '../../utils/testing/StubCacheAdapter';
+import { createUnitTestEntityCompanionProvider } from '../../utils/testing/createUnitTestEntityCompanionProvider';
+
+describe('Two entities backed by the same table', () => {
+  test('load by different types', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const one = await OneTestEntity.creator(viewerContext)
+      .setField('entity_type', EntityType.ONE)
+      .enforceCreateAsync();
+
+    const two = await TwoTestEntity.creator(viewerContext)
+      .setField('entity_type', EntityType.TWO)
+      .setField('other_field', 'blah')
+      .enforceCreateAsync();
+
+    expect(one).toBeInstanceOf(OneTestEntity);
+    expect(two).toBeInstanceOf(TwoTestEntity);
+
+    await expect(
+      TwoTestEntity.loader(viewerContext).enforcing().loadByIDAsync(one.getID())
+    ).rejects.toThrowError(EntityNotFoundError);
+    await expect(
+      OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID())
+    ).rejects.toThrowError(EntityNotFoundError);
+  });
+
+  test('not cached if error is thrown during instantiation', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const one = await OneTestEntity.creator(viewerContext)
+      .setField('id', 'one')
+      .setField('entity_type', EntityType.ONE)
+      .enforceCreateAsync();
+
+    const two = await TwoTestEntity.creator(viewerContext)
+      .setField('id', 'two')
+      .setField('entity_type', EntityType.TWO)
+      .setField('other_field', 'blah')
+      .enforceCreateAsync();
+
+    try {
+      await OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID());
+    } catch (e) {}
+
+    const twoLoaded = await TwoTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(two.getID());
+    expect(twoLoaded.getAllFields()).toEqual(two.getAllFields());
+
+    try {
+      await TwoTestEntity.loader(viewerContext).enforcing().loadByIDAsync(one.getID());
+    } catch (e) {}
+
+    const oneLoaded = await OneTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(one.getID());
+    expect(oneLoaded.getAllFields()).toEqual(one.getAllFields());
+
+    const companion = companionProvider.getCompanionForEntity(
+      TwoTestEntity,
+      twoTestEntityCompanion
+    );
+    const cacheAdapter = companion['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<
+      TwoTestFields
+    >;
+
+    // check that only two objects were cached (invalid loads were not cached)
+    expect(cacheAdapter.cache.size).toEqual(2);
+  });
+});
+
+enum EntityType {
+  ONE,
+  TWO,
+}
+
+interface OneTestFields {
+  id: string;
+  entity_type: EntityType.ONE;
+}
+
+interface TwoTestFields {
+  id: string;
+  other_field: string;
+  entity_type: EntityType.TWO;
+}
+
+const oneTestEntityConfiguration = new EntityConfiguration<OneTestFields>({
+  idField: 'id',
+  tableName: 'entities',
+  cacheName: 'entities_1',
+  schema: {
+    id: new UUIDField({
+      columnName: 'custom_id',
+      cache: true,
+    }),
+    entity_type: new EnumField<EntityType>({
+      columnName: 'entity_type',
+      validator: {
+        read: (type) => type === EntityType.ONE,
+      },
+    }),
+  },
+});
+
+const twoTestEntityConfiguration = new EntityConfiguration<TwoTestFields>({
+  idField: 'id',
+  tableName: 'entities',
+  cacheName: 'entities_2',
+  schema: {
+    id: new UUIDField({
+      columnName: 'custom_id',
+      cache: true,
+    }),
+    other_field: new StringField({
+      columnName: 'other_field',
+    }),
+    entity_type: new EnumField<EntityType>({
+      columnName: 'entity_type',
+      validator: {
+        read: (type) => type === EntityType.TWO,
+      },
+    }),
+  },
+});
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+class OneTestEntity extends Entity<OneTestFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    OneTestFields,
+    string,
+    ViewerContext,
+    OneTestEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return oneTestEntityCompanion;
+  }
+}
+
+class TwoTestEntity extends Entity<TwoTestFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TwoTestFields,
+    string,
+    ViewerContext,
+    TwoTestEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return twoTestEntityCompanion;
+  }
+}
+
+const oneTestEntityCompanion = {
+  entityClass: OneTestEntity,
+  entityConfiguration: oneTestEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+};
+
+const twoTestEntityCompanion = {
+  entityClass: TwoTestEntity,
+  entityConfiguration: twoTestEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+};

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -6,6 +6,7 @@ import {
   transformFieldsToDatabaseObject,
   transformCacheObjectToFields,
   transformFieldsToCacheObject,
+  validateFieldsForRead,
 } from '../EntityFieldTransformationUtils';
 
 type BlahT = {
@@ -14,6 +15,7 @@ type BlahT = {
   uniqueButNotCacheable: string;
   transformRead: string;
   transformWrite: string;
+  validateRead: string;
 };
 
 const blahEntityConfiguration = new EntityConfiguration<BlahT>({
@@ -35,6 +37,12 @@ const blahEntityConfiguration = new EntityConfiguration<BlahT>({
     }),
     transformWrite: new StringField({
       columnName: 'transform_write',
+    }),
+    validateRead: new StringField({
+      columnName: 'validate_read',
+      validator: {
+        read: (value) => value !== 'wat',
+      },
     }),
   },
 });
@@ -162,5 +170,31 @@ describe(transformFieldsToCacheObject, () => {
       id: 'hello',
       transformWrite: 'wat-write-transformed-cache',
     });
+  });
+});
+
+describe(validateFieldsForRead, () => {
+  it('validates read if validator is supplied', () => {
+    expect(
+      validateFieldsForRead(blahEntityConfiguration, {
+        id: 'wat',
+        validateRead: 'wat',
+        cacheable: '',
+        uniqueButNotCacheable: '',
+        transformRead: '',
+        transformWrite: '',
+      })
+    ).toBe(false);
+
+    expect(
+      validateFieldsForRead(blahEntityConfiguration, {
+        id: 'wat',
+        validateRead: 'who',
+        cacheable: '',
+        uniqueButNotCacheable: '',
+        transformRead: '',
+        transformWrite: '',
+      })
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
# Why & How

The current implementation of entities had a few caching problems when trying to do this. Using the following as an example:
- Entity class EntityA: `id` is cached, table is `blah`, type is A, otherField string
- Entity class EntityB: `id` is cached, table is `blah`, type is B
- Entity instance 1: `id = 1`, `type = A`
- Entity instance 2: `id = 2`, `type = B`

1. "Invalid loads" would be cached if loaded by a field that is cached. Let's say I did a `EntityA.loader(vc).loadByID(2)`. This would load successfully from the DB, and be cached. Then, when returned to the user the business logic would see that the type is incorrect and would throw, but at this point it is too late as the entity is already in the dataloader and cache and only contains fields from A. To solve this, the validation logic is moved to happen at the database adapter level so that if an "invalid" load is encountered it acts as if no data was returned for that query.
1. "Invalid loads" would negatively cache invalid rows for the cache key, which could be the same for both entities. Let's say I did a `EntityA.loader(vc).loadByID(2)`. The new validator from (1) would nullify the load, and the cache adapter would treat this as a MISS, thus negatively caching the key value. To solve this, create a mechanism for having separate caches even with the same backing table.

# Test Plan

Run tests (old and new).
