### PR TITLE
feat: add entity write validation

### DIFF
--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -11,7 +11,7 @@ export default class EntityConfiguration<TFields> {
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly cacheKeyVersion: number;
 
-  readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>;
+  readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>;
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
 
@@ -23,7 +23,7 @@ export default class EntityConfiguration<TFields> {
   }: {
     idField: keyof TFields;
     tableName: string;
-    schema: Record<keyof TFields, EntityFieldDefinition>;
+    schema: Record<keyof TFields, EntityFieldDefinition<any>>;
     cacheKeyVersion?: number;
   }) {
     this.idField = idField;
@@ -43,7 +43,7 @@ export default class EntityConfiguration<TFields> {
   }
 
   private static computeCacheableKeys<TFields>(
-    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>
+    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>
   ): ReadonlySet<keyof TFields> {
     return reduceMap(
       schema,
@@ -58,7 +58,7 @@ export default class EntityConfiguration<TFields> {
   }
 
   private static computeEntityToDBFieldsKeyMapping<TFields>(
-    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>
+    schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>
   ): ReadonlyMap<keyof TFields, string> {
     return mapMap(schema, (v) => v.columnName);
   }

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -1,6 +1,17 @@
-export abstract class EntityFieldDefinition {
+export interface FieldValidator<T> {
+  /**
+   * Validation to apply for this field before an entity is created or updated.
+   * Only applies to fields changed during a mutation; any existing fields will
+   * not be re-validated in order to allow for changing of validator logic.
+   */
+  write?: (value: T) => Promise<void>;
+}
+
+export abstract class EntityFieldDefinition<T> {
   readonly columnName: string;
   readonly cache: boolean;
+  readonly validator: FieldValidator<T>;
+
   /**
    *
    * @param columnName - Column name in the database.
@@ -8,19 +19,30 @@ export abstract class EntityFieldDefinition {
    *              used to derive a cache key for the cache entry. If true, this column must be able uniquely
    *              identify the entity.
    */
-  constructor({ columnName, cache = false }: { columnName: string; cache?: boolean }) {
+  constructor({
+    columnName,
+    cache = false,
+    validator = {},
+  }: {
+    columnName: string;
+    cache?: boolean;
+    validator?: FieldValidator<T>;
+  }) {
     this.columnName = columnName;
     this.cache = cache;
+    this.validator = validator;
   }
 }
 
-export class StringField extends EntityFieldDefinition {}
+export class StringField extends EntityFieldDefinition<string> {}
 export class UUIDField extends StringField {}
-export class DateField extends EntityFieldDefinition {}
-export class BooleanField extends EntityFieldDefinition {}
-export class NumberField extends EntityFieldDefinition {}
-export class StringArrayField extends EntityFieldDefinition {}
-export class JSONObjectField extends EntityFieldDefinition {}
-export class EnumField extends EntityFieldDefinition {}
-export class JSONArrayField extends EntityFieldDefinition {}
-export class MaybeJSONArrayField extends EntityFieldDefinition {}
+export class DateField extends EntityFieldDefinition<Date> {}
+export class BooleanField extends EntityFieldDefinition<boolean> {}
+export class NumberField extends EntityFieldDefinition<number> {}
+export class StringArrayField extends EntityFieldDefinition<string[]> {}
+export class JSONObjectField<T extends object> extends EntityFieldDefinition<T> {}
+export class EnumField<T> extends EntityFieldDefinition<T> {}
+export class JSONArrayField<T> extends EntityFieldDefinition<T[]> {}
+export class MaybeJSONArrayField<TArray, TNotArray> extends EntityFieldDefinition<
+  TArray[] | TNotArray
+> {}

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -1,6 +1,6 @@
 import { EntityFieldDefinition } from '../EntityFields';
 
-class TestFieldDefinition extends EntityFieldDefinition {}
+class TestFieldDefinition extends EntityFieldDefinition<any> {}
 
 describe(EntityFieldDefinition, () => {
   it('returns correct column name and defaults cache to false', () => {
@@ -11,5 +11,22 @@ describe(EntityFieldDefinition, () => {
     const fieldDefinition2 = new TestFieldDefinition({ columnName: 'wat', cache: true });
     expect(fieldDefinition2.columnName).toEqual('wat');
     expect(fieldDefinition2.cache).toEqual(true);
+  });
+
+  it('defaults validator to no-op', () => {
+    const fieldDefinition = new TestFieldDefinition({ columnName: 'wat', cache: true });
+    expect(fieldDefinition.validator).toEqual({});
+
+    const fn = async (): Promise<void> => {
+      throw new Error();
+    };
+    const fieldDefinition2 = new TestFieldDefinition({
+      columnName: 'wat',
+      cache: true,
+      validator: {
+        write: fn,
+      },
+    });
+    expect(fieldDefinition2.validator.write).toEqual(fn);
   });
 });

--- a/packages/entity/src/testfixtures/ValidationTestEntity.ts
+++ b/packages/entity/src/testfixtures/ValidationTestEntity.ts
@@ -1,0 +1,72 @@
+import Entity from '../Entity';
+import {
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  EntityCompanionDefinition,
+} from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField, NumberField } from '../EntityFields';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import ViewerContext from '../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
+
+export type ValidationTestFields = {
+  id: string;
+  numberOtherThanTen: number;
+};
+
+export const validationTestEntityConfiguration = new EntityConfiguration<ValidationTestFields>({
+  idField: 'id',
+  tableName: 'validation_test_entity',
+  schema: {
+    id: new UUIDField({
+      columnName: 'custom_id',
+    }),
+    numberOtherThanTen: new NumberField({
+      columnName: 'not_ten',
+      validator: {
+        async write(value) {
+          if (value === 10) {
+            throw new Error('should not be ten');
+          }
+        },
+      },
+    }),
+  },
+});
+
+export class ValidationTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  ValidationTestFields,
+  string,
+  ViewerContext,
+  ValidationTestEntity
+> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+export default class ValidationTestEntity extends Entity<
+  ValidationTestFields,
+  string,
+  ViewerContext
+> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    ValidationTestFields,
+    string,
+    ViewerContext,
+    ValidationTestEntity,
+    ValidationTestEntityPrivacyPolicy
+  > {
+    return validationTestEntityCompanion;
+  }
+}
+
+export const validationTestEntityCompanion = {
+  entityClass: ValidationTestEntity,
+  entityConfiguration: validationTestEntityConfiguration,
+  databaseAdaptorFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdaptorFlavor: CacheAdapterFlavor.REDIS,
+  privacyPolicyClass: ValidationTestEntityPrivacyPolicy,
+};


### PR DESCRIPTION
# Why

#25 

This adds the ability for custom field validators to be specified for fields, which will allow moving some field-specific logic to the entity layer in application in a structured way rather than needing the validation to be at the edge/API layer.

Some notes:
- Validating runtime types of field values is another logical extension here. This is straightforward for all fields except enums since enum membership validation isn't possible in typescript due to the way it's compiled. `Object.values(enumType).includes(value)` doesn't work due to reverse mapping generated https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings, which would make keys valid values.
- Validating whole entities also seems like a good feature. https://guides.rubyonrails.org/active_record_validations.html may be a good superset of validations that would be worth investigating.

# How

Add write validator and validate during mutation.

# Test Plan

Run new tests.
