### PR TITLE
ci: fix checkout action to checkout branch at current state

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-node@v1
       with:
         node-version: 10.x


### PR DESCRIPTION
# Why

I just wasted ~2 hours on this, so I bet it'll affect others as well.

1. Create branch A at base T, add some commits, create PR(A). See checkout passes and no conflicts.
1. Create branch B at base T, add some commits that create logical conflict with branch A, create PR(B). See checkout passes and no conflicts.
1. Land PR(B) into master.
1. Push additional commit only changing comments to branch A to address comments on PR(A). See that the build is now failing in CI. Run the build locally on branch A and see that it is passing. Waste 2 hours only to find out that instead of running the build on branch A as is represented in PR(A), the "checkout" action doesn't actually "checkout" branch. Instead it creates a merge commit of all the commits on the branch into the current state of the destination branch, which is super non-obvious and not the matching behavior of CircleCI or other CI platforms which checkout the branch ref. The action should be called "checkout-base-and-create-merge-commit".

https://github.com/actions/checkout/issues/27

Adding @nicknovitski as reviewer since he probably is most familiar with how this could affect us in other places that use GH actions.

# How

https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit

# Test Plan

Wait for build.
