### PR TITLE
fix: update setField to correct typing

### DIFF
--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -74,7 +74,7 @@ export class CreateMutator<
    * @param fieldName - entity field being updated
    * @param value - value for entity field
    */
-  setField<K extends keyof TFields>(fieldName: K, value: TFields[K]): this {
+  setField<K extends keyof Pick<TFields, TSelectedFields>>(fieldName: K, value: TFields[K]): this {
     this.fieldsForEntity[fieldName] = value;
     return this;
   }
@@ -193,7 +193,7 @@ export class UpdateMutator<
    * @param fieldName - entity field being updated
    * @param value - value for entity field
    */
-  setField<K extends keyof TFields>(fieldName: K, value: TFields[K]): this {
+  setField<K extends keyof Pick<TFields, TSelectedFields>>(fieldName: K, value: TFields[K]): this {
     this.fieldsForEntity[fieldName] = value;
     this.updatedFields[fieldName] = value;
     return this;


### PR DESCRIPTION
# Why

4e40b2e521407e521d236978ec3b3b56db3990be incorrectly didn't update the set of fields that could be mutated for an entity that selects a subset of fields.

# How

Update types.

# Test Plan

`yarn tsc`

Use typeahead and see that only that entity's field subset are suggested.
