### PR TITLE
fix: fix stub cache key generation for global cache

### DIFF
--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -118,6 +118,11 @@ class InMemoryFullCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFie
   }
 
   private createCacheKey<N extends keyof TFields>(fieldName: N, fieldValue: TFields[N]): string {
-    return `${fieldName}:::${fieldValue}`;
+    return [
+      this.entityConfiguration.tableName,
+      `v${this.entityConfiguration.cacheKeyVersion}`,
+      fieldName as string,
+      String(fieldValue),
+    ].join(':');
   }
 }


### PR DESCRIPTION
# Why

https://github.com/expo/entity/commit/4e40b2e521407e521d236978ec3b3b56db3990be#diff-7787fea5a7ed6c1892424d39f09dbc4aR51 added a companion-wide stub cache adapter to better simulate testing a real external cache adapter. Unfortunately, the cache key generation function for the stub cache adapter wasn't updated accordingly, so keys for entities from different tables could collide.

# How

Use a more comprehensive cache key generation function.

# Test Plan

`yarn tsc`
