### PR TITLE
fix!: remove lodash dependency for vuln, require node 12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: Cache Node.js modules
         uses: actions/cache@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 12.x
     - name: Cache Node.js modules
       uses: actions/cache@v1
       with:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/invariant": "^2.2.32",
     "@types/ioredis": "^4.14.9",
     "@types/jest": "^25.2.1",
-    "@types/lodash": "^4.14.150",
     "@types/node": "^13.13.4",
     "@types/uuid": "^7.0.3",
     "@typescript-eslint/eslint-plugin": "^2.30.0",

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -18,7 +18,7 @@
     "barrelsby": "barrelsby --directory src --location top --exclude tests__ --singleQuotes --exportDefault --delete"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "keywords": [
     "entity"

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -18,7 +18,7 @@
     "barrelsby": "barrelsby --directory src --location top --exclude tests__ --singleQuotes --exportDefault --delete"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "keywords": [
     "entity"

--- a/packages/entity-example/package.json
+++ b/packages/entity-example/package.json
@@ -14,7 +14,7 @@
     "start": "tsnd --transpile-only --inspect --respawn --no-notify --async-stack-traces --throw-deprecation -- src/index.ts"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "keywords": [
     "entity"

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -18,7 +18,7 @@
     "barrelsby": "barrelsby --directory src --location top --exclude tests__ --singleQuotes --exportDefault --delete"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "keywords": [
     "entity"
@@ -30,7 +30,6 @@
     "dataloader": "^2.0.0",
     "es6-error": "^4.1.1",
     "invariant": "^2.2.4",
-    "lodash": "^4.17.15",
     "uuid": "^7.0.3"
   }
 }

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -1,5 +1,4 @@
 import { Result, asyncResult, result, enforceAsyncResult } from '@expo/results';
-import _ from 'lodash';
 
 import Entity, { IEntityClass } from './Entity';
 import { EntityCompanionDefinition } from './EntityCompanionProvider';
@@ -192,8 +191,8 @@ export class UpdateMutator<
       databaseAdapter,
       metricsAdapter
     );
-    this.originalFieldsForEntity = _.cloneDeep(fieldsForEntity);
-    this.fieldsForEntity = _.cloneDeep(fieldsForEntity);
+    this.originalFieldsForEntity = { ...fieldsForEntity };
+    this.fieldsForEntity = { ...fieldsForEntity };
   }
 
   /**

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -1,5 +1,4 @@
 import invariant from 'invariant';
-import { pick } from 'lodash';
 
 import { IEntityClass } from './Entity';
 import EntityAssociationLoader from './EntityAssociationLoader';
@@ -8,6 +7,7 @@ import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
+import { pick } from './entityUtils';
 
 /**
  * A readonly entity exposes only the read functionality of an Entity. Used as the base

--- a/packages/entity/src/__tests__/entityUtils-test.ts
+++ b/packages/entity/src/__tests__/entityUtils-test.ts
@@ -6,6 +6,7 @@ import {
   failedResults,
   successfulResultsFilterMap,
   failedResultsFilterMap,
+  pick,
 } from '../entityUtils';
 
 describe(enforceResultsAsync, () => {
@@ -42,39 +43,57 @@ describe(failedResults, () => {
 });
 
 describe(successfulResultsFilterMap, () => {
-  const result1 = result(1);
-  const result2 = result(new Error('hello'));
-  const result3 = result(1);
-  const allResults = new Map(
-    Object.entries({
-      a: result1,
-      b: result2,
-      c: result3,
-    })
-  );
+  it('filters out failed results', () => {
+    const result1 = result(1);
+    const result2 = result(new Error('hello'));
+    const result3 = result(1);
+    const allResults = new Map(
+      Object.entries({
+        a: result1,
+        b: result2,
+        c: result3,
+      })
+    );
 
-  const resultingMap = successfulResultsFilterMap(allResults);
+    const resultingMap = successfulResultsFilterMap(allResults);
 
-  expect(resultingMap.get('a')).toEqual(result1);
-  expect(resultingMap.get('b')).toBeUndefined();
-  expect(resultingMap.get('c')).toEqual(result3);
+    expect(resultingMap.get('a')).toEqual(result1);
+    expect(resultingMap.get('b')).toBeUndefined();
+    expect(resultingMap.get('c')).toEqual(result3);
+  });
 });
 
 describe(failedResultsFilterMap, () => {
-  const result1 = result(1);
-  const result2 = result(new Error('hello'));
-  const result3 = result(1);
-  const allResults = new Map(
-    Object.entries({
-      a: result1,
-      b: result2,
-      c: result3,
-    })
-  );
+  it('filters out successful results', () => {
+    const result1 = result(1);
+    const result2 = result(new Error('hello'));
+    const result3 = result(1);
+    const allResults = new Map(
+      Object.entries({
+        a: result1,
+        b: result2,
+        c: result3,
+      })
+    );
 
-  const resultingMap = failedResultsFilterMap(allResults);
+    const resultingMap = failedResultsFilterMap(allResults);
 
-  expect(resultingMap.get('a')).toBeUndefined();
-  expect(resultingMap.get('b')).toEqual(result2);
-  expect(resultingMap.get('c')).toBeUndefined();
+    expect(resultingMap.get('a')).toBeUndefined();
+    expect(resultingMap.get('b')).toEqual(result2);
+    expect(resultingMap.get('c')).toBeUndefined();
+  });
+});
+
+describe(pick, () => {
+  it('picks specified keys', () => {
+    const object = {
+      a: 1,
+      b: 2,
+      c: 3,
+    };
+    expect(pick(object, ['a', 'b'])).toEqual({
+      a: 1,
+      b: 2,
+    });
+  });
 });

--- a/packages/entity/src/entityUtils.ts
+++ b/packages/entity/src/entityUtils.ts
@@ -93,3 +93,10 @@ export const partitionErrors = <T>(valuesAndErrors: (T | Error)[]): [T[], Error[
 const isError = <T>(value: T | Error): value is Error => {
   return value instanceof Error;
 };
+
+export const pick = <T extends object, U extends keyof T>(object: T, props: U[]): Pick<T, U> => {
+  const propsSet = new Set(props);
+  return Object.fromEntries(
+    Object.entries(object).filter((entry) => propsSet.has(entry[0] as any))
+  ) as any;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2018"],
+    "target": "es2019",
+    "lib": ["es2019"],
     "module": "commonjs",
     "sourceMap": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,23 +311,22 @@
     which "^1.3.1"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.4.0"
+  version "0.5.2"
   dependencies:
     ioredis "^4.16.1"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.4.0"
+  version "0.5.2"
   dependencies:
     knex "^0.20.11"
 
 "@expo/entity@file:packages/entity":
-  version "0.4.0"
+  version "0.5.2"
   dependencies:
     "@expo/results" "^0.3.0"
     dataloader "^2.0.0"
     es6-error "^4.1.1"
     invariant "^2.2.4"
-    lodash "^4.17.15"
     uuid "^7.0.3"
 
 "@expo/results@^0.3.0":
@@ -1612,11 +1611,6 @@
   integrity sha512-RfG2EuSc+nv/E+xbDSLW8KCoeri/3AkqwVPuENfF/DctllRoXhooboO//Sw7yFtkLvj7nG7O1H3JcZmoTQz8nQ==
   dependencies:
     "@types/koa" "*"
-
-"@types/lodash@^4.14.150":
-  version "4.14.150"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
-  integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
 
 "@types/long@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
# Why

https://github.com/advisories/GHSA-p6mc-m468-83gw

Figured we don't actually need lodash. 
- `pick` is easy to re-create for our needs (less edge cases due to typescript). 
- Don't actually need `cloneDeep` for mutator, since all we need to ensure is that `setField` doesn't change the original object, and `setField` doesn't support deep changes to objects.

# How

Remove `lodash` dependencies, add new method.

# Test Plan

Run tests.
