### PR TITLE
feat!: add support for reference deletion and enclose mutations in transactions

### DIFF
--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
@@ -48,9 +48,12 @@ describe(RedisCacheAdapter, () => {
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
     // creating an entity should put it in cache (loader loads it after creation)
-    const entity1 = await enforceAsyncResult(
-      RedisTestEntity.creator(vc1).setField('name', 'blah').createAsync()
-    );
+    const entity1Created = await RedisTestEntity.creator(vc1)
+      .setField('name', 'blah')
+      .enforceCreateAsync();
+    const entity1 = await RedisTestEntity.loader(vc1)
+      .enforcing()
+      .loadByIDAsync(entity1Created.getID());
 
     const cachedJSON = await redisCacheAdapterContext.redisClient.get(
       cacheKeyMaker('id', entity1.getID())

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
@@ -47,10 +47,11 @@ describe(RedisCacheAdapter, () => {
     )['tableDataCoordinator']['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
-    // creating an entity should put it in cache (loader loads it after creation)
     const entity1Created = await RedisTestEntity.creator(vc1)
       .setField('name', 'blah')
       .enforceCreateAsync();
+
+    // loading an entity should put it in cache
     const entity1 = await RedisTestEntity.loader(vc1)
       .enforcing()
       .loadByIDAsync(entity1Created.getID());

--- a/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
@@ -11,8 +11,8 @@ import Knex from 'knex';
 export default class PostgresEntityQueryContextProvider implements IEntityQueryContextProvider {
   constructor(private readonly knexInstance: Knex) {}
 
-  getRegularEntityQueryContext(): EntityNonTransactionalQueryContext {
-    return new EntityNonTransactionalQueryContext(this.knexInstance);
+  getQueryContext(): EntityNonTransactionalQueryContext {
+    return new EntityNonTransactionalQueryContext(this.knexInstance, this);
   }
 
   async runInTransactionAsync<T>(

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -57,7 +57,7 @@ class ChildEntity extends Entity<ChildFields, string, ViewerContext> {
 const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
   idField: 'id',
   tableName: 'parents',
-  inboundEdgeEntities: [ChildEntity],
+  inboundEdges: [ChildEntity],
   schema: {
     id: new UUIDField({
       columnName: 'id',

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -81,7 +81,7 @@ const childEntityConfiguration = new EntityConfiguration<ChildFields>({
       cache: true,
       association: {
         associatedEntityClass: ParentEntity,
-        edgeDeletionBehavior: EntityEdgeDeletionBehavior.INVALIDATE_CACHE,
+        edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
       },
     }),
   },

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -1,0 +1,184 @@
+import {
+  EntityPrivacyPolicy,
+  ViewerContext,
+  AlwaysAllowPrivacyPolicyRule,
+  Entity,
+  EntityCompanionDefinition,
+  EntityConfiguration,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  UUIDField,
+  EntityEdgeDeletionBehavior,
+} from '@expo/entity';
+import Knex from 'knex';
+
+import { createKnexIntegrationTestEntityCompanionProvider } from '../testfixtures/createKnexIntegrationTestEntityCompanionProvider';
+
+interface ParentFields {
+  id: string;
+}
+
+interface ChildFields {
+  id: string;
+  parent_id: string;
+}
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+class ParentEntity extends Entity<ParentFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    ParentFields,
+    string,
+    ViewerContext,
+    ParentEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return parentEntityCompanion;
+  }
+}
+
+class ChildEntity extends Entity<ChildFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    ChildFields,
+    string,
+    ViewerContext,
+    ChildEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return childEntityCompanion;
+  }
+}
+
+const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
+  idField: 'id',
+  tableName: 'parents',
+  inboundEdgeEntities: [ChildEntity],
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+  },
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+});
+
+const childEntityConfiguration = new EntityConfiguration<ChildFields>({
+  idField: 'id',
+  tableName: 'children',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    parent_id: new UUIDField({
+      columnName: 'parent_id',
+      cache: true,
+      association: {
+        associatedEntityClass: ParentEntity,
+        edgeDeletionBehavior: EntityEdgeDeletionBehavior.INVALIDATE_CACHE,
+      },
+    }),
+  },
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+});
+
+const parentEntityCompanion = new EntityCompanionDefinition({
+  entityClass: ParentEntity,
+  entityConfiguration: parentEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+});
+
+const childEntityCompanion = new EntityCompanionDefinition({
+  entityClass: ChildEntity,
+  entityConfiguration: childEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+});
+
+async function createOrTruncatePostgresTables(knex: Knex): Promise<void> {
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'); // for uuid_generate_v4()
+
+  await knex.schema.createTable('parents', (table) => {
+    table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+  });
+  await knex.into('parents').truncate();
+
+  await knex.schema.createTable('children', (table) => {
+    table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+    table.uuid('parent_id').references('id').inTable('parents').onDelete('cascade').unique();
+  });
+  await knex.into('children').truncate();
+}
+
+async function dropPostgresTable(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable('children')) {
+    await knex.schema.dropTable('children');
+  }
+  if (await knex.schema.hasTable('parents')) {
+    await knex.schema.dropTable('parents');
+  }
+}
+
+describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
+  let knexInstance: Knex;
+
+  beforeAll(() => {
+    knexInstance = Knex({
+      client: 'pg',
+      connection: {
+        user: process.env.PGUSER,
+        password: process.env.PGPASSWORD,
+        host: 'localhost',
+        port: parseInt(process.env.PGPORT!, 10),
+        database: process.env.PGDATABASE,
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    await createOrTruncatePostgresTables(knexInstance);
+  });
+
+  afterAll(async () => {
+    await dropPostgresTable(knexInstance);
+    knexInstance.destroy();
+  });
+
+  describe('EntityEdgeDeletionBehavior.INVALIDATE_CACHE', () => {
+    it('invalidates the cache', async () => {
+      const viewerContext = new ViewerContext(
+        createKnexIntegrationTestEntityCompanionProvider(knexInstance)
+      );
+
+      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const child = await ChildEntity.creator(viewerContext)
+        .setField('parent_id', parent.getID())
+        .enforceCreateAsync();
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.not.toBeNull();
+      await expect(
+        ChildEntity.loader(viewerContext)
+          .enforcing()
+          .loadByFieldEqualingAsync('parent_id', parent.getID())
+      ).resolves.not.toBeNull();
+
+      await ParentEntity.enforceDeleteAsync(parent);
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.toBeNull();
+
+      await expect(
+        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID())
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -1,0 +1,216 @@
+import {
+  EntityPrivacyPolicy,
+  ViewerContext,
+  AlwaysAllowPrivacyPolicyRule,
+  Entity,
+  EntityCompanionDefinition,
+  EntityConfiguration,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  UUIDField,
+  EntityEdgeDeletionBehavior,
+} from '@expo/entity';
+import Knex from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+
+import { createKnexIntegrationTestEntityCompanionProvider } from '../testfixtures/createKnexIntegrationTestEntityCompanionProvider';
+
+interface CategoryFields {
+  id: string;
+  parent_other_id: string;
+}
+
+interface OtherFields {
+  id: string;
+  parent_category_id: string;
+}
+
+class PrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
+  const categoriesTableName = uuidv4();
+  const othersTableName = uuidv4();
+
+  class CategoryEntity extends Entity<CategoryFields, string, ViewerContext> {
+    static getCompanionDefinition(): EntityCompanionDefinition<
+      CategoryFields,
+      string,
+      ViewerContext,
+      CategoryEntity,
+      PrivacyPolicy
+    > {
+      return categoryEntityCompanion;
+    }
+  }
+
+  class OtherEntity extends Entity<OtherFields, string, ViewerContext> {
+    static getCompanionDefinition(): EntityCompanionDefinition<
+      OtherFields,
+      string,
+      ViewerContext,
+      OtherEntity,
+      PrivacyPolicy
+    > {
+      return otherEntityCompanion;
+    }
+  }
+
+  const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
+    idField: 'id',
+    tableName: categoriesTableName,
+    inboundEdges: [OtherEntity],
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+        cache: true,
+      }),
+      parent_other_id: new UUIDField({
+        columnName: 'parent_other_id',
+        cache: true,
+        association: {
+          associatedEntityClass: OtherEntity,
+          edgeDeletionBehavior,
+        },
+      }),
+    },
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  });
+
+  const categoryEntityCompanion = new EntityCompanionDefinition({
+    entityClass: CategoryEntity,
+    entityConfiguration: categoryEntityConfiguration,
+    privacyPolicyClass: PrivacyPolicy,
+  });
+
+  const otherEntityConfiguration = new EntityConfiguration<OtherFields>({
+    idField: 'id',
+    tableName: othersTableName,
+    inboundEdges: [CategoryEntity],
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+        cache: true,
+      }),
+      parent_category_id: new UUIDField({
+        columnName: 'parent_category_id',
+        cache: true,
+        association: {
+          associatedEntityClass: CategoryEntity,
+          edgeDeletionBehavior,
+        },
+      }),
+    },
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  });
+
+  const otherEntityCompanion = new EntityCompanionDefinition({
+    entityClass: OtherEntity,
+    entityConfiguration: otherEntityConfiguration,
+    privacyPolicyClass: PrivacyPolicy,
+  });
+
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'); // for uuid_generate_v4()
+
+  await knex.schema.createTable(categoriesTableName, (table) => {
+    table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+  });
+
+  await knex.schema.createTable(othersTableName, (table) => {
+    table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+    if (edgeDeletionBehavior === EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE) {
+      table
+        .uuid('parent_category_id')
+        .references('id')
+        .inTable(categoriesTableName)
+        .unique()
+        .onDelete('cascade');
+    } else {
+      table.uuid('parent_category_id').unique();
+    }
+  });
+
+  await knex.schema.alterTable(categoriesTableName, (table) => {
+    if (edgeDeletionBehavior === EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE) {
+      table
+        .uuid('parent_other_id')
+        .references('id')
+        .inTable(othersTableName)
+        .unique()
+        .onDelete('cascade');
+    } else {
+      table.uuid('parent_other_id').unique();
+    }
+  });
+
+  return { CategoryEntity, OtherEntity };
+};
+describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
+  let knexInstance: Knex;
+
+  beforeAll(() => {
+    knexInstance = Knex({
+      client: 'pg',
+      connection: {
+        user: process.env.PGUSER,
+        password: process.env.PGPASSWORD,
+        host: 'localhost',
+        port: parseInt(process.env.PGPORT!, 10),
+        database: process.env.PGDATABASE,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    knexInstance.destroy();
+  });
+
+  it.each([
+    EntityEdgeDeletionBehavior.CASCADE_DELETE,
+    EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
+    EntityEdgeDeletionBehavior.SET_NULL,
+  ])('behavior: %p', async (edgeDeletionBehavior) => {
+    const { CategoryEntity, OtherEntity } = await makeEntityClasses(
+      knexInstance,
+      edgeDeletionBehavior
+    );
+
+    const viewerContext = new ViewerContext(
+      createKnexIntegrationTestEntityCompanionProvider(knexInstance)
+    );
+
+    const category1 = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const other1 = await OtherEntity.creator(viewerContext)
+      .setField('parent_category_id', category1.getID())
+      .enforceCreateAsync();
+    await CategoryEntity.updater(category1)
+      .setField('parent_other_id', other1.getID())
+      .enforceUpdateAsync();
+
+    await CategoryEntity.enforceDeleteAsync(category1);
+
+    if (edgeDeletionBehavior === EntityEdgeDeletionBehavior.SET_NULL) {
+      await expect(
+        CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(category1.getID())
+      ).resolves.toBeNull();
+      const otherLoaded = await OtherEntity.loader(viewerContext)
+        .enforcing()
+        .loadByIDNullableAsync(other1.getID());
+      expect(otherLoaded?.getField('parent_category_id')).toBeNull();
+    } else {
+      await expect(
+        CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(category1.getID())
+      ).resolves.toBeNull();
+      await expect(
+        OtherEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(other1.getID())
+      ).resolves.toBeNull();
+    }
+  });
+});

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -43,9 +43,6 @@ describe('postgres entity integration', () => {
       await expect(InvalidTestEntity.deleteAsync(entity1)).rejects.toThrowError(
         'Excessive deletions from database adapter delete'
       );
-      await expect(InvalidTestEntity.deleteAsync(entity1)).rejects.toThrowError(
-        'No deletions from database adapter delete'
-      );
     });
 
     it('throws after update of multiple rows', async () => {

--- a/packages/entity-database-adapter-knex/src/testfixtures/createKnexIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/createKnexIntegrationTestEntityCompanionProvider.ts
@@ -4,7 +4,7 @@ import {
   EntityCompanionProvider,
   CacheAdapterFlavor,
   DatabaseAdapterFlavor,
-  NoCacheStubCacheAdapterProvider,
+  InMemoryFullCacheStubCacheAdapterProvider,
 } from '@expo/entity';
 import Knex from 'knex';
 
@@ -25,7 +25,7 @@ export const createKnexIntegrationTestEntityCompanionProvider = (
     },
     {
       [CacheAdapterFlavor.REDIS]: {
-        cacheAdapterProvider: new NoCacheStubCacheAdapterProvider(),
+        cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
       },
     }
   );

--- a/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
+++ b/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
@@ -1,17 +1,16 @@
 import {
   IEntityQueryContextProvider,
-  EntityQueryContext,
   EntityNonTransactionalQueryContext,
   EntityTransactionalQueryContext,
 } from '@expo/entity';
 
 export default class InMemoryQueryContextProvider implements IEntityQueryContextProvider {
-  getRegularEntityQueryContext(): EntityQueryContext {
-    return new EntityNonTransactionalQueryContext({});
+  getQueryContext(): EntityNonTransactionalQueryContext {
+    return new EntityNonTransactionalQueryContext({}, this);
   }
 
   async runInTransactionAsync<T>(
-    transactionScope: (queryContext: EntityQueryContext) => Promise<T>
+    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<T>
   ): Promise<T> {
     return await transactionScope(new EntityTransactionalQueryContext({}));
   }

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -64,7 +64,7 @@ export default abstract class Entity<
     queryContext: EntityQueryContext = viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): CreateMutator<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
@@ -105,7 +105,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): UpdateMutator<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
     return existingEntity
       .getViewerContext()
@@ -146,7 +146,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<Result<void>> {
     return existingEntity
       .getViewerContext()
@@ -188,7 +188,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<void> {
     return existingEntity
       .getViewerContext()
@@ -241,7 +241,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<boolean> {
     const privacyPolicy = new (this.getCompanionDefinition().privacyPolicyClass)();
     const evaluationResult = await asyncResult(
@@ -290,7 +290,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<boolean> {
     const privacyPolicy = new (this.getCompanionDefinition().privacyPolicyClass)();
     const evaluationResult = await asyncResult(

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -53,7 +53,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<Result<TAssociatedEntity>> {
     const associatedEntityID = this.entity.getField(fieldIdentifyingAssociatedEntity);
     const loader = this.entity
@@ -104,7 +104,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<readonly Result<TAssociatedEntity>[]> {
     const thisID = this.entity.getID();
     const loader = this.entity
@@ -158,7 +158,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<Result<TAssociatedEntity> | null> {
     const associatedFieldValue = this.entity.getField(fieldIdentifyingAssociatedEntity);
     const loader = this.entity
@@ -212,7 +212,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): Promise<readonly Result<TAssociatedEntity>[]> {
     const associatedFieldValue = this.entity.getField(fieldIdentifyingAssociatedEntity);
     const loader = this.entity

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -67,7 +67,7 @@ export default class EntityCompanion<
       tableDataCoordinator.dataManager
     );
     this.entityMutatorFactory = new EntityMutatorFactory(
-      tableDataCoordinator.entityConfiguration.idField,
+      tableDataCoordinator.entityConfiguration,
       entityClass,
       privacyPolicy,
       this.entityLoaderFactory,

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -1,3 +1,4 @@
+import { IEntityClass } from './Entity';
 import { DatabaseAdapterFlavor, CacheAdapterFlavor } from './EntityCompanionProvider';
 import { EntityFieldDefinition } from './EntityFields';
 import { mapMap, invertMap, reduceMap } from './utils/collections/maps';
@@ -12,6 +13,7 @@ export default class EntityConfiguration<TFields> {
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly cacheKeyVersion: number;
 
+  readonly inboundEdges: IEntityClass<any, any, any, any, any, any>[];
   readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>;
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
@@ -23,6 +25,7 @@ export default class EntityConfiguration<TFields> {
     idField,
     tableName,
     schema,
+    inboundEdges = [],
     cacheKeyVersion = 0,
     databaseAdapterFlavor,
     cacheAdapterFlavor,
@@ -30,6 +33,7 @@ export default class EntityConfiguration<TFields> {
     idField: keyof TFields;
     tableName: string;
     schema: Record<keyof TFields, EntityFieldDefinition>;
+    inboundEdges?: IEntityClass<any, any, any, any, any, any>[];
     cacheKeyVersion?: number;
     databaseAdapterFlavor: DatabaseAdapterFlavor;
     cacheAdapterFlavor: CacheAdapterFlavor;
@@ -39,6 +43,8 @@ export default class EntityConfiguration<TFields> {
     this.cacheKeyVersion = cacheKeyVersion;
     this.databaseAdapterFlavor = databaseAdapterFlavor;
     this.cacheAdapterFlavor = cacheAdapterFlavor;
+
+    this.inboundEdges = inboundEdges;
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -348,10 +348,6 @@ export default abstract class EntityDatabaseAdapter<TFields> {
       throw new Error(
         `Excessive deletions from database adapter delete: ${this.entityConfiguration.tableName}(id = ${id})`
       );
-    } else if (numDeleted === 0) {
-      throw new Error(
-        `No deletions from database adapter delete: ${this.entityConfiguration.tableName}(id = ${id})`
-      );
     }
   }
 

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -1,6 +1,79 @@
+import { IEntityClass } from './Entity';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+export enum EntityEdgeDeletionBehavior {
+  /**
+   * Default. Invalidate the cache for all entities that reference the entity
+   * being deleted through this field. This is most useful when the database itself expresses foreign
+   * keys and cascading deletes or set nulls and the entity framework just needs to
+   * be kept consistent with the state of the database.
+   */
+  INVALIDATE_CACHE,
+
+  /**
+   * Delete all entities that reference the entity being deleted through this field. This is very similar
+   * to SQL `ON DELETE CASCADE` but is done in the Entity framework instead of at the underlying level,
+   * and should not be used in combination with database-schema-expressed foreign keys and deletion behavior.
+   */
+  CASCADE_DELETE,
+
+  /**
+   * Set this field to null when the referenced entity is deleted. This is very similar
+   * to SQL `ON DELETE SET NULL` but is done in the Entity framework instead of at the underlying level,
+   * and should not be used in combination with database-schema-expressed foreign keys and deletion behavior.
+   */
+  SET_NULL,
+}
+
+export interface EntityAssociationDefinition<
+  TViewerContext extends ViewerContext,
+  TAssociatedFields,
+  TAssociatedID,
+  TAssociatedEntity extends ReadonlyEntity<
+    TAssociatedFields,
+    TAssociatedID,
+    TViewerContext,
+    TAssociatedSelectedFields
+  >,
+  TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
+    TAssociatedFields,
+    TAssociatedID,
+    TViewerContext,
+    TAssociatedEntity,
+    TAssociatedSelectedFields
+  >,
+  TAssociatedSelectedFields extends keyof TAssociatedFields = keyof TAssociatedFields
+> {
+  /**
+   * Class of entity on the other end of this edge.
+   */
+  associatedEntityClass: IEntityClass<
+    TAssociatedFields,
+    TAssociatedID,
+    TViewerContext,
+    TAssociatedEntity,
+    TAssociatedPrivacyPolicy,
+    TAssociatedSelectedFields
+  >;
+
+  /**
+   * Field by which to load the instance of associatedEntityClass. If not provided, the
+   * associatedEntityClass instance is fetched by its ID.
+   */
+  associatedEntityLookupByField?: keyof TAssociatedFields;
+
+  /**
+   * What to do on the current entity when the entity on the other end of this edge is deleted.
+   */
+  edgeDeletionBehavior?: EntityEdgeDeletionBehavior;
+}
+
 export abstract class EntityFieldDefinition {
   readonly columnName: string;
   readonly cache: boolean;
+  readonly association?: EntityAssociationDefinition<any, any, any, any, any, any>;
   /**
    *
    * @param columnName - Column name in the database.
@@ -8,9 +81,18 @@ export abstract class EntityFieldDefinition {
    *              used to derive a cache key for the cache entry. If true, this column must be able uniquely
    *              identify the entity.
    */
-  constructor({ columnName, cache = false }: { columnName: string; cache?: boolean }) {
+  constructor({
+    columnName,
+    cache = false,
+    association,
+  }: {
+    columnName: string;
+    cache?: boolean;
+    association?: EntityAssociationDefinition<any, any, any, any, any, any>;
+  }) {
     this.columnName = columnName;
     this.cache = cache;
+    this.association = association;
   }
 }
 

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -10,7 +10,7 @@ export enum EntityEdgeDeletionBehavior {
    * keys and cascading deletes or set nulls and the entity framework just needs to
    * be kept consistent with the state of the database.
    */
-  INVALIDATE_CACHE,
+  CASCADE_DELETE_INVALIDATE_CACHE,
 
   /**
    * Delete all entities that reference the entity being deleted through this field. This is very similar

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -6,7 +6,8 @@ import ViewerContext from './ViewerContext';
 export enum EntityEdgeDeletionBehavior {
   /**
    * Default. Invalidate the cache for all entities that reference the entity
-   * being deleted through this field. This is most useful when the database itself expresses foreign
+   * being deleted through this field, and transitively run deletions on those entities.
+   * This is most useful when the database itself expresses foreign
    * keys and cascading deletes or set nulls and the entity framework just needs to
    * be kept consistent with the state of the database.
    */
@@ -75,8 +76,8 @@ export interface EntityAssociationDefinition<
    * application requirements, and sometimes even a mix-and-match is the right choice.
    *
    * - If referential integrity is critical to your application, database foreign key constraints
-   *   combined with {@link EntityEdgeDeletionBehavior.INVALIDATE_CACHE} are recommended.
-   * - If the database being used doesn't support foreign keys, then using entity for referential
+   *   combined with {@link EntityEdgeDeletionBehavior.CASACDE_DELETE_INVALIDATE_CACHE} are recommended.
+   * - If the database being used doesn't support foreign keys, then using the entity framework for referential
    *   integrity is recommended.
    */
   edgeDeletionBehavior?: EntityEdgeDeletionBehavior;

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -14,15 +14,15 @@ export enum EntityEdgeDeletionBehavior {
 
   /**
    * Delete all entities that reference the entity being deleted through this field. This is very similar
-   * to SQL `ON DELETE CASCADE` but is done in the Entity framework instead of at the underlying level,
-   * and should not be used in combination with database-schema-expressed foreign keys and deletion behavior.
+   * to SQL `ON DELETE CASCADE` but is done in the Entity framework instead of at the underlying level.
+   * This will also invalidate the cached referencing entities.
    */
   CASCADE_DELETE,
 
   /**
    * Set this field to null when the referenced entity is deleted. This is very similar
-   * to SQL `ON DELETE SET NULL` but is done in the Entity framework instead of at the underlying level,
-   * and should not be used in combination with database-schema-expressed foreign keys and deletion behavior.
+   * to SQL `ON DELETE SET NULL` but is done in the Entity framework instead of at the underlying level.
+   * This will also invalidate the cached referencing entities.
    */
   SET_NULL,
 }
@@ -65,7 +65,19 @@ export interface EntityAssociationDefinition<
   associatedEntityLookupByField?: keyof TAssociatedFields;
 
   /**
-   * What to do on the current entity when the entity on the other end of this edge is deleted.
+   * What action to perform on the current entity when the entity on the referencing end of
+   * this edge is deleted.
+   *
+   * @remarks
+   * The entity framework doesn't prescribe a one-size-fits-all solution for referential
+   * integrity; instead it exposes mechanisms that supports both database foreign key constraints
+   * and implicit entity-specified foreign keys. Choosing which approach to use often depends on
+   * application requirements, and sometimes even a mix-and-match is the right choice.
+   *
+   * - If referential integrity is critical to your application, database foreign key constraints
+   *   combined with {@link EntityEdgeDeletionBehavior.INVALIDATE_CACHE} are recommended.
+   * - If the database being used doesn't support foreign keys, then using entity for referential
+   *   integrity is recommended.
    */
   edgeDeletionBehavior?: EntityEdgeDeletionBehavior;
 }

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -1,4 +1,5 @@
 import Entity, { IEntityClass } from './Entity';
+import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
@@ -25,7 +26,7 @@ export default class EntityMutatorFactory<
   TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
-    private readonly idField: keyof TFields,
+    private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly entityClass: IEntityClass<
       TFields,
       TID,
@@ -60,7 +61,7 @@ export default class EntityMutatorFactory<
     return new CreateMutator(
       viewerContext,
       queryContext,
-      this.idField,
+      this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
       this.entityLoaderFactory,
@@ -82,7 +83,7 @@ export default class EntityMutatorFactory<
     return new UpdateMutator(
       existingEntity.getViewerContext(),
       queryContext,
-      this.idField,
+      this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
       this.entityLoaderFactory,
@@ -104,7 +105,7 @@ export default class EntityMutatorFactory<
     return new DeleteMutator(
       existingEntity.getViewerContext(),
       queryContext,
-      this.idField,
+      this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
       this.entityLoaderFactory,

--- a/packages/entity/src/IEntityQueryContextProvider.ts
+++ b/packages/entity/src/IEntityQueryContextProvider.ts
@@ -1,6 +1,6 @@
 import {
-  EntityNonTransactionalQueryContext,
   EntityTransactionalQueryContext,
+  EntityNonTransactionalQueryContext,
 } from './EntityQueryContext';
 
 /**
@@ -8,9 +8,9 @@ import {
  */
 export default interface IEntityQueryContextProvider {
   /**
-   * Vend a regular (non-transactional) entity query context.
+   * Vend an entity query context.
    */
-  getRegularEntityQueryContext(): EntityNonTransactionalQueryContext;
+  getQueryContext(): EntityNonTransactionalQueryContext;
 
   /**
    * Start a transaction and execute the provided transaction-scoped closure within the transaction.

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -3,6 +3,7 @@ import { pick } from 'lodash';
 
 import { IEntityClass } from './Entity';
 import EntityAssociationLoader from './EntityAssociationLoader';
+import { EntityCompanionDefinition } from './EntityCompanionProvider';
 import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
@@ -36,14 +37,24 @@ export default abstract class ReadonlyEntity<
     private readonly viewerContext: TViewerContext,
     private readonly databaseFields: Readonly<TFields>
   ) {
-    const idField = (this.constructor as any).getCompanionDefinition().entityConfiguration
-      .idField as keyof Pick<TFields, TSelectedFields>;
+    const companionDefinition = (this
+      .constructor as any).getCompanionDefinition() as EntityCompanionDefinition<
+      TFields,
+      TID,
+      TViewerContext,
+      this,
+      EntityPrivacyPolicy<TFields, TID, TViewerContext, this, TSelectedFields>,
+      TSelectedFields
+    >;
+    const idField = companionDefinition.entityConfiguration.idField as keyof Pick<
+      TFields,
+      TSelectedFields
+    >;
     const id = databaseFields[idField];
     invariant(id, 'must provide ID to create an entity');
     this.id = id as any;
 
-    const entitySelectedFields = (this.constructor as any).getCompanionDefinition()
-      .entitySelectedFields as (keyof TFields)[];
+    const entitySelectedFields = companionDefinition.entitySelectedFields as (keyof TFields)[];
     this.rawFields = pick(databaseFields, entitySelectedFields);
   }
 

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -62,8 +62,8 @@ export default abstract class ReadonlyEntity<
     return `${this.constructor.name}[${this.getID()}]`;
   }
 
-  equals(otherEntity: this): boolean {
-    return this.toString() === otherEntity.toString();
+  getUniqueIdentifier(): string {
+    return this.toString();
   }
 
   /**

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -62,6 +62,10 @@ export default abstract class ReadonlyEntity<
     return `${this.constructor.name}[${this.getID()}]`;
   }
 
+  equals(otherEntity: this): boolean {
+    return this.toString() === otherEntity.toString();
+  }
+
   /**
    * @returns the ViewerContext authorized to read this entity
    */

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -6,7 +6,7 @@ import EntityAssociationLoader from './EntityAssociationLoader';
 import { EntityCompanionDefinition } from './EntityCompanionProvider';
 import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
-import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
+import { EntityQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
 
 /**
@@ -118,7 +118,7 @@ export default abstract class ReadonlyEntity<
    * Get the regular (non-transactional) query context for this entity.
    * @param viewerContext - viewer context of calling user
    */
-  static getRegularEntityQueryContext<
+  static getQueryContext<
     TMFields,
     TMID,
     TMViewerContext extends ViewerContext,
@@ -146,7 +146,7 @@ export default abstract class ReadonlyEntity<
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext();
+      .getQueryContext();
   }
 
   /**
@@ -179,12 +179,13 @@ export default abstract class ReadonlyEntity<
       TMSelectedFields
     >,
     viewerContext: TMViewerContext2,
-    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>
+    transactionScope: (queryContext: EntityQueryContext) => Promise<TResult>
   ): Promise<TResult> {
     return await viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .runInTransactionAsync(transactionScope);
+      .getQueryContext()
+      .runInTransactionIfNotInTransactionAsync(transactionScope);
   }
 
   /**
@@ -219,7 +220,7 @@ export default abstract class ReadonlyEntity<
     queryContext: EntityQueryContext = viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
-      .getRegularEntityQueryContext()
+      .getQueryContext()
   ): EntityLoader<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -209,14 +209,6 @@ describe(EntityDatabaseAdapter, () => {
   });
 
   describe('deleteAsync', () => {
-    it('throws when update result count zero', async () => {
-      const queryContext = instance(mock(EntityQueryContext));
-      const adapter = new TestEntityDatabaseAdapter({ deleteCount: 0 });
-      await expect(adapter.deleteAsync(queryContext, 'customIdField', 'wat')).rejects.toThrowError(
-        'No deletions from database adapter delet'
-      );
-    });
-
     it('throws when update result count greater than 1', async () => {
       const queryContext = instance(mock(EntityQueryContext));
       const adapter = new TestEntityDatabaseAdapter({ deleteCount: 2 });

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -1,0 +1,347 @@
+import Entity from '../Entity';
+import {
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  EntityCompanionDefinition,
+} from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField, EntityEdgeDeletionBehavior } from '../EntityFields';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import { CacheStatus } from '../internal/ReadThroughEntityCache';
+import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
+import TestViewerContext from '../testfixtures/TestViewerContext';
+import { InMemoryFullCacheStubCacheAdapter } from '../utils/testing/StubCacheAdapter';
+import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
+
+interface ParentFields {
+  id: string;
+}
+
+interface ChildFields {
+  id: string;
+  parent_id: string;
+}
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  any,
+  string,
+  TestViewerContext,
+  any,
+  any
+> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
+  describe('OnDeleteBehavior.DELETE', () => {
+    class ParentEntity extends Entity<ParentFields, string, TestViewerContext> {
+      static getCompanionDefinition(): EntityCompanionDefinition<
+        ParentFields,
+        string,
+        TestViewerContext,
+        ParentEntity,
+        TestEntityPrivacyPolicy
+      > {
+        return parentEntityCompanion;
+      }
+    }
+
+    class ChildEntity extends Entity<ChildFields, string, TestViewerContext> {
+      static getCompanionDefinition(): EntityCompanionDefinition<
+        ChildFields,
+        string,
+        TestViewerContext,
+        ChildEntity,
+        TestEntityPrivacyPolicy
+      > {
+        return childEntityCompanion;
+      }
+    }
+
+    const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
+      idField: 'id',
+      tableName: 'parents',
+      inboundEdges: [ChildEntity],
+      schema: {
+        id: new UUIDField({
+          columnName: 'id',
+          cache: true,
+        }),
+      },
+      databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+      cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    });
+
+    const childEntityConfiguration = new EntityConfiguration<ChildFields>({
+      idField: 'id',
+      tableName: 'children',
+      schema: {
+        id: new UUIDField({
+          columnName: 'id',
+          cache: true,
+        }),
+        parent_id: new UUIDField({
+          columnName: 'parent_id',
+          association: {
+            associatedEntityClass: ParentEntity,
+            edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE,
+          },
+        }),
+      },
+      databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+      cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    });
+
+    const parentEntityCompanion = new EntityCompanionDefinition({
+      entityClass: ParentEntity,
+      entityConfiguration: parentEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    });
+
+    const childEntityCompanion = new EntityCompanionDefinition({
+      entityClass: ChildEntity,
+      entityConfiguration: childEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    });
+
+    it('deletes', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new TestViewerContext(companionProvider);
+
+      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const child = await ChildEntity.creator(viewerContext)
+        .setField('parent_id', parent.getID())
+        .enforceCreateAsync();
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.not.toBeNull();
+      await expect(
+        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID())
+      ).resolves.not.toBeNull();
+
+      await ParentEntity.enforceDeleteAsync(parent);
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.toBeNull();
+      await expect(
+        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID())
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe('OnDeleteBehavior.SET_NULL', () => {
+    class ParentEntity extends Entity<ParentFields, string, TestViewerContext> {
+      static getCompanionDefinition(): EntityCompanionDefinition<
+        ParentFields,
+        string,
+        TestViewerContext,
+        ParentEntity,
+        TestEntityPrivacyPolicy
+      > {
+        return parentEntityCompanion;
+      }
+    }
+
+    class ChildEntity extends Entity<ChildFields, string, TestViewerContext> {
+      static getCompanionDefinition(): EntityCompanionDefinition<
+        ChildFields,
+        string,
+        TestViewerContext,
+        ChildEntity,
+        TestEntityPrivacyPolicy
+      > {
+        return childEntityCompanion;
+      }
+    }
+
+    const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
+      idField: 'id',
+      tableName: 'parents',
+      inboundEdges: [ChildEntity],
+      schema: {
+        id: new UUIDField({
+          columnName: 'id',
+          cache: true,
+        }),
+      },
+      databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+      cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    });
+
+    const childEntityConfiguration = new EntityConfiguration<ChildFields>({
+      idField: 'id',
+      tableName: 'children',
+      schema: {
+        id: new UUIDField({
+          columnName: 'id',
+          cache: true,
+        }),
+        parent_id: new UUIDField({
+          columnName: 'parent_id',
+          association: {
+            associatedEntityClass: ParentEntity,
+            edgeDeletionBehavior: EntityEdgeDeletionBehavior.SET_NULL,
+          },
+        }),
+      },
+      databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+      cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    });
+
+    const parentEntityCompanion = new EntityCompanionDefinition({
+      entityClass: ParentEntity,
+      entityConfiguration: parentEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    });
+
+    const childEntityCompanion = new EntityCompanionDefinition({
+      entityClass: ChildEntity,
+      entityConfiguration: childEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    });
+
+    it('sets null', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new TestViewerContext(companionProvider);
+
+      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const child = await ChildEntity.creator(viewerContext)
+        .setField('parent_id', parent.getID())
+        .enforceCreateAsync();
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.not.toBeNull();
+      await expect(
+        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID())
+      ).resolves.not.toBeNull();
+
+      await ParentEntity.enforceDeleteAsync(parent);
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.toBeNull();
+
+      const loadedChild = await ChildEntity.loader(viewerContext)
+        .enforcing()
+        .loadByIDAsync(child.getID());
+      expect(loadedChild.getField('parent_id')).toBeNull();
+    });
+  });
+
+  describe('OnDeleteBehavior.INVALIDATE_CACHE', () => {
+    class ParentEntity extends Entity<ParentFields, string, TestViewerContext> {
+      static getCompanionDefinition(): EntityCompanionDefinition<
+        ParentFields,
+        string,
+        TestViewerContext,
+        ParentEntity,
+        TestEntityPrivacyPolicy
+      > {
+        return parentEntityCompanion;
+      }
+    }
+
+    class ChildEntity extends Entity<ChildFields, string, TestViewerContext> {
+      static getCompanionDefinition(): EntityCompanionDefinition<
+        ChildFields,
+        string,
+        TestViewerContext,
+        ChildEntity,
+        TestEntityPrivacyPolicy
+      > {
+        return childEntityCompanion;
+      }
+    }
+
+    const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
+      idField: 'id',
+      tableName: 'parents',
+      inboundEdges: [ChildEntity],
+      schema: {
+        id: new UUIDField({
+          columnName: 'id',
+          cache: true,
+        }),
+      },
+      databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+      cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    });
+
+    const childEntityConfiguration = new EntityConfiguration<ChildFields>({
+      idField: 'id',
+      tableName: 'children',
+      schema: {
+        id: new UUIDField({
+          columnName: 'id',
+          cache: true,
+        }),
+        parent_id: new UUIDField({
+          columnName: 'parent_id',
+          cache: true,
+          association: {
+            associatedEntityClass: ParentEntity,
+            edgeDeletionBehavior: EntityEdgeDeletionBehavior.INVALIDATE_CACHE,
+          },
+        }),
+      },
+      databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+      cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    });
+
+    const parentEntityCompanion = new EntityCompanionDefinition({
+      entityClass: ParentEntity,
+      entityConfiguration: parentEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    });
+
+    const childEntityCompanion = new EntityCompanionDefinition({
+      entityClass: ChildEntity,
+      entityConfiguration: childEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    });
+
+    it('invalidates the cache', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new TestViewerContext(companionProvider);
+
+      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const child = await ChildEntity.creator(viewerContext)
+        .setField('parent_id', parent.getID())
+        .enforceCreateAsync();
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.not.toBeNull();
+      await expect(
+        ChildEntity.loader(viewerContext)
+          .enforcing()
+          .loadByFieldEqualingAsync('parent_id', parent.getID())
+      ).resolves.not.toBeNull();
+
+      const cacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
+        'entityCompanion'
+      ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
+      const cachedBefore = await cacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
+      expect(cachedBefore.get(parent.getID())?.status).toEqual(CacheStatus.HIT);
+
+      await ParentEntity.enforceDeleteAsync(parent);
+
+      const cachedAfter = await cacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
+      expect(cachedAfter.get(parent.getID())?.status).toEqual(CacheStatus.MISS);
+
+      await expect(
+        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID())
+      ).resolves.toBeNull();
+
+      await expect(
+        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID())
+      ).resolves.not.toBeNull();
+    });
+  });
+});

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -2,7 +2,6 @@ import { enforceAsyncResult } from '@expo/results';
 import { mock, instance, verify, spy, deepEqual, anyOfClass, anything, when } from 'ts-mockito';
 
 import EntityLoader from '../EntityLoader';
-import { EntityNonTransactionalQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import { enforceResultsAsync } from '../entityUtils';
 import EntityDataManager from '../internal/EntityDataManager';
@@ -21,7 +20,7 @@ describe(EntityLoader, () => {
   it('loads entities', async () => {
     const dateToInsert = new Date();
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const databaseAdapter = new StubDatabaseAdapter<TestFields>(
       testEntityConfiguration,
@@ -96,7 +95,7 @@ describe(EntityLoader, () => {
     const privacyPolicy = new TestEntityPrivacyPolicy();
     const spiedPrivacyPolicy = spy(privacyPolicy);
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const databaseAdapter = new StubDatabaseAdapter<TestFields>(
       testEntityConfiguration,
@@ -172,7 +171,7 @@ describe(EntityLoader, () => {
     const spiedPrivacyPolicy = spy(privacyPolicy);
 
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const databaseAdapter = new StubDatabaseAdapter<TestFields>(
       testEntityConfiguration,
@@ -217,7 +216,7 @@ describe(EntityLoader, () => {
 
   it('invalidates upon invalidate one', async () => {
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
     const dataManagerMock = mock(EntityDataManager);
     const dataManagerInstance = instance(dataManagerMock);
@@ -239,7 +238,7 @@ describe(EntityLoader, () => {
 
   it('invalidates upon invalidate by field', async () => {
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
     const dataManagerMock = mock(EntityDataManager);
     const dataManagerInstance = instance(dataManagerMock);
@@ -260,7 +259,7 @@ describe(EntityLoader, () => {
 
   it('returns error result when not allowed', async () => {
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicyMock = mock(TestEntityPrivacyPolicy);
     const dataManagerMock = mock(EntityDataManager);
 
@@ -294,7 +293,7 @@ describe(EntityLoader, () => {
 
   it('throws upon database adapter error', async () => {
     const viewerContext = instance(mock(ViewerContext));
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
     const dataManagerMock = mock(EntityDataManager);
 

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -80,7 +80,7 @@ const createEntityMutatorFactory = (
     dataManager
   );
   const entityMutatorFactory = new EntityMutatorFactory(
-    testEntityConfiguration.idField,
+    testEntityConfiguration,
     TestEntity,
     privacyPolicy,
     entityLoaderFactory,
@@ -291,7 +291,7 @@ describe(EntityMutatorFactory, () => {
     ).thenReject(rejectionError);
 
     const entityMutatorFactory = new EntityMutatorFactory(
-      simpleTestEntityConfiguration.idField,
+      simpleTestEntityConfiguration,
       SimpleTestEntity,
       instance(privacyPolicyMock),
       entityLoaderFactory,
@@ -355,7 +355,7 @@ describe(EntityMutatorFactory, () => {
     );
 
     const entityMutatorFactory = new EntityMutatorFactory(
-      simpleTestEntityConfiguration.idField,
+      simpleTestEntityConfiguration,
       SimpleTestEntity,
       privacyPolicy,
       entityLoaderFactory,

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -1,0 +1,239 @@
+import Entity from '../Entity';
+import {
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  EntityCompanionDefinition,
+} from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField, EntityEdgeDeletionBehavior } from '../EntityFields';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import { CacheStatus } from '../internal/ReadThroughEntityCache';
+import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
+import TestViewerContext from '../testfixtures/TestViewerContext';
+import { InMemoryFullCacheStubCacheAdapter } from '../utils/testing/StubCacheAdapter';
+import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
+
+interface CategoryFields {
+  id: string;
+  parent_category_id: string | null;
+}
+
+class CategoryPrivacyPolicy extends EntityPrivacyPolicy<
+  CategoryFields,
+  string,
+  TestViewerContext,
+  any,
+  any
+> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
+  class CategoryEntity extends Entity<CategoryFields, string, TestViewerContext> {
+    static getCompanionDefinition(): EntityCompanionDefinition<
+      CategoryFields,
+      string,
+      TestViewerContext,
+      CategoryEntity,
+      CategoryPrivacyPolicy
+    > {
+      return categoryEntityCompanion;
+    }
+  }
+
+  const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
+    idField: 'id',
+    tableName: 'categories',
+    inboundEdges: [CategoryEntity],
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+        cache: true,
+      }),
+      parent_category_id: new UUIDField({
+        columnName: 'parent_category_id',
+        cache: true,
+        association: {
+          associatedEntityClass: CategoryEntity,
+          edgeDeletionBehavior,
+        },
+      }),
+    },
+    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  });
+
+  const categoryEntityCompanion = new EntityCompanionDefinition({
+    entityClass: CategoryEntity,
+    entityConfiguration: categoryEntityConfiguration,
+    privacyPolicyClass: CategoryPrivacyPolicy,
+  });
+
+  return {
+    CategoryEntity,
+  };
+};
+
+describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
+  it('deletes', async () => {
+    const { CategoryEntity } = makeEntityClass(EntityEdgeDeletionBehavior.CASCADE_DELETE);
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new TestViewerContext(companionProvider);
+
+    const parentCategory = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const subCategory = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', parentCategory.getID())
+      .enforceCreateAsync();
+    const subSubCategory = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', subCategory.getID())
+      .enforceCreateAsync();
+
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parentCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subSubCategory.getID())
+    ).resolves.not.toBeNull();
+
+    await CategoryEntity.enforceDeleteAsync(parentCategory);
+
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parentCategory.getID())
+    ).resolves.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID())
+    ).resolves.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subSubCategory.getID())
+    ).resolves.toBeNull();
+  });
+});
+
+describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
+  it('sets null', async () => {
+    const { CategoryEntity } = makeEntityClass(EntityEdgeDeletionBehavior.SET_NULL);
+
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new TestViewerContext(companionProvider);
+
+    const parentCategory = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const subCategory = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', parentCategory.getID())
+      .enforceCreateAsync();
+    const subSubCategory = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', subCategory.getID())
+      .enforceCreateAsync();
+
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parentCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subSubCategory.getID())
+    ).resolves.not.toBeNull();
+
+    await CategoryEntity.enforceDeleteAsync(parentCategory);
+
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parentCategory.getID())
+    ).resolves.toBeNull();
+
+    const loadedSubCategory = await CategoryEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(subCategory.getID());
+    expect(loadedSubCategory.getField('parent_category_id')).toBeNull();
+
+    const loadedSubSubCategory = await CategoryEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(subSubCategory.getID());
+    expect(loadedSubSubCategory.getField('parent_category_id')).not.toBeNull();
+  });
+});
+
+describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
+  it('invalidates the cache', async () => {
+    const { CategoryEntity } = makeEntityClass(
+      EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE
+    );
+
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new TestViewerContext(companionProvider);
+
+    const parentCategory = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const subCategory = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', parentCategory.getID())
+      .enforceCreateAsync();
+    const subSubCategory = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', subCategory.getID())
+      .enforceCreateAsync();
+
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parentCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext)
+        .enforcing()
+        .loadByFieldEqualingAsync('parent_category_id', parentCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext)
+        .enforcing()
+        .loadByFieldEqualingAsync('parent_category_id', subCategory.getID())
+    ).resolves.not.toBeNull();
+
+    const subCategoryCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(
+      CategoryEntity
+    )['entityCompanion']['tableDataCoordinator'][
+      'cacheAdapter'
+    ] as InMemoryFullCacheStubCacheAdapter<CategoryFields>;
+    const subCategoryCachedBefore = await subCategoryCacheAdapter.loadManyAsync(
+      'parent_category_id',
+      [parentCategory.getID()]
+    );
+    expect(subCategoryCachedBefore.get(parentCategory.getID())?.status).toEqual(CacheStatus.HIT);
+
+    const subSubCategoryCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(
+      CategoryEntity
+    )['entityCompanion']['tableDataCoordinator'][
+      'cacheAdapter'
+    ] as InMemoryFullCacheStubCacheAdapter<CategoryFields>;
+    const subSubCategoryCachedBefore = await subSubCategoryCacheAdapter.loadManyAsync(
+      'parent_category_id',
+      [subCategory.getID()]
+    );
+    expect(subSubCategoryCachedBefore.get(subCategory.getID())?.status).toEqual(CacheStatus.HIT);
+
+    await CategoryEntity.enforceDeleteAsync(parentCategory);
+
+    const subCategoryCachedAfter = await subCategoryCacheAdapter.loadManyAsync(
+      'parent_category_id',
+      [parentCategory.getID()]
+    );
+    expect(subCategoryCachedAfter.get(parentCategory.getID())?.status).toEqual(CacheStatus.MISS);
+
+    const subSubCategoryCachedAfter = await subSubCategoryCacheAdapter.loadManyAsync(
+      'parent_category_id',
+      [subCategory.getID()]
+    );
+    expect(subSubCategoryCachedAfter.get(subCategory.getID())?.status).toEqual(CacheStatus.MISS);
+
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parentCategory.getID())
+    ).resolves.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID())
+    ).resolves.not.toBeNull();
+    await expect(
+      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subSubCategory.getID())
+    ).resolves.not.toBeNull();
+  });
+});

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -6,6 +6,7 @@ import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
+import TestEntity from '../testfixtures/TestEntity';
 import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
 
 describe(ReadonlyEntity, () => {
@@ -28,6 +29,42 @@ describe(ReadonlyEntity, () => {
       };
       const testEntity = new SimpleTestEntity(viewerContext, data);
       expect(testEntity.toString()).toEqual('SimpleTestEntity[what]');
+    });
+  });
+
+  describe('getUniqueIdentifier', () => {
+    it('returns a different value for two different entities of the same type', () => {
+      const viewerContext = instance(mock(ViewerContext));
+      const testEntity = new SimpleTestEntity(viewerContext, {
+        id: '1',
+      });
+      const testEntity2 = new SimpleTestEntity(viewerContext, {
+        id: '2',
+      });
+      expect(testEntity.getUniqueIdentifier()).not.toEqual(testEntity2.getUniqueIdentifier());
+    });
+
+    it('returns the same value even if different viewer context', () => {
+      const viewerContext = instance(mock(ViewerContext));
+      const viewerContext2 = instance(mock(ViewerContext));
+      const data = { id: '1' };
+      const testEntity = new SimpleTestEntity(viewerContext, data);
+      const testEntity2 = new SimpleTestEntity(viewerContext2, data);
+      expect(testEntity.getUniqueIdentifier()).toEqual(testEntity2.getUniqueIdentifier());
+    });
+
+    it('returns a different value for different entities even if same ID', () => {
+      const viewerContext = instance(mock(ViewerContext));
+      const data = { id: '1' };
+      const testEntity = new SimpleTestEntity(viewerContext, data);
+      const testEntity2 = new TestEntity(viewerContext, {
+        customIdField: '1',
+        testIndexedField: '2',
+        stringField: '3',
+        numberField: 4,
+        dateField: new Date(),
+      });
+      expect(testEntity.getUniqueIdentifier()).not.toEqual(testEntity2.getUniqueIdentifier());
     });
   });
 

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -74,7 +74,7 @@ describe(ReadonlyEntity, () => {
     it('creates a new regular query context', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      const queryContext = SimpleTestEntity.getRegularEntityQueryContext(viewerContext);
+      const queryContext = SimpleTestEntity.getQueryContext(viewerContext);
       expect(queryContext).toBeInstanceOf(EntityQueryContext);
       expect(queryContext.isInTransaction()).toBe(false);
     });

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -63,7 +63,7 @@ export default class EntityDataManager<TFields> {
       async (fetcherValues) => {
         this.metricsAdapter.incrementDataManagerDatabaseLoadCount(fieldValues.length);
         return await this.databaseAdapter.fetchManyWhereAsync(
-          this.queryContextProvider.getRegularEntityQueryContext(),
+          this.queryContextProvider.getQueryContext(),
           fieldName,
           fetcherValues
         );

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -71,7 +71,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
@@ -118,7 +118,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
@@ -165,7 +165,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
     // use second data manager to ensure that cache is hit instead of data loader
     const entityDataManager2 = new EntityDataManager(
       databaseAdapter,
@@ -207,7 +207,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
@@ -242,7 +242,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
@@ -285,7 +285,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1];
 
@@ -323,7 +323,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1];
 
@@ -398,7 +398,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyByFieldEqualityConjunctionAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
@@ -443,7 +443,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       new NoOpEntityMetricsAdapter()
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     await expect(
       entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'customIdField', ['2'])
@@ -469,7 +469,7 @@ describe(EntityDataManager, () => {
       StubQueryContextProvider,
       metricsAdapter
     );
-    const queryContext = StubQueryContextProvider.getRegularEntityQueryContext();
+    const queryContext = StubQueryContextProvider.getQueryContext();
 
     await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'customIdField', ['1']);
     verify(

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -57,7 +57,7 @@ export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAd
   }
 }
 
-class InMemoryFullCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+export class InMemoryFullCacheStubCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
   constructor(
     entityConfiguration: EntityConfiguration<TFields>,
     readonly cache: Map<string, Readonly<object>>

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -205,7 +205,9 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
     const objectIndex = objectCollection.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
-    invariant(objectIndex >= 0, 'should exist');
+    if (objectIndex < 0) {
+      return 0;
+    }
     objectCollection.splice(objectIndex, 1);
     return 1;
   }

--- a/packages/entity/src/utils/testing/StubQueryContextProvider.ts
+++ b/packages/entity/src/utils/testing/StubQueryContextProvider.ts
@@ -1,17 +1,16 @@
 import {
   EntityNonTransactionalQueryContext,
-  EntityQueryContext,
   EntityTransactionalQueryContext,
 } from '../../EntityQueryContext';
 import IEntityQueryContextProvider from '../../IEntityQueryContextProvider';
 
 class StubQueryContextProvider implements IEntityQueryContextProvider {
-  getRegularEntityQueryContext(): EntityQueryContext {
-    return new EntityNonTransactionalQueryContext({});
+  getQueryContext(): EntityNonTransactionalQueryContext {
+    return new EntityNonTransactionalQueryContext({}, this);
   }
 
   async runInTransactionAsync<T>(
-    transactionScope: (queryContext: EntityQueryContext) => Promise<T>
+    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<T>
   ): Promise<T> {
     return await transactionScope(new EntityTransactionalQueryContext({}));
   }

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -1,7 +1,7 @@
 import { instance, mock } from 'ts-mockito';
 
 import { OrderByOrdering } from '../../../EntityDatabaseAdapter';
-import { EntityNonTransactionalQueryContext } from '../../../EntityQueryContext';
+import { EntityQueryContext } from '../../../EntityQueryContext';
 import {
   DateIDTestFields,
   dateIDTestEntityConfiguration,
@@ -20,7 +20,7 @@ import StubDatabaseAdapter from '../StubDatabaseAdapter';
 describe(StubDatabaseAdapter, () => {
   describe('fetchManyWhereAsync', () => {
     it('fetches many where', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
@@ -58,7 +58,7 @@ describe(StubDatabaseAdapter, () => {
 
   describe('fetchManyByFieldEqualityConjunctionAsync', () => {
     it('supports conjuntions and query modifiers', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
@@ -123,7 +123,7 @@ describe(StubDatabaseAdapter, () => {
     });
 
     it('supports multiple order bys', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
@@ -188,7 +188,7 @@ describe(StubDatabaseAdapter, () => {
 
   describe('fetchManyByRawWhereClauseAsync', () => {
     it('throws because it is unsupported', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         new Map()
@@ -201,7 +201,7 @@ describe(StubDatabaseAdapter, () => {
 
   describe('insertAsync', () => {
     it('inserts a record', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         new Map()
@@ -221,7 +221,7 @@ describe(StubDatabaseAdapter, () => {
 
   describe('updateAsync', () => {
     it('updates a record', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
@@ -254,7 +254,7 @@ describe(StubDatabaseAdapter, () => {
 
   describe('deleteAsync', () => {
     it('deletes an object', async () => {
-      const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+      const queryContext = instance(mock(EntityQueryContext));
       const databaseAdapter = new StubDatabaseAdapter<TestFields>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
@@ -285,7 +285,7 @@ describe(StubDatabaseAdapter, () => {
   });
 
   it('supports string and number IDs', async () => {
-    const queryContext = instance(mock(EntityNonTransactionalQueryContext));
+    const queryContext = instance(mock(EntityQueryContext));
     const databaseAdapter1 = new StubDatabaseAdapter<SimpleTestFields>(
       simpleTestEntityConfiguration,
       new Map()

--- a/resources/jest-integration.config.js
+++ b/resources/jest-integration.config.js
@@ -3,4 +3,11 @@ module.exports = {
   testMatch: ['**/__integration-tests__/**/*-test.ts'],
   coveragePathIgnorePatterns: ['testfixtures'],
   coverageDirectory: 'coverage-integration',
+  globals: {
+    'ts-jest': {
+      diagnostics: {
+        warnOnly: true,
+      },
+    },
+  },
 };

--- a/resources/jest.config.js
+++ b/resources/jest.config.js
@@ -2,4 +2,11 @@ module.exports = {
   preset: 'ts-jest',
   testMatch: ['**/__tests__/**/*-test.ts'],
   coveragePathIgnorePatterns: ['testfixtures'],
+  globals: {
+    'ts-jest': {
+      diagnostics: {
+        warnOnly: true,
+      },
+    },
+  },
 };


### PR DESCRIPTION
# Why

#19

This PR adds the ability to specify relationships between entities for use during deletion. Three modes are supported:
- `INVALIDATE_CACHE`: Invalidates the cache for all entities that reference the entity being deleted. This is most useful when the database itself expresses foreign keys and cascading deletes or set nulls and the entity framework just needs to be kept consistent with the state of the database.
- `CASCADE_DELETE`: Deletes the entities that reference the entity being deleted. This is very similar to DBMS `ON DELETE CASCADE` but is done in the Entity framework instead of at the underlying level, and should not be used in combination with database-schema-expressed foreign keys and deletion behavior. This has the nice effect of keeping the cache consistent as well of course.
- `SET_NULL`: Sets fields referencing the entity being deleted to null in any entities that reference the entity being deleted. 

Next up: See if it is possible to combine this and association loader in a type safe way. I'm doubting it'll be possible to infer types of edges based on this new schema association specification, but we may at least be able to share the edge definitions for chain loading.

Edit: this PR also now creates a transaction if not already in one for all creates, updates, and deletes. This will become very useful for triggers, but is also useful for dependent deletions added in this PR.

# How

The main piece of this PR is the `processEntityDeletionForInboundEdgesAsync`. See docblock for description. Everything else is tests.

# Test Plan

Run all new tests.
