### PR TITLE
feat: support entity fields subset of db fields

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
   ],
   "rules": {
     "no-restricted-imports": ["error",{ "paths": [".", "..", "../.."] }],
-    "tsdoc/syntax": "warn"
+    "tsdoc/syntax": "warn",
+    "no-console": "warn"
   },
   "overrides": [
     {

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
@@ -44,7 +44,7 @@ describe(RedisCacheAdapter, () => {
     const cacheAdapter = vc1.entityCompanionProvider.getCompanionForEntity(
       RedisTestEntity,
       RedisTestEntity.getCompanionDefinition()
-    )['cacheAdapter'];
+    )['tableDataCoordinator']['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
     // creating an entity should put it in cache (loader loads it after creation)

--- a/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
@@ -20,8 +20,8 @@ const entityConfiguration = new EntityConfiguration<BlahFields>({
   schema: {
     id: new UUIDField({ columnName: 'id', cache: true }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 describe(RedisCacheAdapter, () => {

--- a/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
@@ -1,4 +1,10 @@
-import { CacheStatus, UUIDField, EntityConfiguration } from '@expo/entity';
+import {
+  CacheStatus,
+  UUIDField,
+  EntityConfiguration,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+} from '@expo/entity';
 import { Redis, Pipeline } from 'ioredis';
 import { mock, when, instance, anything, verify } from 'ts-mockito';
 
@@ -14,6 +20,8 @@ const entityConfiguration = new EntityConfiguration<BlahFields>({
   schema: {
     id: new UUIDField({ columnName: 'id', cache: true }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 describe(RedisCacheAdapter, () => {

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -85,12 +85,12 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
       columnName: 'date_field',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 const redisTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: RedisTestEntity,
   entityConfiguration: redisTestEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: RedisTestEntityPrivacyPolicy,
 });

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -85,8 +85,8 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
       columnName: 'date_field',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 const redisTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -87,10 +87,10 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
   },
 });
 
-const redisTestEntityCompanionDefinition = {
+const redisTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: RedisTestEntity,
   entityConfiguration: redisTestEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: RedisTestEntityPrivacyPolicy,
-};
+});

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -104,12 +104,12 @@ export const invalidTestEntityConfiguration = new EntityConfiguration<InvalidTes
       columnName: 'name',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 const invalidTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: InvalidTestEntity,
   entityConfiguration: invalidTestEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: InvalidTestEntityPrivacyPolicy,
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -104,8 +104,8 @@ export const invalidTestEntityConfiguration = new EntityConfiguration<InvalidTes
       columnName: 'name',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 const invalidTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -106,10 +106,10 @@ export const invalidTestEntityConfiguration = new EntityConfiguration<InvalidTes
   },
 });
 
-const invalidTestEntityCompanionDefinition = {
+const invalidTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: InvalidTestEntity,
   entityConfiguration: invalidTestEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: InvalidTestEntityPrivacyPolicy,
-};
+});

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -150,12 +150,12 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresT
       columnName: 'maybe_json_array_field',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: PostgresTestEntity,
   entityConfiguration: postgresTestEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: PostgresTestEntityPrivacyPolicy,
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -150,8 +150,8 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresT
       columnName: 'maybe_json_array_field',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -152,10 +152,10 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresT
   },
 });
 
-const postgresTestEntityCompanionDefinition = {
+const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: PostgresTestEntity,
   entityConfiguration: postgresTestEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: PostgresTestEntityPrivacyPolicy,
-};
+});

--- a/packages/entity-example/src/__tests__/NoteEntity-test.ts
+++ b/packages/entity-example/src/__tests__/NoteEntity-test.ts
@@ -13,6 +13,7 @@ describe(NoteEntity, () => {
       .setField('body', 'image')
       .setField('title', 'page')
       .createAsync();
+    console.log(createdEntityResult);
     expect(createdEntityResult.ok).toBe(true);
 
     const createdEntityResultImpersonate = await NoteEntity.creator(viewerContext)

--- a/packages/entity-example/src/__tests__/NoteEntity-test.ts
+++ b/packages/entity-example/src/__tests__/NoteEntity-test.ts
@@ -13,7 +13,6 @@ describe(NoteEntity, () => {
       .setField('body', 'image')
       .setField('title', 'page')
       .createAsync();
-    console.log(createdEntityResult);
     expect(createdEntityResult.ok).toBe(true);
 
     const createdEntityResultImpersonate = await NoteEntity.creator(viewerContext)

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -35,7 +35,6 @@ export default class AllowIfUserOwnerPrivacyRule<
     _queryContext: EntityQueryContext,
     entity: TEntity
   ): Promise<RuleEvaluationResult> {
-    console.log(entity.getField(this.entityOwnerField), entity.getAllFields());
     if (viewerContext.isUserViewerContext()) {
       if (String(entity.getField(this.entityOwnerField)) === viewerContext.userID) {
         return RuleEvaluationResult.ALLOW;

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -35,6 +35,7 @@ export default class AllowIfUserOwnerPrivacyRule<
     _queryContext: EntityQueryContext,
     entity: TEntity
   ): Promise<RuleEvaluationResult> {
+    console.log(entity.getField(this.entityOwnerField), entity.getAllFields());
     if (viewerContext.isUserViewerContext()) {
       if (String(entity.getField(this.entityOwnerField)) === viewerContext.userID) {
         return RuleEvaluationResult.ALLOW;

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -57,8 +57,8 @@ export const noteEntityCompanion = new EntityCompanionDefinition({
         columnName: 'body',
       }),
     },
-    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
   }),
   privacyPolicyClass: NotePrivacyPolicy,
 });

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -57,8 +57,8 @@ export const noteEntityCompanion = new EntityCompanionDefinition({
         columnName: 'body',
       }),
     },
+    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   }),
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NotePrivacyPolicy,
 });

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -38,7 +38,7 @@ export default class NoteEntity extends Entity<NoteFields, string, ExampleViewer
  * of entity. In some languages, this would be representable as "abstract" static members
  * of the class itself, but TypeScript disallows static generic and abstract methods.
  */
-export const noteEntityCompanion = {
+export const noteEntityCompanion = new EntityCompanionDefinition({
   entityClass: NoteEntity,
   entityConfiguration: new EntityConfiguration<NoteFields>({
     idField: 'id',
@@ -61,4 +61,4 @@ export const noteEntityCompanion = {
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NotePrivacyPolicy,
-};
+});

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -13,8 +13,15 @@ export default class EnforcingEntityLoader<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly entityLoader: EntityLoader<
@@ -22,7 +29,8 @@ export default class EnforcingEntityLoader<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >
   ) {}
 

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -28,8 +28,9 @@ import ViewerContext from './ViewerContext';
 export default abstract class Entity<
   TFields,
   TID,
-  TViewerContext extends ViewerContext
-> extends ReadonlyEntity<TFields, TID, TViewerContext> {
+  TViewerContext extends ViewerContext,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields> {
   /**
    * Vend mutator for creating a new entity in given query context.
    * @param viewerContext - viewer context of creating user
@@ -41,16 +42,30 @@ export default abstract class Entity<
     TMID,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
     viewerContext: TMViewerContext2,
     queryContext: EntityQueryContext = viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
       .getRegularEntityQueryContext()
-  ): CreateMutator<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy> {
+  ): CreateMutator<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
@@ -67,17 +82,31 @@ export default abstract class Entity<
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
     existingEntity: TMEntity,
     queryContext: EntityQueryContext = existingEntity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
       .getRegularEntityQueryContext()
-  ): UpdateMutator<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy> {
+  ): UpdateMutator<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
     return existingEntity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
@@ -94,10 +123,24 @@ export default abstract class Entity<
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
     existingEntity: TMEntity,
     queryContext: EntityQueryContext = existingEntity
       .getViewerContext()
@@ -122,10 +165,24 @@ export default abstract class Entity<
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
     existingEntity: TMEntity,
     queryContext: EntityQueryContext = existingEntity
       .getViewerContext()
@@ -161,10 +218,24 @@ export default abstract class Entity<
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
     existingEntity: TMEntity,
     queryContext: EntityQueryContext = existingEntity
       .getViewerContext()
@@ -196,10 +267,24 @@ export default abstract class Entity<
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    this: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>,
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
     existingEntity: TMEntity,
     queryContext: EntityQueryContext = existingEntity
       .getViewerContext()
@@ -226,8 +311,15 @@ export interface IEntityClass<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   new (viewerContext: TViewerContext, obj: Readonly<TFields>): TEntity;
   getCompanionDefinition(): EntityCompanionDefinition<
@@ -235,6 +327,7 @@ export interface IEntityClass<
     TID,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy
+    TPrivacyPolicy,
+    TSelectedFields
   >;
 }

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -183,7 +183,7 @@ export default class EntityAssociationLoader<
       TAssociatedEntity
     >
   >(
-    fieldIdentifyingAssociatedEntity: keyof TFields,
+    fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
       TAssociatedID,
@@ -217,14 +217,6 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-    TPrivacyPolicyRoot extends EntityPrivacyPolicy<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntityRoot,
-      TSelectedFields
-    >,
     TFields2,
     TID2,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
@@ -245,6 +237,7 @@ export default class EntityAssociationLoader<
         TID2,
         TEntity2,
         TPrivacyPolicy2,
+        TSelectedFields,
         TSelectedFields2
       >
     ],
@@ -258,14 +251,6 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-    TPrivacyPolicyRoot extends EntityPrivacyPolicy<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntityRoot,
-      TSelectedFields
-    >,
     TFields2,
     TID2,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
@@ -297,6 +282,7 @@ export default class EntityAssociationLoader<
         TID2,
         TEntity2,
         TPrivacyPolicy2,
+        TSelectedFields,
         TSelectedFields2
       >,
       EntityLoadThroughDirective<
@@ -306,6 +292,7 @@ export default class EntityAssociationLoader<
         TID3,
         TEntity3,
         TPrivacyPolicy3,
+        TSelectedFields2,
         TSelectedFields3
       >
     ],
@@ -319,14 +306,6 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-    TPrivacyPolicyRoot extends EntityPrivacyPolicy<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntityRoot,
-      TSelectedFields
-    >,
     TFields2,
     TID2,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
@@ -369,6 +348,7 @@ export default class EntityAssociationLoader<
         TID2,
         TEntity2,
         TPrivacyPolicy2,
+        TSelectedFields,
         TSelectedFields2
       >,
       EntityLoadThroughDirective<
@@ -378,6 +358,7 @@ export default class EntityAssociationLoader<
         TID3,
         TEntity3,
         TPrivacyPolicy3,
+        TSelectedFields2,
         TSelectedFields3
       >,
       EntityLoadThroughDirective<
@@ -387,6 +368,7 @@ export default class EntityAssociationLoader<
         TID4,
         TEntity4,
         TPrivacyPolicy4,
+        TSelectedFields3,
         TSelectedFields4
       >
     ],
@@ -469,6 +451,7 @@ export interface EntityLoadThroughDirective<
     TAssociatedEntity,
     TAssociatedSelectedFields
   >,
+  TSelectedFields extends keyof TFields = keyof TFields,
   TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
 > {
   /**
@@ -486,7 +469,7 @@ export interface EntityLoadThroughDirective<
   /**
    * Field of the current entity with which to load an instance of associatedEntityClass.
    */
-  fieldIdentifyingAssociatedEntity: keyof TFields;
+  fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>;
 
   /**
    * Field by which to load the instance of associatedEntityClass. If not provided, the

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -10,7 +10,8 @@ export default class EntityAssociationLoader<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(private readonly entity: TEntity) {}
 
@@ -24,21 +25,29 @@ export default class EntityAssociationLoader<
   async loadAssociatedEntityAsync<
     TAssociatedFields,
     TAssociatedID,
-    TAssociatedEntity extends ReadonlyEntity<TAssociatedFields, TAssociatedID, TViewerContext>,
+    TAssociatedEntity extends ReadonlyEntity<
+      TAssociatedFields,
+      TAssociatedID,
+      TViewerContext,
+      TAssociatedSelectedFields
+    >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
-      TAssociatedEntity
-    >
+      TAssociatedEntity,
+      TAssociatedSelectedFields
+    >,
+    TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
   >(
-    fieldIdentifyingAssociatedEntity: keyof TFields,
+    fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
       TAssociatedEntity,
-      TAssociatedPrivacyPolicy
+      TAssociatedPrivacyPolicy,
+      TAssociatedSelectedFields
     >,
     queryContext: EntityQueryContext = this.entity
       .getViewerContext()
@@ -112,21 +121,29 @@ export default class EntityAssociationLoader<
   async loadAssociatedEntityByFieldEqualingAsync<
     TAssociatedFields,
     TAssociatedID,
-    TAssociatedEntity extends ReadonlyEntity<TAssociatedFields, TAssociatedID, TViewerContext>,
+    TAssociatedEntity extends ReadonlyEntity<
+      TAssociatedFields,
+      TAssociatedID,
+      TViewerContext,
+      TAssociatedSelectedFields
+    >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
-      TAssociatedEntity
-    >
+      TAssociatedEntity,
+      TAssociatedSelectedFields
+    >,
+    TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
   >(
-    fieldIdentifyingAssociatedEntity: keyof TFields,
+    fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
       TAssociatedEntity,
-      TAssociatedPrivacyPolicy
+      TAssociatedPrivacyPolicy,
+      TAssociatedSelectedFields
     >,
     associatedEntityLookupByField: keyof TAssociatedFields,
     queryContext: EntityQueryContext = this.entity
@@ -200,15 +217,36 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext>,
-    TPrivacyPolicyRoot extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntityRoot>,
+    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TPrivacyPolicyRoot extends EntityPrivacyPolicy<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntityRoot,
+      TSelectedFields
+    >,
     TFields2,
     TID2,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext>,
-    TPrivacyPolicy2 extends EntityPrivacyPolicy<TFields2, TID2, TViewerContext, TEntity2>
+    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TPrivacyPolicy2 extends EntityPrivacyPolicy<
+      TFields2,
+      TID2,
+      TViewerContext,
+      TEntity2,
+      TSelectedFields2
+    >,
+    TSelectedFields2 extends keyof TFields2 = keyof TFields2
   >(
     loadDirectives: [
-      EntityLoadThroughDirective<TViewerContext, TFields, TFields2, TID2, TEntity2, TPrivacyPolicy2>
+      EntityLoadThroughDirective<
+        TViewerContext,
+        TFields,
+        TFields2,
+        TID2,
+        TEntity2,
+        TPrivacyPolicy2,
+        TSelectedFields2
+      >
     ],
     queryContext?: EntityQueryContext
   ): Promise<Result<TEntity2> | null>;
@@ -220,16 +258,36 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext>,
-    TPrivacyPolicyRoot extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntityRoot>,
+    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TPrivacyPolicyRoot extends EntityPrivacyPolicy<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntityRoot,
+      TSelectedFields
+    >,
     TFields2,
     TID2,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext>,
-    TPrivacyPolicy2 extends EntityPrivacyPolicy<TFields2, TID2, TViewerContext, TEntity2>,
+    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TPrivacyPolicy2 extends EntityPrivacyPolicy<
+      TFields2,
+      TID2,
+      TViewerContext,
+      TEntity2,
+      TSelectedFields2
+    >,
     TFields3,
     TID3,
-    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext>,
-    TPrivacyPolicy3 extends EntityPrivacyPolicy<TFields3, TID3, TViewerContext, TEntity3>
+    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
+    TPrivacyPolicy3 extends EntityPrivacyPolicy<
+      TFields3,
+      TID3,
+      TViewerContext,
+      TEntity3,
+      TSelectedFields3
+    >,
+    TSelectedFields2 extends keyof TFields2 = keyof TFields2,
+    TSelectedFields3 extends keyof TFields3 = keyof TFields3
   >(
     loadDirectives: [
       EntityLoadThroughDirective<
@@ -238,7 +296,8 @@ export default class EntityAssociationLoader<
         TFields2,
         TID2,
         TEntity2,
-        TPrivacyPolicy2
+        TPrivacyPolicy2,
+        TSelectedFields2
       >,
       EntityLoadThroughDirective<
         TViewerContext,
@@ -246,7 +305,8 @@ export default class EntityAssociationLoader<
         TFields3,
         TID3,
         TEntity3,
-        TPrivacyPolicy3
+        TPrivacyPolicy3,
+        TSelectedFields3
       >
     ],
     queryContext?: EntityQueryContext
@@ -259,20 +319,47 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext>,
-    TPrivacyPolicyRoot extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntityRoot>,
+    TEntityRoot extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TPrivacyPolicyRoot extends EntityPrivacyPolicy<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntityRoot,
+      TSelectedFields
+    >,
     TFields2,
     TID2,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext>,
-    TPrivacyPolicy2 extends EntityPrivacyPolicy<TFields2, TID2, TViewerContext, TEntity2>,
+    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TPrivacyPolicy2 extends EntityPrivacyPolicy<
+      TFields2,
+      TID2,
+      TViewerContext,
+      TEntity2,
+      TSelectedFields2
+    >,
     TFields3,
     TID3,
-    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext>,
-    TPrivacyPolicy3 extends EntityPrivacyPolicy<TFields3, TID3, TViewerContext, TEntity3>,
+    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
+    TPrivacyPolicy3 extends EntityPrivacyPolicy<
+      TFields3,
+      TID3,
+      TViewerContext,
+      TEntity3,
+      TSelectedFields3
+    >,
     TFields4,
     TID4,
-    TEntity4 extends ReadonlyEntity<TFields4, TID4, TViewerContext>,
-    TPrivacyPolicy4 extends EntityPrivacyPolicy<TFields4, TID4, TViewerContext, TEntity4>
+    TEntity4 extends ReadonlyEntity<TFields4, TID4, TViewerContext, TSelectedFields4>,
+    TPrivacyPolicy4 extends EntityPrivacyPolicy<
+      TFields4,
+      TID4,
+      TViewerContext,
+      TEntity4,
+      TSelectedFields4
+    >,
+    TSelectedFields2 extends keyof TFields2 = keyof TFields2,
+    TSelectedFields3 extends keyof TFields3 = keyof TFields3,
+    TSelectedFields4 extends keyof TFields4 = keyof TFields4
   >(
     loadDirective: [
       EntityLoadThroughDirective<
@@ -281,7 +368,8 @@ export default class EntityAssociationLoader<
         TFields2,
         TID2,
         TEntity2,
-        TPrivacyPolicy2
+        TPrivacyPolicy2,
+        TSelectedFields2
       >,
       EntityLoadThroughDirective<
         TViewerContext,
@@ -289,7 +377,8 @@ export default class EntityAssociationLoader<
         TFields3,
         TID3,
         TEntity3,
-        TPrivacyPolicy3
+        TPrivacyPolicy3,
+        TSelectedFields3
       >,
       EntityLoadThroughDirective<
         TViewerContext,
@@ -297,7 +386,8 @@ export default class EntityAssociationLoader<
         TFields4,
         TID4,
         TEntity4,
-        TPrivacyPolicy4
+        TPrivacyPolicy4,
+        TSelectedFields4
       >
     ],
     queryContext?: EntityQueryContext
@@ -310,22 +400,22 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync(
-    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any>[],
+    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any, any>[],
     queryContext?: EntityQueryContext
-  ): Promise<Result<ReadonlyEntity<any, any, any>> | null>;
+  ): Promise<Result<ReadonlyEntity<any, any, any, any>> | null>;
 
   async loadAssociatedEntityThroughAsync(
-    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any>[],
+    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any, any>[],
     queryContext?: EntityQueryContext
-  ): Promise<Result<ReadonlyEntity<any, any, any>> | null> {
-    let currentEntity: ReadonlyEntity<any, any, any> = this.entity;
+  ): Promise<Result<ReadonlyEntity<any, any, any, any>> | null> {
+    let currentEntity: ReadonlyEntity<any, any, any, any> = this.entity;
     for (const loadDirective of loadDirectives) {
       const {
         associatedEntityClass,
         fieldIdentifyingAssociatedEntity,
         associatedEntityLookupByField,
       } = loadDirective;
-      let associatedEntityResult: Result<ReadonlyEntity<any, any, any>> | null;
+      let associatedEntityResult: Result<ReadonlyEntity<any, any, any, any>> | null;
       if (associatedEntityLookupByField) {
         associatedEntityResult = await currentEntity
           .associationLoader()
@@ -366,13 +456,20 @@ export interface EntityLoadThroughDirective<
   TFields,
   TAssociatedFields,
   TAssociatedID,
-  TAssociatedEntity extends ReadonlyEntity<TAssociatedFields, TAssociatedID, TViewerContext>,
+  TAssociatedEntity extends ReadonlyEntity<
+    TAssociatedFields,
+    TAssociatedID,
+    TViewerContext,
+    TAssociatedSelectedFields
+  >,
   TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
     TAssociatedFields,
     TAssociatedID,
     TViewerContext,
-    TAssociatedEntity
-  >
+    TAssociatedEntity,
+    TAssociatedSelectedFields
+  >,
+  TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
 > {
   /**
    * Class of entity to load at this step.
@@ -382,7 +479,8 @@ export interface EntityLoadThroughDirective<
     TAssociatedID,
     TViewerContext,
     TAssociatedEntity,
-    TAssociatedPrivacyPolicy
+    TAssociatedPrivacyPolicy,
+    TAssociatedSelectedFields
   >;
 
   /**

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -70,7 +70,6 @@ export default class EntityCompanion<
     cacheAdapterProvider: IEntityCacheAdapterProvider,
     PrivacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>,
     private readonly queryContextProvider: IEntityQueryContextProvider,
-
     metricsAdapter: IEntityMetricsAdapter
   ) {
     this.databaseAdapter = databaseAdapterProvider.getDatabaseAdapter(entityConfiguration);

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -25,8 +25,15 @@ export default class EntityCompanion<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   // defined as properties so that they can be accessed from tests
   private readonly databaseAdapter: EntityDatabaseAdapter<TFields>;
@@ -37,18 +44,27 @@ export default class EntityCompanion<
     TID,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy
+    TPrivacyPolicy,
+    TSelectedFields
   >;
   private readonly entityMutatorFactory: EntityMutatorFactory<
     TFields,
     TID,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy
+    TPrivacyPolicy,
+    TSelectedFields
   >;
 
   constructor(
-    entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     entityConfiguration: EntityConfiguration<TFields>,
     databaseAdapterProvider: IEntityDatabaseAdapterProvider,
     cacheAdapterProvider: IEntityCacheAdapterProvider,
@@ -82,11 +98,25 @@ export default class EntityCompanion<
     );
   }
 
-  getLoaderFactory(): EntityLoaderFactory<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  getLoaderFactory(): EntityLoaderFactory<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return this.entityLoaderFactory;
   }
 
-  getMutatorFactory(): EntityMutatorFactory<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  getMutatorFactory(): EntityMutatorFactory<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return this.entityMutatorFactory;
   }
 

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -55,7 +55,7 @@ export interface CacheAdapterFlavorDefinition {
  * Definition for constructing a companion for an entity. Defines the core set of objects
  * used to power the entity framework for a particular type of entity.
  */
-export interface EntityCompanionDefinition<
+export class EntityCompanionDefinition<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
@@ -69,11 +69,49 @@ export interface EntityCompanionDefinition<
   >,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>;
-  entityConfiguration: EntityConfiguration<TFields>;
-  databaseAdaptorFlavor: DatabaseAdapterFlavor;
-  cacheAdaptorFlavor: CacheAdapterFlavor;
-  privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+  readonly entityClass: IEntityClass<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >;
+  readonly entityConfiguration: EntityConfiguration<TFields>;
+  readonly databaseAdaptorFlavor: DatabaseAdapterFlavor;
+  readonly cacheAdaptorFlavor: CacheAdapterFlavor;
+  readonly privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+  readonly entitySelectedFields: TSelectedFields[];
+
+  constructor({
+    entityClass,
+    entityConfiguration,
+    databaseAdaptorFlavor,
+    cacheAdaptorFlavor,
+    privacyPolicyClass,
+    entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
+  }: {
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >;
+    entityConfiguration: EntityConfiguration<TFields>;
+    databaseAdaptorFlavor: DatabaseAdapterFlavor;
+    cacheAdaptorFlavor: CacheAdapterFlavor;
+    privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+    entitySelectedFields?: TSelectedFields[];
+  }) {
+    this.entityClass = entityClass;
+    this.entityConfiguration = entityConfiguration;
+    this.databaseAdaptorFlavor = databaseAdaptorFlavor;
+    this.cacheAdaptorFlavor = cacheAdaptorFlavor;
+    this.privacyPolicyClass = privacyPolicyClass;
+    this.entitySelectedFields = entitySelectedFields;
+  }
 }
 
 /**

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -194,10 +194,10 @@ export default class EntityCompanionProvider {
   ): EntityTableDataCoordinator<TFields> {
     return computeIfAbsent(this.tableDataCoordinatorMap, entityConfiguration.tableName, () => {
       const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors[
-        entityConfiguration.databaseAdaptorFlavor
+        entityConfiguration.databaseAdapterFlavor
       ];
       const entityCacheAdapterFlavor = this.cacheAdapterFlavors[
-        entityConfiguration.cacheAdaptorFlavor
+        entityConfiguration.cacheAdapterFlavor
       ];
       return new EntityTableDataCoordinator(
         entityConfiguration,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -59,10 +59,17 @@ export interface EntityCompanionDefinition<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>;
+  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>;
   entityConfiguration: EntityConfiguration<TFields>;
   databaseAdaptorFlavor: DatabaseAdapterFlavor;
   cacheAdaptorFlavor: CacheAdapterFlavor;
@@ -81,7 +88,7 @@ export interface EntityCompanionDefinition<
 export default class EntityCompanionProvider {
   private readonly entityCompanionMap: Map<
     string,
-    EntityCompanion<any, any, any, any, any>
+    EntityCompanion<any, any, any, any, any, any>
   > = new Map();
 
   /**
@@ -107,18 +114,33 @@ export default class EntityCompanionProvider {
     TFields,
     TID,
     TViewerContext extends ViewerContext,
-    TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-    TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+    TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TPrivacyPolicy extends EntityPrivacyPolicy<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    TSelectedFields extends keyof TFields = keyof TFields
   >(
-    entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     entityCompanionDefinition: EntityCompanionDefinition<
       TFields,
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >
-  ): EntityCompanion<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): EntityCompanion<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return computeIfAbsent(this.entityCompanionMap, entityClass.name, () => {
       const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors[
         entityCompanionDefinition.databaseAdaptorFlavor

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -1,9 +1,10 @@
+import { DatabaseAdapterFlavor, CacheAdapterFlavor } from './EntityCompanionProvider';
 import { EntityFieldDefinition } from './EntityFields';
 import { mapMap, invertMap, reduceMap } from './utils/collections/maps';
 
 /**
  * The data storage configuration for a type of Entity. Contains information relating to IDs,
- * cachable fields, and field mappings.
+ * cachable fields, field mappings, and types of cache and database adapter.
  */
 export default class EntityConfiguration<TFields> {
   readonly idField: keyof TFields;
@@ -15,20 +16,29 @@ export default class EntityConfiguration<TFields> {
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
 
+  readonly databaseAdaptorFlavor: DatabaseAdapterFlavor;
+  readonly cacheAdaptorFlavor: CacheAdapterFlavor;
+
   constructor({
     idField,
     tableName,
     schema,
     cacheKeyVersion = 0,
+    databaseAdaptorFlavor,
+    cacheAdaptorFlavor,
   }: {
     idField: keyof TFields;
     tableName: string;
     schema: Record<keyof TFields, EntityFieldDefinition>;
     cacheKeyVersion?: number;
+    databaseAdaptorFlavor: DatabaseAdapterFlavor;
+    cacheAdaptorFlavor: CacheAdapterFlavor;
   }) {
     this.idField = idField;
     this.tableName = tableName;
     this.cacheKeyVersion = cacheKeyVersion;
+    this.databaseAdaptorFlavor = databaseAdaptorFlavor;
+    this.cacheAdaptorFlavor = cacheAdaptorFlavor;
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -16,29 +16,29 @@ export default class EntityConfiguration<TFields> {
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
 
-  readonly databaseAdaptorFlavor: DatabaseAdapterFlavor;
-  readonly cacheAdaptorFlavor: CacheAdapterFlavor;
+  readonly databaseAdapterFlavor: DatabaseAdapterFlavor;
+  readonly cacheAdapterFlavor: CacheAdapterFlavor;
 
   constructor({
     idField,
     tableName,
     schema,
     cacheKeyVersion = 0,
-    databaseAdaptorFlavor,
-    cacheAdaptorFlavor,
+    databaseAdapterFlavor,
+    cacheAdapterFlavor,
   }: {
     idField: keyof TFields;
     tableName: string;
     schema: Record<keyof TFields, EntityFieldDefinition>;
     cacheKeyVersion?: number;
-    databaseAdaptorFlavor: DatabaseAdapterFlavor;
-    cacheAdaptorFlavor: CacheAdapterFlavor;
+    databaseAdapterFlavor: DatabaseAdapterFlavor;
+    cacheAdapterFlavor: CacheAdapterFlavor;
   }) {
     this.idField = idField;
     this.tableName = tableName;
     this.cacheKeyVersion = cacheKeyVersion;
-    this.databaseAdaptorFlavor = databaseAdaptorFlavor;
-    this.cacheAdaptorFlavor = cacheAdaptorFlavor;
+    this.databaseAdapterFlavor = databaseAdapterFlavor;
+    this.cacheAdapterFlavor = cacheAdapterFlavor;
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups

--- a/packages/entity/src/EntityErrors.ts
+++ b/packages/entity/src/EntityErrors.ts
@@ -11,12 +11,26 @@ export class EntityNotFoundError<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>,
-  N extends keyof TFields
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  N extends keyof TFields,
+  TSelectedFields extends keyof TFields = keyof TFields
 > extends EntityError {
   constructor(
-    entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     fieldName: N,
     fieldValue: TFields[N]
   ) {
@@ -28,7 +42,8 @@ export class EntityNotAuthorizedError<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > extends EntityError {
   public readonly entityClassName: string;
 

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -21,8 +21,15 @@ export default class EntityLoader<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly viewerContext: TViewerContext,
@@ -33,7 +40,8 @@ export default class EntityLoader<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly privacyPolicy: TPrivacyPolicy,
     private readonly entityDataManager: EntityDataManager<TFields>
@@ -44,7 +52,14 @@ export default class EntityLoader<
    * guaranteed to be the values of successful results (or null for some loader methods),
    * and will throw otherwise.
    */
-  enforcing(): EnforcingEntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  enforcing(): EnforcingEntityLoader<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return new EnforcingEntityLoader(this);
   }
 

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -1,5 +1,4 @@
 import { IEntityClass } from './Entity';
-import EntityConfiguration from './EntityConfiguration';
 import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -25,7 +24,7 @@ export default class EntityLoaderFactory<
   TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly idField: keyof TFields,
     private readonly entityClass: IEntityClass<
       TFields,
       TID,
@@ -50,7 +49,7 @@ export default class EntityLoaderFactory<
     return new EntityLoader(
       viewerContext,
       queryContext,
-      this.entityConfiguration,
+      this.idField,
       this.entityClass,
       this.privacyPolicyClass,
       this.dataManager

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -14,8 +14,15 @@ export default class EntityLoaderFactory<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
@@ -24,7 +31,8 @@ export default class EntityLoaderFactory<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly privacyPolicyClass: TPrivacyPolicy,
     private readonly dataManager: EntityDataManager<TFields>
@@ -38,7 +46,7 @@ export default class EntityLoaderFactory<
   forLoad(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext
-  ): EntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): EntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new EntityLoader(
       viewerContext,
       queryContext,

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -2,7 +2,6 @@ import { Result, asyncResult, result, enforceAsyncResult } from '@expo/results';
 import _ from 'lodash';
 
 import Entity, { IEntityClass } from './Entity';
-import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
@@ -28,7 +27,7 @@ abstract class BaseMutator<
   constructor(
     protected readonly viewerContext: TViewerContext,
     protected readonly queryContext: EntityQueryContext,
-    protected readonly entityConfiguration: EntityConfiguration<TFields>,
+    protected readonly idField: keyof TFields,
     protected readonly entityClass: IEntityClass<
       TFields,
       TID,
@@ -101,7 +100,7 @@ export class CreateMutator<
 
   private async createInternalAsync(): Promise<Result<TEntity>> {
     const temporaryEntityForPrivacyCheck = new this.entityClass(this.viewerContext, ({
-      [this.entityConfiguration.idField]: '00000000-0000-0000-0000-000000000000', // zero UUID
+      [this.idField]: '00000000-0000-0000-0000-000000000000', // zero UUID
       ...this.fieldsForEntity,
     } as unknown) as TFields);
 
@@ -153,7 +152,7 @@ export class UpdateMutator<
   constructor(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    entityConfiguration: EntityConfiguration<TFields>,
+    idField: keyof TFields,
     entityClass: IEntityClass<
       TFields,
       TID,
@@ -178,7 +177,7 @@ export class UpdateMutator<
     super(
       viewerContext,
       queryContext,
-      entityConfiguration,
+      idField,
       entityClass,
       privacyPolicy,
       entityLoaderFactory,
@@ -235,7 +234,7 @@ export class UpdateMutator<
 
     const updateResult = await this.databaseAdapter.updateAsync(
       this.queryContext,
-      this.entityConfiguration.idField,
+      this.idField,
       entityAboutToBeUpdated.getID(),
       this.updatedFields
     );
@@ -270,7 +269,7 @@ export class DeleteMutator<
   constructor(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    entityConfiguration: EntityConfiguration<TFields>,
+    idField: keyof TFields,
     entityClass: IEntityClass<
       TFields,
       TID,
@@ -295,7 +294,7 @@ export class DeleteMutator<
     super(
       viewerContext,
       queryContext,
-      entityConfiguration,
+      idField,
       entityClass,
       privacyPolicy,
       entityLoaderFactory,
@@ -332,7 +331,7 @@ export class DeleteMutator<
 
     const id = this.entity.getID();
 
-    await this.databaseAdapter.deleteAsync(this.queryContext, this.entityConfiguration.idField, id);
+    await this.databaseAdapter.deleteAsync(this.queryContext, this.idField, id);
 
     const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, this.queryContext);
     await entityLoader.invalidateFieldsAsync(this.entity.getAllDatabaseFields());

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -15,8 +15,15 @@ abstract class BaseMutator<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     protected readonly viewerContext: TViewerContext,
@@ -27,7 +34,8 @@ abstract class BaseMutator<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     protected readonly privacyPolicy: TPrivacyPolicy,
     protected readonly entityLoaderFactory: EntityLoaderFactory<
@@ -35,7 +43,8 @@ abstract class BaseMutator<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     protected readonly databaseAdapter: EntityDatabaseAdapter<TFields>,
     protected readonly metricsAdapter: IEntityMetricsAdapter
@@ -49,9 +58,16 @@ export class CreateMutator<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
-> extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
   private readonly fieldsForEntity: Partial<TFields> = {};
 
   /**
@@ -120,9 +136,16 @@ export class UpdateMutator<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
-> extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
   private readonly originalFieldsForEntity: Readonly<TFields>;
   private readonly fieldsForEntity: TFields;
   private readonly updatedFields: Partial<TFields> = {};
@@ -131,9 +154,23 @@ export class UpdateMutator<
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entityConfiguration: EntityConfiguration<TFields>,
-    entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     privacyPolicy: TPrivacyPolicy,
-    entityLoaderFactory: EntityLoaderFactory<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityLoaderFactory: EntityLoaderFactory<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     databaseAdapter: EntityDatabaseAdapter<TFields>,
     metricsAdapter: IEntityMetricsAdapter,
     fieldsForEntity: Readonly<TFields>
@@ -220,16 +257,37 @@ export class DeleteMutator<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
-> extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
   constructor(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entityConfiguration: EntityConfiguration<TFields>,
-    entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     privacyPolicy: TPrivacyPolicy,
-    entityLoaderFactory: EntityLoaderFactory<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityLoaderFactory: EntityLoaderFactory<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     databaseAdapter: EntityDatabaseAdapter<TFields>,
     metricsAdapter: IEntityMetricsAdapter,
     private readonly entity: TEntity
@@ -277,7 +335,7 @@ export class DeleteMutator<
     await this.databaseAdapter.deleteAsync(this.queryContext, this.entityConfiguration.idField, id);
 
     const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, this.queryContext);
-    await entityLoader.invalidateFieldsAsync(this.entity.getAllFields());
+    await entityLoader.invalidateFieldsAsync(this.entity.getAllDatabaseFields());
 
     return result();
   }

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -1,5 +1,4 @@
 import Entity, { IEntityClass } from './Entity';
-import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
@@ -26,7 +25,7 @@ export default class EntityMutatorFactory<
   TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly idField: keyof TFields,
     private readonly entityClass: IEntityClass<
       TFields,
       TID,
@@ -61,7 +60,7 @@ export default class EntityMutatorFactory<
     return new CreateMutator(
       viewerContext,
       queryContext,
-      this.entityConfiguration,
+      this.idField,
       this.entityClass,
       this.privacyPolicy,
       this.entityLoaderFactory,
@@ -83,7 +82,7 @@ export default class EntityMutatorFactory<
     return new UpdateMutator(
       existingEntity.getViewerContext(),
       queryContext,
-      this.entityConfiguration,
+      this.idField,
       this.entityClass,
       this.privacyPolicy,
       this.entityLoaderFactory,
@@ -105,7 +104,7 @@ export default class EntityMutatorFactory<
     return new DeleteMutator(
       existingEntity.getViewerContext(),
       queryContext,
-      this.entityConfiguration,
+      this.idField,
       this.entityClass,
       this.privacyPolicy,
       this.entityLoaderFactory,

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -15,8 +15,15 @@ export default class EntityMutatorFactory<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
@@ -25,7 +32,8 @@ export default class EntityMutatorFactory<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly privacyPolicy: TPrivacyPolicy,
     private readonly entityLoaderFactory: EntityLoaderFactory<
@@ -33,7 +41,8 @@ export default class EntityMutatorFactory<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly databaseAdapter: EntityDatabaseAdapter<TFields>,
     private readonly metricsAdapter: IEntityMetricsAdapter
@@ -48,7 +57,7 @@ export default class EntityMutatorFactory<
   forCreate(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext
-  ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new CreateMutator(
       viewerContext,
       queryContext,
@@ -70,7 +79,7 @@ export default class EntityMutatorFactory<
   forUpdate(
     existingEntity: TEntity,
     queryContext: EntityQueryContext
-  ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new UpdateMutator(
       existingEntity.getViewerContext(),
       queryContext,
@@ -80,7 +89,7 @@ export default class EntityMutatorFactory<
       this.entityLoaderFactory,
       this.databaseAdapter,
       this.metricsAdapter,
-      existingEntity.getAllFields()
+      existingEntity.getAllDatabaseFields()
     );
   }
 
@@ -92,7 +101,7 @@ export default class EntityMutatorFactory<
   forDelete(
     existingEntity: TEntity,
     queryContext: EntityQueryContext
-  ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new DeleteMutator(
       existingEntity.getViewerContext(),
       queryContext,

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -14,18 +14,23 @@ export type EntityPrivacyPolicyEvaluator<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > =
   | {
       mode: EntityPrivacyPolicyEvaluationMode.ENFORCE;
     }
   | {
       mode: EntityPrivacyPolicyEvaluationMode.DRY_RUN;
-      denyHandler: (error: EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity>) => void;
+      denyHandler: (
+        error: EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+      ) => void;
     }
   | {
       mode: EntityPrivacyPolicyEvaluationMode.ENFORCE_AND_LOG;
-      denyHandler: (error: EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity>) => void;
+      denyHandler: (
+        error: EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+      ) => void;
     };
 
 export enum EntityAuthorizationAction {
@@ -60,31 +65,36 @@ export default abstract class EntityPrivacyPolicy<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   protected readonly createRules: readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
-    TEntity
+    TEntity,
+    TSelectedFields
   >[] = [];
   protected readonly readRules: readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
-    TEntity
+    TEntity,
+    TSelectedFields
   >[] = [];
   protected readonly updateRules: readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
-    TEntity
+    TEntity,
+    TSelectedFields
   >[] = [];
   protected readonly deleteRules: readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
-    TEntity
+    TEntity,
+    TSelectedFields
   >[] = [];
 
   /**
@@ -97,7 +107,7 @@ export default abstract class EntityPrivacyPolicy<
    */
   protected getPrivacyPolicyEvaluator(
     _viewerContext: TViewerContext
-  ): EntityPrivacyPolicyEvaluator<TFields, TID, TViewerContext, TEntity> {
+  ): EntityPrivacyPolicyEvaluator<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
     return {
       mode: EntityPrivacyPolicyEvaluationMode.ENFORCE,
     };
@@ -192,7 +202,7 @@ export default abstract class EntityPrivacyPolicy<
   }
 
   private async authorizeForRulesetAsync(
-    ruleset: readonly PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity>[],
+    ruleset: readonly PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entity: TEntity,
@@ -244,7 +254,7 @@ export default abstract class EntityPrivacyPolicy<
   }
 
   private async authorizeForRulesetInnerAsync(
-    ruleset: readonly PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity>[],
+    ruleset: readonly PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entity: TEntity,

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -29,11 +29,32 @@ export default class ViewerContext {
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity>
+    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields
   >(
-    entityClass: IEntityClass<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy>
-  ): ViewerScopedEntityCompanion<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy> {
+    entityClass: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >
+  ): ViewerScopedEntityCompanion<
+    TMFields,
+    TMID,
+    TMViewerContext,
+    TMEntity,
+    TMPrivacyPolicy,
+    TMSelectedFields
+  > {
     return this.viewerScopedEntityCompanionProvider.getViewerScopedCompanionForEntity(
       entityClass,
       entityClass.getCompanionDefinition()

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -14,8 +14,15 @@ export default class ViewerScopedEntityCompanion<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly entityCompanion: EntityCompanion<
@@ -23,7 +30,8 @@ export default class ViewerScopedEntityCompanion<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly viewerContext: TViewerContext
   ) {}
@@ -36,7 +44,8 @@ export default class ViewerScopedEntityCompanion<
     TID,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy
+    TPrivacyPolicy,
+    TSelectedFields
   > {
     return new ViewerScopedEntityLoaderFactory(
       this.entityCompanion.getLoaderFactory(),
@@ -52,7 +61,8 @@ export default class ViewerScopedEntityCompanion<
     TID,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy
+    TPrivacyPolicy,
+    TSelectedFields
   > {
     return new ViewerScopedEntityMutatorFactory(
       this.entityCompanion.getMutatorFactory(),

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -25,18 +25,40 @@ export default class ViewerScopedEntityCompanionProvider {
     TFields,
     TID,
     TViewerContext extends ViewerContext,
-    TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-    TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+    TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TPrivacyPolicy extends EntityPrivacyPolicy<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    TSelectedFields extends keyof TFields = keyof TFields
   >(
-    entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy>,
+    entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
     entityCompanionDefinition: EntityCompanionDefinition<
       TFields,
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >
-  ): ViewerScopedEntityCompanion<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): ViewerScopedEntityCompanion<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return new ViewerScopedEntityCompanion(
       this.entityCompanionProvider.getCompanionForEntity(entityClass, entityCompanionDefinition),
       this.viewerContext as TViewerContext

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -12,8 +12,15 @@ export default class ViewerScopedEntityLoaderFactory<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly entityLoaderFactory: EntityLoaderFactory<
@@ -21,14 +28,15 @@ export default class ViewerScopedEntityLoaderFactory<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly viewerContext: TViewerContext
   ) {}
 
   forLoad(
     queryContext: EntityQueryContext
-  ): EntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): EntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return this.entityLoaderFactory.forLoad(this.viewerContext, queryContext);
   }
 }

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -12,8 +12,15 @@ export default class ViewerScopedEntityMutatorFactory<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
     private readonly entityMutatorFactory: EntityMutatorFactory<
@@ -21,28 +28,29 @@ export default class ViewerScopedEntityMutatorFactory<
       TID,
       TViewerContext,
       TEntity,
-      TPrivacyPolicy
+      TPrivacyPolicy,
+      TSelectedFields
     >,
     private readonly viewerContext: TViewerContext
   ) {}
 
   forCreate(
     queryContext: EntityQueryContext
-  ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return this.entityMutatorFactory.forCreate(this.viewerContext, queryContext);
   }
 
   forUpdate(
     existingEntity: TEntity,
     queryContext: EntityQueryContext
-  ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return this.entityMutatorFactory.forUpdate(existingEntity, queryContext);
   }
 
   forDelete(
     existingEntity: TEntity,
     queryContext: EntityQueryContext
-  ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy> {
+  ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return this.entityMutatorFactory.forDelete(existingEntity, queryContext);
   }
 }

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -134,13 +134,13 @@ class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, Viewer
   }
 }
 
-const simpleTestDenyUpdateEntityCompanion = {
+const simpleTestDenyUpdateEntityCompanion = new EntityCompanionDefinition({
   entityClass: SimpleTestDenyUpdateEntity,
   entityConfiguration: testEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: SimpleTestDenyUpdateEntityPrivacyPolicy,
-};
+});
 
 class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, ViewerContext> {
   static getCompanionDefinition(): EntityCompanionDefinition<
@@ -154,10 +154,10 @@ class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, Viewer
   }
 }
 
-const simpleTestDenyDeleteEntityCompanion = {
+const simpleTestDenyDeleteEntityCompanion = new EntityCompanionDefinition({
   entityClass: SimpleTestDenyDeleteEntity,
   entityConfiguration: testEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: SimpleTestDenyDeleteEntityPrivacyPolicy,
-};
+});

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -96,8 +96,8 @@ const testEntityConfiguration = new EntityConfiguration<TestEntityFields>({
       columnName: 'custom_id',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class SimpleTestDenyUpdateEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -96,6 +96,8 @@ const testEntityConfiguration = new EntityConfiguration<TestEntityFields>({
       columnName: 'custom_id',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class SimpleTestDenyUpdateEntityPrivacyPolicy extends EntityPrivacyPolicy<
@@ -137,8 +139,6 @@ class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, Viewer
 const simpleTestDenyUpdateEntityCompanion = new EntityCompanionDefinition({
   entityClass: SimpleTestDenyUpdateEntity,
   entityConfiguration: testEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: SimpleTestDenyUpdateEntityPrivacyPolicy,
 });
 
@@ -157,7 +157,5 @@ class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, Viewer
 const simpleTestDenyDeleteEntityCompanion = new EntityCompanionDefinition({
   entityClass: SimpleTestDenyDeleteEntity,
   entityConfiguration: testEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: SimpleTestDenyDeleteEntityPrivacyPolicy,
 });

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -86,7 +86,7 @@ class BlahEntityPrivacyPolicy extends EntityPrivacyPolicy<
   ];
 }
 
-const blahCompanion = {
+const blahCompanion = new EntityCompanionDefinition({
   entityClass: BlahEntity,
   entityConfiguration: new EntityConfiguration<BlahFields>({
     idField: 'id',
@@ -104,7 +104,7 @@ const blahCompanion = {
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: BlahEntityPrivacyPolicy,
-};
+});
 
 it('runs through a common workflow', async () => {
   // will be one entity companion provider for each request, so

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -100,9 +100,9 @@ const blahCompanion = new EntityCompanionDefinition({
         columnName: 'owner_id',
       }),
     },
+    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   }),
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: BlahEntityPrivacyPolicy,
 });
 

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -100,8 +100,8 @@ const blahCompanion = new EntityCompanionDefinition({
         columnName: 'owner_id',
       }),
     },
-    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
   }),
   privacyPolicyClass: BlahEntityPrivacyPolicy,
 });

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -1,26 +1,24 @@
-import { instance, mock } from 'ts-mockito';
+import { instance, mock, when } from 'ts-mockito';
 
 import EntityCompanion from '../EntityCompanion';
 import EntityLoaderFactory from '../EntityLoaderFactory';
 import EntityMutatorFactory from '../EntityMutatorFactory';
-import IEntityQueryContextProvider from '../IEntityQueryContextProvider';
+import EntityTableDataCoordinator from '../internal/EntityTableDataCoordinator';
 import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
 import TestEntity, {
   TestEntityPrivacyPolicy,
   testEntityConfiguration,
 } from '../testfixtures/TestEntity';
-import { NoCacheStubCacheAdapterProvider } from '../utils/testing/StubCacheAdapter';
-import StubDatabaseAdapterProvider from '../utils/testing/StubDatabaseAdapterProvider';
 
 describe(EntityCompanion, () => {
   it('correctly instantiates mutator and loader factories', () => {
+    const tableDataCoordinatorMock = mock(EntityTableDataCoordinator);
+    when(tableDataCoordinatorMock.entityConfiguration).thenReturn(testEntityConfiguration);
+
     const companion = new EntityCompanion(
       TestEntity,
-      testEntityConfiguration,
-      new StubDatabaseAdapterProvider(),
-      new NoCacheStubCacheAdapterProvider(),
+      instance(tableDataCoordinatorMock),
       TestEntityPrivacyPolicy,
-      instance(mock<IEntityQueryContextProvider>()),
       instance(mock<IEntityMetricsAdapter>())
     );
     expect(companion.getLoaderFactory()).toBeInstanceOf(EntityLoaderFactory);

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -22,6 +22,8 @@ const blahConfiguration = new EntityConfiguration<BlahFields>({
       columnName: 'hello',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class Blah1Entity extends Entity<BlahFields, string, ViewerContext> {
@@ -64,21 +66,17 @@ class NoOpTest2PrivacyPolicy extends EntityPrivacyPolicy<
 const blah1CompanionDefinition = new EntityCompanionDefinition({
   entityClass: Blah1Entity,
   entityConfiguration: blahConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NoOpTest1PrivacyPolicy,
 });
 
 const blah2CompanionDefinition = new EntityCompanionDefinition({
   entityClass: Blah2Entity,
   entityConfiguration: blahConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NoOpTest2PrivacyPolicy,
 });
 
 describe(EntityCompanionProvider, () => {
-  it('returns different instances for different entity types', () => {
+  it('returns different instances for different entity types, but share table data coordinators', () => {
     const entityCompanionProvider = createUnitTestEntityCompanionProvider();
     const companion1 = entityCompanionProvider.getCompanionForEntity(
       Blah1Entity,
@@ -91,5 +89,6 @@ describe(EntityCompanionProvider, () => {
     );
 
     expect(companion1).not.toEqual(companion2);
+    expect(companion1['tableDataCoordinator']).toEqual(companion2['tableDataCoordinator']);
   });
 });

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -22,8 +22,8 @@ const blahConfiguration = new EntityConfiguration<BlahFields>({
       columnName: 'hello',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class Blah1Entity extends Entity<BlahFields, string, ViewerContext> {

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -61,21 +61,21 @@ class NoOpTest2PrivacyPolicy extends EntityPrivacyPolicy<
   Blah2Entity
 > {}
 
-const blah1CompanionDefinition = {
+const blah1CompanionDefinition = new EntityCompanionDefinition({
   entityClass: Blah1Entity,
   entityConfiguration: blahConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NoOpTest1PrivacyPolicy,
-};
+});
 
-const blah2CompanionDefinition = {
+const blah2CompanionDefinition = new EntityCompanionDefinition({
   entityClass: Blah2Entity,
   entityConfiguration: blahConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NoOpTest2PrivacyPolicy,
-};
+});
 
 describe(EntityCompanionProvider, () => {
   it('returns different instances for different entity types', () => {

--- a/packages/entity/src/__tests__/EntityDataConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityDataConfiguration-test.ts
@@ -28,15 +28,15 @@ describe(EntityConfiguration, () => {
         columnName: 'unique_but_not_cacheable',
       }),
     },
-    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
   });
 
   it('returns correct fields', () => {
     expect(blahEntityConfiguration.idField).toEqual('id');
     expect(blahEntityConfiguration.tableName).toEqual('blah_table');
-    expect(blahEntityConfiguration.databaseAdaptorFlavor).toEqual(DatabaseAdapterFlavor.POSTGRES);
-    expect(blahEntityConfiguration.cacheAdaptorFlavor).toEqual(CacheAdapterFlavor.REDIS);
+    expect(blahEntityConfiguration.databaseAdapterFlavor).toEqual(DatabaseAdapterFlavor.POSTGRES);
+    expect(blahEntityConfiguration.cacheAdapterFlavor).toEqual(CacheAdapterFlavor.REDIS);
   });
 
   it('filters cacheable fields', () => {
@@ -53,8 +53,8 @@ describe(EntityConfiguration, () => {
             columnName: 'id',
           }),
         },
-        databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-        cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+        databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+        cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
       });
       expect(entityConfiguration.cacheKeyVersion).toEqual(0);
     });
@@ -68,8 +68,8 @@ describe(EntityConfiguration, () => {
             columnName: 'id',
           }),
         },
-        databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-        cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+        databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+        cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
         cacheKeyVersion: 100,
       });
       expect(entityConfiguration.cacheKeyVersion).toEqual(100);

--- a/packages/entity/src/__tests__/EntityDataConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityDataConfiguration-test.ts
@@ -1,3 +1,4 @@
+import { DatabaseAdapterFlavor, CacheAdapterFlavor } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField, StringField } from '../EntityFields';
 
@@ -27,11 +28,15 @@ describe(EntityConfiguration, () => {
         columnName: 'unique_but_not_cacheable',
       }),
     },
+    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   });
 
   it('returns correct fields', () => {
     expect(blahEntityConfiguration.idField).toEqual('id');
     expect(blahEntityConfiguration.tableName).toEqual('blah_table');
+    expect(blahEntityConfiguration.databaseAdaptorFlavor).toEqual(DatabaseAdapterFlavor.POSTGRES);
+    expect(blahEntityConfiguration.cacheAdaptorFlavor).toEqual(CacheAdapterFlavor.REDIS);
   });
 
   it('filters cacheable fields', () => {
@@ -48,6 +53,8 @@ describe(EntityConfiguration, () => {
             columnName: 'id',
           }),
         },
+        databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+        cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
       });
       expect(entityConfiguration.cacheKeyVersion).toEqual(0);
     });
@@ -61,6 +68,8 @@ describe(EntityConfiguration, () => {
             columnName: 'id',
           }),
         },
+        databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+        cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
         cacheKeyVersion: 100,
       });
       expect(entityConfiguration.cacheKeyVersion).toEqual(100);

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -63,7 +63,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManager
@@ -144,7 +144,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManager
@@ -206,7 +206,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManager
@@ -225,7 +225,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManagerInstance
@@ -247,7 +247,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManagerInstance
@@ -280,7 +280,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManagerInstance
@@ -309,7 +309,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
-      testEntityConfiguration,
+      testEntityConfiguration.idField,
       TestEntity,
       privacyPolicy,
       dataManagerInstance

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -73,13 +73,13 @@ const createEntityMutatorFactory = (
     metricsAdapter
   );
   const entityLoaderFactory = new EntityLoaderFactory(
-    testEntityConfiguration,
+    testEntityConfiguration.idField,
     TestEntity,
     privacyPolicy,
     dataManager
   );
   const entityMutatorFactory = new EntityMutatorFactory(
-    testEntityConfiguration,
+    testEntityConfiguration.idField,
     TestEntity,
     privacyPolicy,
     entityLoaderFactory,
@@ -289,7 +289,7 @@ describe(EntityMutatorFactory, () => {
     ).thenReject(rejectionError);
 
     const entityMutatorFactory = new EntityMutatorFactory(
-      simpleTestEntityConfiguration,
+      simpleTestEntityConfiguration.idField,
       SimpleTestEntity,
       instance(privacyPolicyMock),
       entityLoaderFactory,
@@ -352,7 +352,7 @@ describe(EntityMutatorFactory, () => {
     );
 
     const entityMutatorFactory = new EntityMutatorFactory(
-      simpleTestEntityConfiguration,
+      simpleTestEntityConfiguration.idField,
       SimpleTestEntity,
       privacyPolicy,
       entityLoaderFactory,

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -234,9 +234,9 @@ const blahEntityCompanionDefinition = new EntityCompanionDefinition({
         columnName: 'id',
       }),
     },
+    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   }),
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: AlwaysDenyPolicy,
 });
 

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -224,7 +224,7 @@ class EmptyPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext,
   protected readonly deleteRules = [];
 }
 
-const blahEntityCompanionDefinition = {
+const blahEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: BlahEntity,
   entityConfiguration: new EntityConfiguration<BlahFields>({
     idField: 'id',
@@ -238,7 +238,7 @@ const blahEntityCompanionDefinition = {
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: AlwaysDenyPolicy,
-};
+});
 
 describe(EntityPrivacyPolicy, () => {
   it('throws EntityNotAuthorizedError when deny', async () => {

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -234,8 +234,8 @@ const blahEntityCompanionDefinition = new EntityCompanionDefinition({
         columnName: 'id',
       }),
     },
-    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
   }),
   privacyPolicyClass: AlwaysDenyPolicy,
 });

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
@@ -115,18 +115,20 @@ class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFie
   }
 }
 
-const oneTestEntityCompanion = {
+const oneTestEntityCompanion = new EntityCompanionDefinition({
   entityClass: OneTestEntity,
   entityConfiguration: testEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntityPrivacyPolicy,
-};
+  entitySelectedFields: ['id', 'entity_type'],
+});
 
-const twoTestEntityCompanion = {
+const twoTestEntityCompanion = new EntityCompanionDefinition({
   entityClass: TwoTestEntity,
   entityConfiguration: testEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntityPrivacyPolicy,
-};
+  entitySelectedFields: ['id', 'other_field', 'entity_type'],
+});

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
@@ -35,50 +35,6 @@ describe('Two entities backed by the same table', () => {
       OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID())
     ).rejects.toThrowError('OneTestEntity must be instantiated with one data');
   });
-
-  test('not cached if error is thrown during instantiation', async () => {
-    const companionProvider = createUnitTestEntityCompanionProvider();
-    const viewerContext = new ViewerContext(companionProvider);
-
-    const one = await OneTestEntity.creator(viewerContext)
-      .setField('id', 'one')
-      .setField('entity_type', EntityType.ONE)
-      .enforceCreateAsync();
-
-    const two = await TwoTestEntity.creator(viewerContext)
-      .setField('id', 'two')
-      .setField('entity_type', EntityType.TWO)
-      .setField('other_field', 'blah')
-      .enforceCreateAsync();
-
-    try {
-      await OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID());
-    } catch (e) {}
-
-    const twoLoaded = await TwoTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(two.getID());
-    expect(twoLoaded.getAllFields()).toEqual(two.getAllFields());
-
-    try {
-      await TwoTestEntity.loader(viewerContext).enforcing().loadByIDAsync(one.getID());
-    } catch (e) {}
-
-    const oneLoaded = await OneTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(one.getID());
-    expect(oneLoaded.getAllFields()).toEqual(one.getAllFields());
-
-    // const companion = companionProvider.getCompanionForEntity(
-    //   TwoTestEntity,
-    //   twoTestEntityCompanion
-    // );
-    //   TwoTestFields
-    // >;
-
-    // // check that only two objects were cached (invalid loads were not cached)
-    // expect(cacheAdapter.cache.size).toEqual(2);
-  });
 });
 
 enum EntityType {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTable-test.ts
@@ -1,0 +1,176 @@
+import Entity from '../../Entity';
+import {
+  EntityCompanionDefinition,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+} from '../../EntityCompanionProvider';
+import EntityConfiguration from '../../EntityConfiguration';
+import { UUIDField, EnumField, StringField } from '../../EntityFields';
+import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
+import ViewerContext from '../../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { createUnitTestEntityCompanionProvider } from '../../utils/testing/createUnitTestEntityCompanionProvider';
+
+describe('Two entities backed by the same table', () => {
+  test('load by different types', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const one = await OneTestEntity.creator(viewerContext)
+      .setField('entity_type', EntityType.ONE)
+      .enforceCreateAsync();
+
+    const two = await TwoTestEntity.creator(viewerContext)
+      .setField('entity_type', EntityType.TWO)
+      .setField('other_field', 'blah')
+      .enforceCreateAsync();
+
+    expect(one).toBeInstanceOf(OneTestEntity);
+    expect(two).toBeInstanceOf(TwoTestEntity);
+
+    await expect(
+      TwoTestEntity.loader(viewerContext).enforcing().loadByIDAsync(one.getID())
+    ).rejects.toThrowError('TwoTestEntity must be instantiated with two data');
+    await expect(
+      OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID())
+    ).rejects.toThrowError('OneTestEntity must be instantiated with one data');
+  });
+
+  test('not cached if error is thrown during instantiation', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const one = await OneTestEntity.creator(viewerContext)
+      .setField('id', 'one')
+      .setField('entity_type', EntityType.ONE)
+      .enforceCreateAsync();
+
+    const two = await TwoTestEntity.creator(viewerContext)
+      .setField('id', 'two')
+      .setField('entity_type', EntityType.TWO)
+      .setField('other_field', 'blah')
+      .enforceCreateAsync();
+
+    try {
+      await OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID());
+    } catch (e) {}
+
+    const twoLoaded = await TwoTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(two.getID());
+    expect(twoLoaded.getAllFields()).toEqual(two.getAllFields());
+
+    try {
+      await TwoTestEntity.loader(viewerContext).enforcing().loadByIDAsync(one.getID());
+    } catch (e) {}
+
+    const oneLoaded = await OneTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(one.getID());
+    expect(oneLoaded.getAllFields()).toEqual(one.getAllFields());
+
+    // const companion = companionProvider.getCompanionForEntity(
+    //   TwoTestEntity,
+    //   twoTestEntityCompanion
+    // );
+    //   TwoTestFields
+    // >;
+
+    // // check that only two objects were cached (invalid loads were not cached)
+    // expect(cacheAdapter.cache.size).toEqual(2);
+  });
+});
+
+enum EntityType {
+  ONE,
+  TWO,
+}
+
+interface TestFields {
+  id: string;
+  other_field: string;
+  entity_type: EntityType;
+}
+
+type OneTestFields = 'id' | 'entity_type';
+type TwoTestFields = 'id' | 'other_field' | 'entity_type';
+
+const testEntityConfiguration = new EntityConfiguration<TestFields>({
+  idField: 'id',
+  tableName: 'entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'custom_id',
+      cache: true,
+    }),
+    other_field: new StringField({
+      columnName: 'other_field',
+    }),
+    entity_type: new EnumField({
+      columnName: 'entity_type',
+    }),
+  },
+});
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {
+  constructor(viewerContext: ViewerContext, rawFields: Readonly<TestFields>) {
+    if (rawFields.entity_type !== EntityType.ONE) {
+      throw new Error('OneTestEntity must be instantiated with one data');
+    }
+    super(viewerContext, rawFields);
+  }
+
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestFields,
+    string,
+    ViewerContext,
+    OneTestEntity,
+    TestEntityPrivacyPolicy,
+    OneTestFields
+  > {
+    return oneTestEntityCompanion;
+  }
+}
+
+class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFields> {
+  constructor(viewerContext: ViewerContext, rawFields: Readonly<TestFields>) {
+    if (rawFields.entity_type !== EntityType.TWO) {
+      throw new Error('TwoTestEntity must be instantiated with two data');
+    }
+    super(viewerContext, rawFields);
+  }
+
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestFields,
+    string,
+    ViewerContext,
+    TwoTestEntity,
+    TestEntityPrivacyPolicy,
+    TwoTestFields
+  > {
+    return twoTestEntityCompanion;
+  }
+}
+
+const oneTestEntityCompanion = {
+  entityClass: OneTestEntity,
+  entityConfiguration: testEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+};
+
+const twoTestEntityCompanion = {
+  entityClass: TwoTestEntity,
+  entityConfiguration: testEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+};

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -66,6 +66,8 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'entity_type',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
@@ -118,8 +120,6 @@ class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFie
 const oneTestEntityCompanion = new EntityCompanionDefinition({
   entityClass: OneTestEntity,
   entityConfiguration: testEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntityPrivacyPolicy,
   entitySelectedFields: ['id', 'entity_type'],
 });
@@ -127,8 +127,6 @@ const oneTestEntityCompanion = new EntityCompanionDefinition({
 const twoTestEntityCompanion = new EntityCompanionDefinition({
   entityClass: TwoTestEntity,
   entityConfiguration: testEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntityPrivacyPolicy,
   entitySelectedFields: ['id', 'other_field', 'entity_type'],
 });

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -66,8 +66,8 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'entity_type',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -16,14 +16,14 @@ describe('Two entities backed by the same table', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
 
-    const entity = await OneTestEntity.creator(viewerContext)
+    const entity1 = await OneTestEntity.creator(viewerContext)
       .setField('fake_field', 'hello')
       .enforceCreateAsync();
-    expect(entity).toBeInstanceOf(OneTestEntity);
+    expect(entity1).toBeInstanceOf(OneTestEntity);
 
     const entity2 = await TwoTestEntity.loader(viewerContext)
       .enforcing()
-      .loadByIDAsync(entity.getID());
+      .loadByIDAsync(entity1.getID());
     expect(entity2).toBeInstanceOf(TwoTestEntity);
 
     const updated2 = await TwoTestEntity.updater(entity2)
@@ -38,7 +38,7 @@ describe('Two entities backed by the same table', () => {
 
     const loaded1 = await OneTestEntity.loader(viewerContext)
       .enforcing()
-      .loadByIDAsync(entity.getID());
+      .loadByIDAsync(entity1.getID());
     expect(loaded1.getAllFields()).toMatchObject({
       id: updated2.getID(),
       fake_field: 'world',
@@ -114,8 +114,8 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
       cache: true,
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -1,0 +1,166 @@
+import Entity from '../../Entity';
+import {
+  EntityCompanionDefinition,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+} from '../../EntityCompanionProvider';
+import EntityConfiguration from '../../EntityConfiguration';
+import { UUIDField, StringField } from '../../EntityFields';
+import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
+import ViewerContext from '../../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { createUnitTestEntityCompanionProvider } from '../../utils/testing/createUnitTestEntityCompanionProvider';
+
+describe('Two entities backed by the same table', () => {
+  test('mutate through different types and keep consistent cache and dataloader', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const entity = await OneTestEntity.creator(viewerContext)
+      .setField('fake_field', 'hello')
+      .enforceCreateAsync();
+    expect(entity).toBeInstanceOf(OneTestEntity);
+
+    const entity2 = await TwoTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity.getID());
+    expect(entity2).toBeInstanceOf(TwoTestEntity);
+
+    const updated2 = await TwoTestEntity.updater(entity2)
+      .setField('fake_field', 'world')
+      .setField('other_field', 'wat')
+      .enforceUpdateAsync();
+    expect(updated2.getAllFields()).toMatchObject({
+      id: updated2.getID(),
+      other_field: 'wat',
+      fake_field: 'world',
+    });
+
+    const loaded1 = await OneTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity.getID());
+    expect(loaded1.getAllFields()).toMatchObject({
+      id: updated2.getID(),
+      fake_field: 'world',
+    });
+  });
+
+  test('cached field that differs between the two to test invalidation', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const entity = await TwoTestEntity.creator(viewerContext)
+      .setField('fake_field', 'hello')
+      .setField('other_field', 'huh')
+      .enforceCreateAsync();
+
+    const loadedEntity = await TwoTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByFieldEqualingAsync('other_field', 'huh');
+    expect(loadedEntity?.getAllFields()).toMatchObject({
+      id: entity.getID(),
+      fake_field: 'hello',
+      other_field: 'huh',
+    });
+
+    const loaded1 = await OneTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity.getID());
+    await OneTestEntity.updater(loaded1).setField('fake_field', 'world').enforceUpdateAsync();
+
+    const loaded2 = await TwoTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByFieldEqualingAsync('other_field', 'huh');
+    expect(loaded2?.getAllFields()).toMatchObject({
+      id: entity.getID(),
+      fake_field: 'world',
+      other_field: 'huh',
+    });
+
+    const loaded22 = await TwoTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByFieldEqualingAsync('fake_field', 'world');
+    expect(loaded22?.getAllFields()).toMatchObject({
+      id: entity.getID(),
+      fake_field: 'world',
+      other_field: 'huh',
+    });
+  });
+});
+
+interface TestFields {
+  id: string;
+  other_field: string;
+  fake_field: string;
+}
+
+type OneTestFields = 'id' | 'fake_field';
+type TwoTestFields = 'id' | 'other_field' | 'fake_field';
+
+const testEntityConfiguration = new EntityConfiguration<TestFields>({
+  idField: 'id',
+  tableName: 'entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'custom_id',
+      cache: true,
+    }),
+    other_field: new StringField({
+      columnName: 'other_field',
+      cache: true,
+    }),
+    fake_field: new StringField({
+      columnName: 'fake_field',
+      cache: true,
+    }),
+  },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+});
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestFields,
+    string,
+    ViewerContext,
+    OneTestEntity,
+    TestEntityPrivacyPolicy,
+    OneTestFields
+  > {
+    return oneTestEntityCompanion;
+  }
+}
+
+class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFields> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestFields,
+    string,
+    ViewerContext,
+    TwoTestEntity,
+    TestEntityPrivacyPolicy,
+    TwoTestFields
+  > {
+    return twoTestEntityCompanion;
+  }
+}
+
+const oneTestEntityCompanion = new EntityCompanionDefinition({
+  entityClass: OneTestEntity,
+  entityConfiguration: testEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+  entitySelectedFields: ['id', 'fake_field'],
+});
+
+const twoTestEntityCompanion = new EntityCompanionDefinition({
+  entityClass: TwoTestEntity,
+  entityConfiguration: testEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+  entitySelectedFields: ['id', 'other_field', 'fake_field'],
+});

--- a/packages/entity/src/internal/EntityTableDataCoordinator.ts
+++ b/packages/entity/src/internal/EntityTableDataCoordinator.ts
@@ -1,0 +1,41 @@
+import EntityCacheAdapter from '../EntityCacheAdapter';
+import EntityConfiguration from '../EntityConfiguration';
+import EntityDatabaseAdapter from '../EntityDatabaseAdapter';
+import IEntityCacheAdapterProvider from '../IEntityCacheAdapterProvider';
+import IEntityDatabaseAdapterProvider from '../IEntityDatabaseAdapterProvider';
+import IEntityQueryContextProvider from '../IEntityQueryContextProvider';
+import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
+import EntityDataManager from './EntityDataManager';
+import ReadThroughEntityCache from './ReadThroughEntityCache';
+
+/**
+ * Responsible for orchestrating fetching and caching of entity data from a
+ * table. Note that one instance is shared amongst all entities that read from
+ * the table to ensure cross-entity data consistency.
+ */
+export default class EntityTableDataCoordinator<TFields> {
+  readonly databaseAdapter: EntityDatabaseAdapter<TFields>;
+  readonly cacheAdapter: EntityCacheAdapter<TFields>;
+  readonly dataManager: EntityDataManager<TFields>;
+
+  constructor(
+    readonly entityConfiguration: EntityConfiguration<TFields>,
+    databaseAdapterProvider: IEntityDatabaseAdapterProvider,
+    cacheAdapterProvider: IEntityCacheAdapterProvider,
+    private readonly queryContextProvider: IEntityQueryContextProvider,
+    metricsAdapter: IEntityMetricsAdapter
+  ) {
+    this.databaseAdapter = databaseAdapterProvider.getDatabaseAdapter(entityConfiguration);
+    this.cacheAdapter = cacheAdapterProvider.getCacheAdapter(entityConfiguration);
+    this.dataManager = new EntityDataManager(
+      this.databaseAdapter,
+      new ReadThroughEntityCache(entityConfiguration, this.cacheAdapter),
+      queryContextProvider,
+      metricsAdapter
+    );
+  }
+
+  getQueryContextProvider(): IEntityQueryContextProvider {
+    return this.queryContextProvider;
+  }
+}

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -115,6 +115,7 @@ export default class ReadThroughEntityCache<TFields> {
         if (objects.length > 1) {
           // multiple objects received for what was supposed to be a unique query, don't add to return map nor cache
           // TODO(wschurman): emit or throw here since console may not be available
+          // eslint-disable-next-line no-console
           console.warn(
             `unique key ${fieldName} in ${this.entityConfiguration.tableName} returned multiple rows for ${fieldValue}`
           );

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -38,8 +38,8 @@ const blahEntityConfiguration = new EntityConfiguration<BlahT>({
       columnName: 'transform_write',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 describe(getDatabaseFieldForEntityField, () => {

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -1,3 +1,4 @@
+import { DatabaseAdapterFlavor, CacheAdapterFlavor } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField, StringField } from '../../EntityFields';
 import {
@@ -37,6 +38,8 @@ const blahEntityConfiguration = new EntityConfiguration<BlahT>({
       columnName: 'transform_write',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 describe(getDatabaseFieldForEntityField, () => {

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -1,6 +1,7 @@
 import { verify, deepEqual, mock, instance, when, anything } from 'ts-mockito';
 
 import EntityCacheAdapter from '../../EntityCacheAdapter';
+import { DatabaseAdapterFlavor, CacheAdapterFlavor } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField } from '../../EntityFields';
 import ReadThroughEntityCache, { CacheStatus } from '../ReadThroughEntityCache';
@@ -16,6 +17,8 @@ const makeEntityConfiguration = (cacheIdField: boolean): EntityConfiguration<Bla
     schema: {
       id: new UUIDField({ columnName: 'id', cache: cacheIdField }),
     },
+    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   });
 
 const createIdFetcher = (ids: string[]) => async <N extends keyof BlahFields>(

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -17,8 +17,8 @@ const makeEntityConfiguration = (cacheIdField: boolean): EntityConfiguration<Bla
     schema: {
       id: new UUIDField({ columnName: 'id', cache: cacheIdField }),
     },
-    databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
   });
 
 const createIdFetcher = (ids: string[]) => async <N extends keyof BlahFields>(

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -10,8 +10,9 @@ export default class AlwaysAllowPrivacyPolicyRule<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity> {
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -10,8 +10,9 @@ export default class AlwaysDenyPrivacyPolicyRule<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity> {
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -10,8 +10,9 @@ export default class AlwaysSkipPrivacyPolicyRule<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity> {
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -39,7 +39,8 @@ export default abstract class PrivacyPolicyRule<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   abstract async evaluateAsync(
     viewerContext: TViewerContext,

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -22,6 +22,8 @@ export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestF
       columnName: 'custom_id',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class DateIDTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
@@ -59,7 +61,5 @@ export default class DateIDTestEntity extends Entity<DateIDTestFields, Date, Vie
 export const dateIDTestEntityCompanion = new EntityCompanionDefinition({
   entityClass: DateIDTestEntity,
   entityConfiguration: dateIDTestEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: DateIDTestEntityPrivacyPolicy,
 });

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -22,8 +22,8 @@ export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestF
       columnName: 'custom_id',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class DateIDTestEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -56,10 +56,10 @@ export default class DateIDTestEntity extends Entity<DateIDTestFields, Date, Vie
   }
 }
 
-export const dateIDTestEntityCompanion = {
+export const dateIDTestEntityCompanion = new EntityCompanionDefinition({
   entityClass: DateIDTestEntity,
   entityConfiguration: dateIDTestEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: DateIDTestEntityPrivacyPolicy,
-};
+});

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -89,10 +89,10 @@ export default class SimpleTestEntity extends Entity<
   }
 }
 
-export const testEntityCompanion = {
+export const testEntityCompanion = new EntityCompanionDefinition({
   entityClass: SimpleTestEntity,
   entityConfiguration: simpleTestEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: SimpleTestEntityPrivacyPolicy,
-};
+});

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -14,6 +14,8 @@ export type SimpleTestFields = {
   id: string;
 };
 
+export type SimpleTestFieldSelection = keyof SimpleTestFields;
+
 export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestFields>({
   idField: 'id',
   tableName: 'simple_test_entity_should_not_write_to_db',
@@ -28,29 +30,60 @@ export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   SimpleTestFields,
   string,
   ViewerContext,
-  SimpleTestEntity
+  SimpleTestEntity,
+  SimpleTestFieldSelection
 > {
   protected readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<SimpleTestFields, string, ViewerContext, SimpleTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<
+      SimpleTestFields,
+      string,
+      ViewerContext,
+      SimpleTestEntity,
+      SimpleTestFieldSelection
+    >(),
   ];
   protected readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<SimpleTestFields, string, ViewerContext, SimpleTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<
+      SimpleTestFields,
+      string,
+      ViewerContext,
+      SimpleTestEntity,
+      SimpleTestFieldSelection
+    >(),
   ];
   protected readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<SimpleTestFields, string, ViewerContext, SimpleTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<
+      SimpleTestFields,
+      string,
+      ViewerContext,
+      SimpleTestEntity,
+      SimpleTestFieldSelection
+    >(),
   ];
   protected readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<SimpleTestFields, string, ViewerContext, SimpleTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<
+      SimpleTestFields,
+      string,
+      ViewerContext,
+      SimpleTestEntity,
+      SimpleTestFieldSelection
+    >(),
   ];
 }
 
-export default class SimpleTestEntity extends Entity<SimpleTestFields, string, ViewerContext> {
+export default class SimpleTestEntity extends Entity<
+  SimpleTestFields,
+  string,
+  ViewerContext,
+  SimpleTestFieldSelection
+> {
   static getCompanionDefinition(): EntityCompanionDefinition<
     SimpleTestFields,
     string,
     ViewerContext,
     SimpleTestEntity,
-    SimpleTestEntityPrivacyPolicy
+    SimpleTestEntityPrivacyPolicy,
+    SimpleTestFieldSelection
   > {
     return testEntityCompanion;
   }

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -24,8 +24,8 @@ export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestF
       columnName: 'custom_id',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -24,6 +24,8 @@ export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestF
       columnName: 'custom_id',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
@@ -92,7 +94,5 @@ export default class SimpleTestEntity extends Entity<
 export const testEntityCompanion = new EntityCompanionDefinition({
   entityClass: SimpleTestEntity,
   entityConfiguration: simpleTestEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: SimpleTestEntityPrivacyPolicy,
 });

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -41,6 +41,8 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'date_field',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
@@ -106,7 +108,5 @@ export default class TestEntity extends Entity<TestFields, string, ViewerContext
 export const testEntityCompanion = new EntityCompanionDefinition({
   entityClass: TestEntity,
   entityConfiguration: testEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntityPrivacyPolicy,
 });

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -103,10 +103,10 @@ export default class TestEntity extends Entity<TestFields, string, ViewerContext
   }
 }
 
-export const testEntityCompanion = {
+export const testEntityCompanion = new EntityCompanionDefinition({
   entityClass: TestEntity,
   entityConfiguration: testEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntityPrivacyPolicy,
-};
+});

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -41,8 +41,8 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'date_field',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -60,10 +60,10 @@ export default class TestEntity2 extends Entity<Test2Fields, string, ViewerConte
   }
 }
 
-export const testEntity2Companion = {
+export const testEntity2Companion = new EntityCompanionDefinition({
   entityClass: TestEntity2,
   entityConfiguration: testEntity2Configuration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntity2PrivacyPolicy,
-};
+});

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -26,6 +26,8 @@ export const testEntity2Configuration = new EntityConfiguration<Test2Fields>({
       columnName: 'foreign_key',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class TestEntity2PrivacyPolicy extends EntityPrivacyPolicy<
@@ -63,7 +65,5 @@ export default class TestEntity2 extends Entity<Test2Fields, string, ViewerConte
 export const testEntity2Companion = new EntityCompanionDefinition({
   entityClass: TestEntity2,
   entityConfiguration: testEntity2Configuration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: TestEntity2PrivacyPolicy,
 });

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -26,8 +26,8 @@ export const testEntity2Configuration = new EntityConfiguration<Test2Fields>({
       columnName: 'foreign_key',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class TestEntity2PrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -22,6 +22,8 @@ export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFie
       columnName: 'custom_id',
     }),
   },
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class NumberKeyPrivacyPolicy extends EntityPrivacyPolicy<
@@ -59,7 +61,5 @@ export default class NumberKeyEntity extends Entity<NumberKeyFields, number, Vie
 export const numberKeyEntityCompanion = new EntityCompanionDefinition({
   entityClass: NumberKeyEntity,
   entityConfiguration: numberKeyEntityConfiguration,
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NumberKeyPrivacyPolicy,
 });

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -56,10 +56,10 @@ export default class NumberKeyEntity extends Entity<NumberKeyFields, number, Vie
   }
 }
 
-export const numberKeyEntityCompanion = {
+export const numberKeyEntityCompanion = new EntityCompanionDefinition({
   entityClass: NumberKeyEntity,
   entityConfiguration: numberKeyEntityConfiguration,
   databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
   cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
   privacyPolicyClass: NumberKeyPrivacyPolicy,
-};
+});

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -22,8 +22,8 @@ export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFie
       columnName: 'custom_id',
     }),
   },
-  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
 });
 
 export class NumberKeyPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -7,7 +7,8 @@ export interface Case<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
@@ -18,8 +19,9 @@ type CaseMap<
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
-> = Map<string, () => Promise<Case<TFields, TID, TViewerContext, TEntity>>>;
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> = Map<string, () => Promise<Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>>>;
 
 /**
  * Useful for defining test cases that have async preconditions.
@@ -28,17 +30,18 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 >(
-  privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity>,
+  privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
   {
     allowCases = new Map(),
     skipCases = new Map(),
     denyCases = new Map(),
   }: {
-    allowCases?: CaseMap<TFields, TID, TViewerContext, TEntity>;
-    skipCases?: CaseMap<TFields, TID, TViewerContext, TEntity>;
-    denyCases?: CaseMap<TFields, TID, TViewerContext, TEntity>;
+    allowCases?: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
+    skipCases?: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
+    denyCases?: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
   }
 ): void => {
   describe(privacyPolicyRule.constructor.name, () => {
@@ -84,26 +87,27 @@ export const describePrivacyPolicyRule = <
   TFields,
   TID,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext>
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
 >(
-  privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity>,
+  privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
   {
     allowCases = [],
     skipCases = [],
     denyCases = [],
   }: {
-    allowCases?: Case<TFields, TID, TViewerContext, TEntity>[];
-    skipCases?: Case<TFields, TID, TViewerContext, TEntity>[];
-    denyCases?: Case<TFields, TID, TViewerContext, TEntity>[];
+    allowCases?: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+    skipCases?: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+    denyCases?: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
   }
 ): void => {
   const makeCasesMap = (
-    cases: Case<TFields, TID, TViewerContext, TEntity>[]
-  ): CaseMap<TFields, TID, TViewerContext, TEntity> =>
+    cases: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
+  ): CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields> =>
     cases.reduce(
       (
-        acc: CaseMap<TFields, TID, TViewerContext, TEntity>,
-        testCase: Case<TFields, TID, TViewerContext, TEntity>,
+        acc: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+        testCase: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
         index
       ) => {
         acc.set(`case ${index}`, async () => testCase);

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -14,7 +14,7 @@ export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvi
   }
 }
 
-class NoCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+export class NoCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
   public getFieldTransformerMap(): FieldTransformerMap {
     return new Map();
   }
@@ -48,15 +48,22 @@ class NoCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
 }
 
 export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
+  cache: Map<string, Readonly<object>> = new Map();
+
   getCacheAdapter<TFields>(
     entityConfiguration: EntityConfiguration<TFields>
   ): EntityCacheAdapter<TFields> {
-    return new InMemoryFullCacheStubCacheAdapter(entityConfiguration);
+    return new InMemoryFullCacheStubCacheAdapter(entityConfiguration, this.cache);
   }
 }
 
 class InMemoryFullCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
-  cache: Map<string, Readonly<object>> = new Map();
+  constructor(
+    entityConfiguration: EntityConfiguration<TFields>,
+    readonly cache: Map<string, Readonly<object>>
+  ) {
+    super(entityConfiguration);
+  }
 
   public getFieldTransformerMap(): FieldTransformerMap {
     return new Map();
@@ -102,7 +109,7 @@ class InMemoryFullCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFie
 
   public async invalidateManyAsync<N extends keyof TFields>(
     fieldName: N,
-    fieldValues: readonly TFields[N][]
+    fieldValues: readonly NonNullable<TFields[N]>[]
   ): Promise<void> {
     fieldValues.forEach((fieldValue) => {
       const cacheKey = this.createCacheKey(fieldName, fieldValue);


### PR DESCRIPTION
# Why

This is the other approach mentioned in https://github.com/expo/entity/pull/47#issuecomment-646792795: `EntityDataManager` and everything below it doesn't operate on the current entity's "fields". Rather an entity is a selection of fields exposed from the full set of fields loaded.

This PR adds the following concept: If an entity wants to only expose a subset of its database row's fields via `getField` and `getAllFields`, it can do so by specifying a new `TSelectedFields` type parameter. To make the change non-breaking, `TSelectedFields` defaults to all fields on `TFields`.

The underlying mutators and loaders still operate on the full set of fields, as not doing so creates an interesting case: Hypothetically, let's say that two entities reference the same table and also the same rows. Entity A has field selection a, b, c. Entity B has field selection a, c. Entities are cached by all fields from both entities.
Instance A of Entity A is created with a, b, c.
Instance B is loaded with ID of Instance A.
Instance B is mutated, changing field c to something else.
Now, all the cache entries of the underlying fields of B must be invalidated. If only cache entries for Entity B's fields were invalidated, then the following load would be inconsistent.
Instance A is loaded by field b. Because the cache was invalidated by all fields (including field b) this will be consistent.

# How

- Add type parameter to all entity-related classes that need it, then after it typechecks successfully add default `= keyof TFields` (to ensure no cases were missed).
- Add a way to specify field selection at runtime to match compile time specification.
- Add a new concept, `EntityTableDataCoordinator`, which is essentially what `EntityCompanion` used to be but shared amongst all entity companions that use the same table. This way the dataloaders and caches remain consistent.

# Test Plan

Run new tests to ensure it works as expected.
