### PR TITLE
feat: mutation triggers

### DIFF
--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -1,0 +1,154 @@
+import {
+  AlwaysAllowPrivacyPolicyRule,
+  EntityPrivacyPolicy,
+  ViewerContext,
+  UUIDField,
+  StringField,
+  EntityConfiguration,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  EntityCompanionDefinition,
+  Entity,
+  EntityMutationTrigger,
+  EntityQueryContext,
+} from '@expo/entity';
+import Knex from 'knex';
+
+type PostgresTriggerTestEntityFields = {
+  id: string;
+  name: string | null;
+};
+
+export default class PostgresTriggerTestEntity extends Entity<
+  PostgresTriggerTestEntityFields,
+  string,
+  ViewerContext
+> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    PostgresTriggerTestEntityFields,
+    string,
+    ViewerContext,
+    PostgresTriggerTestEntity,
+    PostgresTriggerTestEntityPrivacyPolicy
+  > {
+    return postgresTestEntityCompanionDefinition;
+  }
+
+  public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'); // for uuid_generate_v4()
+
+    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (!hasTable) {
+      await knex.schema.createTable(tableName, (table) => {
+        table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+        table.string('name');
+      });
+    }
+    await knex.into(tableName).truncate();
+  }
+
+  public static async dropPostgresTable(knex: Knex): Promise<void> {
+    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (hasTable) {
+      await knex.schema.dropTable(tableName);
+    }
+  }
+}
+
+class PostgresTriggerTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  PostgresTriggerTestEntityFields,
+  string,
+  ViewerContext,
+  PostgresTriggerTestEntity
+> {
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresTriggerTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresTriggerTestEntity
+    >(),
+  ];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresTriggerTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresTriggerTestEntity
+    >(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresTriggerTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresTriggerTestEntity
+    >(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresTriggerTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresTriggerTestEntity
+    >(),
+  ];
+}
+
+class ThrowConditionallyTrigger extends EntityMutationTrigger<
+  PostgresTriggerTestEntityFields,
+  string,
+  ViewerContext,
+  PostgresTriggerTestEntity
+> {
+  constructor(private fieldName: keyof PostgresTriggerTestEntityFields, private badValue: string) {
+    super();
+  }
+
+  async executeAsync(
+    _viewerContext: ViewerContext,
+    _queryContext: EntityQueryContext,
+    entity: PostgresTriggerTestEntity
+  ): Promise<void> {
+    if (entity.getField(this.fieldName) === this.badValue) {
+      throw new Error(`${this.fieldName} cannot have value ${this.badValue}`);
+    }
+  }
+}
+
+export const postgresTestEntityConfiguration = new EntityConfiguration<
+  PostgresTriggerTestEntityFields
+>({
+  idField: 'id',
+  tableName: 'postgres_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    name: new StringField({
+      columnName: 'name',
+    }),
+  },
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+});
+
+const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
+  entityClass: PostgresTriggerTestEntity,
+  entityConfiguration: postgresTestEntityConfiguration,
+  privacyPolicyClass: PostgresTriggerTestEntityPrivacyPolicy,
+  mutationTriggers: {
+    beforeCreate: [new ThrowConditionallyTrigger('name', 'beforeCreate')],
+    afterCreate: [new ThrowConditionallyTrigger('name', 'afterCreate')],
+    beforeUpdate: [new ThrowConditionallyTrigger('name', 'beforeUpdate')],
+    afterUpdate: [new ThrowConditionallyTrigger('name', 'afterUpdate')],
+    beforeDelete: [new ThrowConditionallyTrigger('name', 'beforeDelete')],
+    afterDelete: [new ThrowConditionallyTrigger('name', 'afterDelete')],
+    beforeAll: [new ThrowConditionallyTrigger('name', 'beforeAll')],
+    afterAll: [new ThrowConditionallyTrigger('name', 'afterAll')],
+    afterCommit: [new ThrowConditionallyTrigger('name', 'afterCommit')],
+  },
+});

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -1,5 +1,6 @@
 import { IEntityClass } from './Entity';
 import EntityLoaderFactory from './EntityLoaderFactory';
+import { EntityMutationTriggerConfiguration } from './EntityMutationTrigger';
 import EntityMutatorFactory from './EntityMutatorFactory';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import IEntityQueryContextProvider from './IEntityQueryContextProvider';
@@ -57,6 +58,13 @@ export default class EntityCompanion<
     >,
     private readonly tableDataCoordinator: EntityTableDataCoordinator<TFields>,
     PrivacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>,
+    mutationTriggers: EntityMutationTriggerConfiguration<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
     metricsAdapter: IEntityMetricsAdapter
   ) {
     const privacyPolicy = new PrivacyPolicyClass();
@@ -70,6 +78,7 @@ export default class EntityCompanion<
       tableDataCoordinator.entityConfiguration,
       entityClass,
       privacyPolicy,
+      mutationTriggers,
       this.entityLoaderFactory,
       tableDataCoordinator.databaseAdapter,
       metricsAdapter

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -1,6 +1,7 @@
 import { IEntityClass } from './Entity';
 import EntityCompanion, { IPrivacyPolicyClass } from './EntityCompanion';
 import EntityConfiguration from './EntityConfiguration';
+import { EntityMutationTriggerConfiguration } from './EntityMutationTrigger';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import IEntityCacheAdapterProvider from './IEntityCacheAdapterProvider';
 import IEntityDatabaseAdapterProvider from './IEntityDatabaseAdapterProvider';
@@ -80,12 +81,20 @@ export class EntityCompanionDefinition<
   >;
   readonly entityConfiguration: EntityConfiguration<TFields>;
   readonly privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+  readonly mutationTriggers: EntityMutationTriggerConfiguration<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >;
   readonly entitySelectedFields: TSelectedFields[];
 
   constructor({
     entityClass,
     entityConfiguration,
     privacyPolicyClass,
+    mutationTriggers = {},
     entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
   }: {
     entityClass: IEntityClass<
@@ -98,11 +107,19 @@ export class EntityCompanionDefinition<
     >;
     entityConfiguration: EntityConfiguration<TFields>;
     privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+    mutationTriggers?: EntityMutationTriggerConfiguration<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >;
     entitySelectedFields?: TSelectedFields[];
   }) {
     this.entityClass = entityClass;
     this.entityConfiguration = entityConfiguration;
     this.privacyPolicyClass = privacyPolicyClass;
+    this.mutationTriggers = mutationTriggers;
     this.entitySelectedFields = entitySelectedFields;
   }
 }
@@ -184,6 +201,7 @@ export default class EntityCompanionProvider {
         entityCompanionDefinition.entityClass,
         tableDataCoordinator,
         entityCompanionDefinition.privacyPolicyClass,
+        entityCompanionDefinition.mutationTriggers,
         this.metricsAdapter
       );
     });

--- a/packages/entity/src/EntityMutationTrigger.ts
+++ b/packages/entity/src/EntityMutationTrigger.ts
@@ -1,0 +1,77 @@
+import { EntityQueryContext } from './EntityQueryContext';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * Interface to define trigger behavior for entities.
+ */
+export interface EntityMutationTriggerConfiguration<
+  TFields,
+  TID,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> {
+  /**
+   * Trigger set that runs within the transaction but before the entity is created in the database.
+   */
+  beforeCreate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  /**
+   * Trigger set that runs within the transaction but after the entity is created in the database and cache is invalidated.
+   */
+  afterCreate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+
+  /**
+   * Trigger set that runs within the transaction but before the entity is updated in the database.
+   */
+  beforeUpdate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  /**
+   * Trigger set that runs within the transaction but after the entity is updated in the database and cache is invalidated.
+   */
+  afterUpdate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+
+  /**
+   * Trigger set that runs within the transaction but before the entity is deleted from the database.
+   */
+  beforeDelete?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  /**
+   * Trigger set that runs within the transaction but after the entity is deleted from the database and cache is invalidated.
+   */
+  afterDelete?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+
+  /**
+   * Trigger set that runs within the transaction but before the entity is created, updated, or deleted.
+   */
+  beforeAll?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  /**
+   * Trigger set that runs within the transaction but before the entity is created in, updated in, or deleted from
+   * the database and the cache is invalidated.
+   */
+  afterAll?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+
+  /**
+   * Trigger set that runs after committing the transaction unless one is supplied
+   * after any mutation (create, update, delete). If the call to the mutation is wrapped in a transaction,
+   * this too will be within the transaction.
+   */
+  afterCommit?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+}
+
+/**
+ * A trigger is a way to specify entity mutation operation side-effects that run within the
+ * same transaction as the mutation itself. The one exception is afterCommit, which will run within
+ * the transaction if a transaction is supplied.
+ */
+export abstract class EntityMutationTrigger<
+  TFields,
+  TID,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> {
+  abstract async executeAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    entity: TEntity
+  ): Promise<void>;
+}

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -2,6 +2,7 @@ import Entity, { IEntityClass } from './Entity';
 import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
+import { EntityMutationTriggerConfiguration } from './EntityMutationTrigger';
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -36,6 +37,13 @@ export default class EntityMutatorFactory<
       TSelectedFields
     >,
     private readonly privacyPolicy: TPrivacyPolicy,
+    private readonly mutationTriggers: EntityMutationTriggerConfiguration<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
     private readonly entityLoaderFactory: EntityLoaderFactory<
       TFields,
       TID,
@@ -64,6 +72,7 @@ export default class EntityMutatorFactory<
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
+      this.mutationTriggers,
       this.entityLoaderFactory,
       this.databaseAdapter,
       this.metricsAdapter
@@ -86,6 +95,7 @@ export default class EntityMutatorFactory<
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
+      this.mutationTriggers,
       this.entityLoaderFactory,
       this.databaseAdapter,
       this.metricsAdapter,
@@ -108,6 +118,7 @@ export default class EntityMutatorFactory<
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
+      this.mutationTriggers,
       this.entityLoaderFactory,
       this.databaseAdapter,
       this.metricsAdapter,

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -17,7 +17,7 @@ export abstract class EntityQueryContext {
   }
 
   abstract async runInTransactionIfNotInTransactionAsync<T>(
-    transactionScope: (queryContext: EntityQueryContext) => Promise<T>
+    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<T>
   ): Promise<T>;
 }
 

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -19,6 +19,7 @@ describe(EntityCompanion, () => {
       TestEntity,
       instance(tableDataCoordinatorMock),
       TestEntityPrivacyPolicy,
+      {},
       instance(mock<IEntityMetricsAdapter>())
     );
     expect(companion.getLoaderFactory()).toBeInstanceOf(EntityLoaderFactory);

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -16,6 +16,7 @@ export * from './EntityFields';
 export { default as EntityLoader } from './EntityLoader';
 export { default as EntityLoaderFactory } from './EntityLoaderFactory';
 export * from './EntityMutator';
+export * from './EntityMutationTrigger';
 export { default as EntityMutatorFactory } from './EntityMutatorFactory';
 export { default as EntityPrivacyPolicy } from './EntityPrivacyPolicy';
 export * from './EntityPrivacyPolicy';


### PR DESCRIPTION
# Why

This PR adds mutation triggers, which are similar to [active record callbacks](https://guides.rubyonrails.org/active_record_callbacks.html). They allow entity authors to specify code that runs before and after mutations, and a special callback that occurs after commit of the transaction.

Use cases:
- Audit logging (similar to https://github.com/paper-trail-gem/paper_trail)
- Third-party service calls to keep data in sync
- Email sending
- etc...

Note that for now, this is separate from full entity validation (not yet implemented), but that will be done in a similar way. Depending on the transaction semantics we want for validation it may be exactly the same as `beforeAll` but it's unclear.

# How

Add ability to specify features, add tests.

# Test Plan

Run tests.
