### PR TITLE
fix: correct some typing issues and exports

### DIFF
--- a/packages/entity-database-adapter-knex/src/index.ts
+++ b/packages/entity-database-adapter-knex/src/index.ts
@@ -1,2 +1,3 @@
 export { default as PostgresEntityDatabaseAdapter } from './PostgresEntityDatabaseAdapter';
+export { default as PostgresEntityDatabaseAdapterProvider } from './PostgresEntityDatabaseAdapterProvider';
 export { default as PostgresEntityQueryContextProvider } from './PostgresEntityQueryContextProvider';

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -21,7 +21,7 @@ export default class EnforcingEntityLoader<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     private readonly entityLoader: EntityLoader<

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -11,7 +11,7 @@ export default class EntityAssociationLoader<
   TID,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(private readonly entity: TEntity) {}
 
@@ -76,20 +76,28 @@ export default class EntityAssociationLoader<
   async loadManyAssociatedEntitiesAsync<
     TAssociatedFields,
     TAssociatedID,
-    TAssociatedEntity extends ReadonlyEntity<TAssociatedFields, TAssociatedID, TViewerContext>,
+    TAssociatedEntity extends ReadonlyEntity<
+      TAssociatedFields,
+      TAssociatedID,
+      TViewerContext,
+      TAssociatedSelectedFields
+    >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
-      TAssociatedEntity
-    >
+      TAssociatedEntity,
+      TAssociatedSelectedFields
+    >,
+    TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
   >(
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
       TAssociatedEntity,
-      TAssociatedPrivacyPolicy
+      TAssociatedPrivacyPolicy,
+      TAssociatedSelectedFields
     >,
     associatedEntityFieldContainingThisID: keyof TAssociatedFields,
     queryContext: EntityQueryContext = this.entity
@@ -175,13 +183,20 @@ export default class EntityAssociationLoader<
   async loadManyAssociatedEntitiesByFieldEqualingAsync<
     TAssociatedFields,
     TAssociatedID,
-    TAssociatedEntity extends ReadonlyEntity<TAssociatedFields, TAssociatedID, TViewerContext>,
+    TAssociatedEntity extends ReadonlyEntity<
+      TAssociatedFields,
+      TAssociatedID,
+      TViewerContext,
+      TAssociatedSelectedFields
+    >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
       TAssociatedID,
       TViewerContext,
-      TAssociatedEntity
-    >
+      TAssociatedEntity,
+      TAssociatedSelectedFields
+    >,
+    TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
   >(
     fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
@@ -189,7 +204,8 @@ export default class EntityAssociationLoader<
       TAssociatedID,
       TViewerContext,
       TAssociatedEntity,
-      TAssociatedPrivacyPolicy
+      TAssociatedPrivacyPolicy,
+      TAssociatedSelectedFields
     >,
     associatedEntityLookupByField: keyof TAssociatedFields,
     queryContext: EntityQueryContext = this.entity
@@ -382,12 +398,12 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync(
-    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any, any>[],
+    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any, any, any>[],
     queryContext?: EntityQueryContext
   ): Promise<Result<ReadonlyEntity<any, any, any, any>> | null>;
 
   async loadAssociatedEntityThroughAsync(
-    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any, any>[],
+    loadDirectives: EntityLoadThroughDirective<TViewerContext, any, any, any, any, any, any, any>[],
     queryContext?: EntityQueryContext
   ): Promise<Result<ReadonlyEntity<any, any, any, any>> | null> {
     let currentEntity: ReadonlyEntity<any, any, any, any> = this.entity;

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -27,7 +27,7 @@ export default class EntityCompanion<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   private readonly entityLoaderFactory: EntityLoaderFactory<
     TFields,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -157,7 +157,7 @@ export default class EntityCompanionProvider {
       TEntity,
       TSelectedFields
     >,
-    TSelectedFields extends keyof TFields = keyof TFields
+    TSelectedFields extends keyof TFields
   >(
     entityClass: IEntityClass<
       TFields,

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -28,7 +28,7 @@ export default class EntityLoader<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     private readonly viewerContext: TViewerContext,

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -21,7 +21,7 @@ export default class EntityLoaderFactory<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     private readonly idField: keyof TFields,

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -22,7 +22,7 @@ abstract class BaseMutator<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     protected readonly viewerContext: TViewerContext,
@@ -65,7 +65,7 @@ export class CreateMutator<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
   private readonly fieldsForEntity: Partial<TFields> = {};
 
@@ -143,7 +143,7 @@ export class UpdateMutator<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
   private readonly originalFieldsForEntity: Readonly<TFields>;
   private readonly fieldsForEntity: TFields;
@@ -264,7 +264,7 @@ export class DeleteMutator<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > extends BaseMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
   constructor(
     viewerContext: TViewerContext,

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -37,7 +37,7 @@ export default class ViewerContext {
       TMEntity,
       TMSelectedFields
     >,
-    TMSelectedFields extends keyof TMFields = keyof TMFields
+    TMSelectedFields extends keyof TMFields
   >(
     entityClass: IEntityClass<
       TMFields,

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -22,7 +22,7 @@ export default class ViewerScopedEntityCompanion<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     private readonly entityCompanion: EntityCompanion<

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -33,7 +33,7 @@ export default class ViewerScopedEntityCompanionProvider {
       TEntity,
       TSelectedFields
     >,
-    TSelectedFields extends keyof TFields = keyof TFields
+    TSelectedFields extends keyof TFields
   >(
     entityClass: IEntityClass<
       TFields,

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -20,7 +20,7 @@ export default class ViewerScopedEntityLoaderFactory<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     private readonly entityLoaderFactory: EntityLoaderFactory<

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -20,7 +20,7 @@ export default class ViewerScopedEntityMutatorFactory<
     TEntity,
     TSelectedFields
   >,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   constructor(
     private readonly entityMutatorFactory: EntityMutatorFactory<

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -7,7 +7,7 @@ import EntityLoader from '../EntityLoader';
 describe(EnforcingEntityLoader, () => {
   describe('loadManyByFieldEqualingManyAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(entityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything())).thenResolve(
         new Map(
@@ -24,7 +24,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(entityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything())).thenResolve(
         new Map(
@@ -49,7 +49,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByFieldEqualingAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(entityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything())).thenResolve([
         result(rejection),
@@ -62,7 +62,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(entityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything())).thenResolve([
         result(resolved),
@@ -77,7 +77,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByFieldEqualingAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenResolve(
         result(rejection)
@@ -90,7 +90,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenResolve(
         result(resolved)
@@ -103,7 +103,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns null when result is successful and no entity is found', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = null;
       when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenResolve(
         result(resolved)
@@ -116,7 +116,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('throws when multiple matching entities are found', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const multipleEntitiesError = new Error();
       when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenReject(
         multipleEntitiesError
@@ -131,7 +131,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByIDAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(entityLoaderMock.loadByIDAsync(anything())).thenResolve(result(rejection));
       const entityLoader = instance(entityLoaderMock);
@@ -140,7 +140,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(entityLoaderMock.loadByIDAsync(anything())).thenResolve(result(resolved));
       const entityLoader = instance(entityLoaderMock);
@@ -151,7 +151,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByIDNullableAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(rejection));
       const entityLoader = instance(entityLoaderMock);
@@ -162,7 +162,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(resolved));
       const entityLoader = instance(entityLoaderMock);
@@ -173,7 +173,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns null when non-existent object', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = null;
       when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(resolved));
       const entityLoader = instance(entityLoaderMock);
@@ -186,7 +186,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByIDsAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(entityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
         new Map(
@@ -201,7 +201,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(entityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
         new Map(
@@ -224,7 +224,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByFieldEqualityConjunction', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(
         entityLoaderMock.loadManyByFieldEqualityConjunctionAsync(anything(), anything())
@@ -237,7 +237,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(
         entityLoaderMock.loadManyByFieldEqualityConjunctionAsync(anything(), anything())
@@ -252,7 +252,7 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByRawWhereClause', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const rejection = new Error();
       when(
         entityLoaderMock.loadManyByRawWhereClauseAsync(anything(), anything(), anything())
@@ -265,7 +265,7 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any>>(EntityLoader);
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
       const resolved = {};
       when(
         entityLoaderMock.loadManyByRawWhereClauseAsync(anything(), anything(), anything())

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -43,7 +43,8 @@ const createEntityMutatorFactory = (
     string,
     ViewerContext,
     TestEntity,
-    TestEntityPrivacyPolicy
+    TestEntityPrivacyPolicy,
+    keyof TestFields
   >;
   entityMutatorFactory: EntityMutatorFactory<
     TestFields,
@@ -259,7 +260,8 @@ describe(EntityMutatorFactory, () => {
           string,
           ViewerContext,
           SimpleTestEntity,
-          SimpleTestEntityPrivacyPolicy
+          SimpleTestEntityPrivacyPolicy,
+          keyof SimpleTestFields
         >
       >(EntityLoaderFactory)
     );
@@ -336,7 +338,8 @@ describe(EntityMutatorFactory, () => {
           string,
           ViewerContext,
           SimpleTestEntity,
-          SimpleTestEntityPrivacyPolicy
+          SimpleTestEntityPrivacyPolicy,
+          keyof SimpleTestFields
         >
       >(EntityLoaderFactory)
     );

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
@@ -11,7 +11,14 @@ describe(ViewerScopedEntityCompanion, () => {
   it('returns viewer scoped loader and mutator factory', () => {
     const vc = instance(mock(ViewerContext));
     const entityCompanion = mock<
-      EntityCompanion<TestFields, string, ViewerContext, TestEntity, TestEntityPrivacyPolicy>
+      EntityCompanion<
+        TestFields,
+        string,
+        ViewerContext,
+        TestEntity,
+        TestEntityPrivacyPolicy,
+        keyof TestFields
+      >
     >();
     const viewerScopedEntityCompanion = new ViewerScopedEntityCompanion(entityCompanion, vc);
     expect(viewerScopedEntityCompanion.getLoaderFactory()).toBeInstanceOf(

--- a/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
@@ -9,13 +9,17 @@ describe(ViewerScopedEntityLoaderFactory, () => {
   it('correctly scopes viewer to entity loads', async () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = instance(mock(EntityQueryContext));
-    const baseLoader = mock<EntityLoaderFactory<any, any, any, any, any>>(EntityLoaderFactory);
+    const baseLoader = mock<EntityLoaderFactory<any, any, any, any, any, any>>(EntityLoaderFactory);
     const baseLoaderInstance = instance(baseLoader);
 
-    const viewerScopedEntityLoader = new ViewerScopedEntityLoaderFactory<any, any, any, any, any>(
-      baseLoaderInstance,
-      viewerContext
-    );
+    const viewerScopedEntityLoader = new ViewerScopedEntityLoaderFactory<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >(baseLoaderInstance, viewerContext);
 
     viewerScopedEntityLoader.forLoad(queryContext);
 

--- a/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
@@ -20,7 +20,8 @@ describe(ViewerScopedEntityMutatorFactory, () => {
       string,
       ViewerContext,
       TestEntity,
-      TestEntityPrivacyPolicy
+      TestEntityPrivacyPolicy,
+      keyof TestFields
     >(baseMutatorFactoryInstance, viewerContext);
 
     viewerScopedEntityLoader.forCreate(queryContext);

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -8,7 +8,7 @@ export interface Case<
   TID,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
@@ -20,7 +20,7 @@ type CaseMap<
   TID,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 > = Map<string, () => Promise<Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>>>;
 
 /**
@@ -31,7 +31,7 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
   TID,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 >(
   privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
   {
@@ -88,7 +88,7 @@ export const describePrivacyPolicyRule = <
   TID,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
+  TSelectedFields extends keyof TFields
 >(
   privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
   {


### PR DESCRIPTION
# Why

- Need to export `PostgresEntityDatabaseAdapterProvider` for usage externally.
- Default generic value for `TSelectedFields` unnecessary in most internal APIs.
- Some logical merge conflicts in `EntityAssociationLoader`

# Test Plan

`yarn tsc`
