### PR TITLE
feat: entity mutation validators

### DIFF
--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -1,0 +1,147 @@
+import {
+  AlwaysAllowPrivacyPolicyRule,
+  EntityPrivacyPolicy,
+  ViewerContext,
+  UUIDField,
+  StringField,
+  EntityConfiguration,
+  DatabaseAdapterFlavor,
+  CacheAdapterFlavor,
+  EntityCompanionDefinition,
+  Entity,
+  EntityMutationTrigger,
+  EntityQueryContext,
+} from '@expo/entity';
+import Knex from 'knex';
+
+type PostgresValidatorTestEntityFields = {
+  id: string;
+  name: string | null;
+};
+
+export default class PostgresValidatorTestEntity extends Entity<
+  PostgresValidatorTestEntityFields,
+  string,
+  ViewerContext
+> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    PostgresValidatorTestEntityFields,
+    string,
+    ViewerContext,
+    PostgresValidatorTestEntity,
+    PostgresValidatorTestEntityPrivacyPolicy
+  > {
+    return postgresTestEntityCompanionDefinition;
+  }
+
+  public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'); // for uuid_generate_v4()
+
+    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (!hasTable) {
+      await knex.schema.createTable(tableName, (table) => {
+        table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+        table.string('name');
+      });
+    }
+    await knex.into(tableName).truncate();
+  }
+
+  public static async dropPostgresTable(knex: Knex): Promise<void> {
+    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (hasTable) {
+      await knex.schema.dropTable(tableName);
+    }
+  }
+}
+
+class PostgresValidatorTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  PostgresValidatorTestEntityFields,
+  string,
+  ViewerContext,
+  PostgresValidatorTestEntity
+> {
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresValidatorTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresValidatorTestEntity
+    >(),
+  ];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresValidatorTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresValidatorTestEntity
+    >(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresValidatorTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresValidatorTestEntity
+    >(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresValidatorTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresValidatorTestEntity
+    >(),
+  ];
+}
+
+class ThrowConditionallyTrigger extends EntityMutationTrigger<
+  PostgresValidatorTestEntityFields,
+  string,
+  ViewerContext,
+  PostgresValidatorTestEntity
+> {
+  constructor(
+    private fieldName: keyof PostgresValidatorTestEntityFields,
+    private badValue: string
+  ) {
+    super();
+  }
+
+  async executeAsync(
+    _viewerContext: ViewerContext,
+    _queryContext: EntityQueryContext,
+    entity: PostgresValidatorTestEntity
+  ): Promise<void> {
+    if (entity.getField(this.fieldName) === this.badValue) {
+      throw new Error(`${this.fieldName} cannot have value ${this.badValue}`);
+    }
+  }
+}
+
+export const postgresTestEntityConfiguration = new EntityConfiguration<
+  PostgresValidatorTestEntityFields
+>({
+  idField: 'id',
+  tableName: 'postgres_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    name: new StringField({
+      columnName: 'name',
+    }),
+  },
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+});
+
+const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
+  entityClass: PostgresValidatorTestEntity,
+  entityConfiguration: postgresTestEntityConfiguration,
+  privacyPolicyClass: PostgresValidatorTestEntityPrivacyPolicy,
+  mutationValidators: [new ThrowConditionallyTrigger('name', 'beforeCreateAndBeforeUpdate')],
+});

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -1,6 +1,9 @@
 import { IEntityClass } from './Entity';
 import EntityLoaderFactory from './EntityLoaderFactory';
-import { EntityMutationTriggerConfiguration } from './EntityMutationTrigger';
+import {
+  EntityMutationTriggerConfiguration,
+  EntityMutationValidatorConfiguration,
+} from './EntityMutationTrigger';
 import EntityMutatorFactory from './EntityMutatorFactory';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import IEntityQueryContextProvider from './IEntityQueryContextProvider';
@@ -58,6 +61,13 @@ export default class EntityCompanion<
     >,
     private readonly tableDataCoordinator: EntityTableDataCoordinator<TFields>,
     PrivacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>,
+    mutationValidators: EntityMutationValidatorConfiguration<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
     mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
       TID,
@@ -78,6 +88,7 @@ export default class EntityCompanion<
       tableDataCoordinator.entityConfiguration,
       entityClass,
       privacyPolicy,
+      mutationValidators,
       mutationTriggers,
       this.entityLoaderFactory,
       tableDataCoordinator.databaseAdapter,

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -1,9 +1,6 @@
 import { IEntityClass } from './Entity';
 import EntityLoaderFactory from './EntityLoaderFactory';
-import {
-  EntityMutationTriggerConfiguration,
-  EntityMutationValidatorConfiguration,
-} from './EntityMutationTrigger';
+import { EntityMutationTriggerConfiguration, EntityMutationTrigger } from './EntityMutationTrigger';
 import EntityMutatorFactory from './EntityMutatorFactory';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import IEntityQueryContextProvider from './IEntityQueryContextProvider';
@@ -61,13 +58,13 @@ export default class EntityCompanion<
     >,
     private readonly tableDataCoordinator: EntityTableDataCoordinator<TFields>,
     PrivacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>,
-    mutationValidators: EntityMutationValidatorConfiguration<
+    mutationValidators: EntityMutationTrigger<
       TFields,
       TID,
       TViewerContext,
       TEntity,
       TSelectedFields
-    >,
+    >[],
     mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
       TID,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -1,10 +1,7 @@
 import { IEntityClass } from './Entity';
 import EntityCompanion, { IPrivacyPolicyClass } from './EntityCompanion';
 import EntityConfiguration from './EntityConfiguration';
-import {
-  EntityMutationTriggerConfiguration,
-  EntityMutationValidatorConfiguration,
-} from './EntityMutationTrigger';
+import { EntityMutationTriggerConfiguration, EntityMutationTrigger } from './EntityMutationTrigger';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import IEntityCacheAdapterProvider from './IEntityCacheAdapterProvider';
 import IEntityDatabaseAdapterProvider from './IEntityDatabaseAdapterProvider';
@@ -84,13 +81,13 @@ export class EntityCompanionDefinition<
   >;
   readonly entityConfiguration: EntityConfiguration<TFields>;
   readonly privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
-  readonly mutationValidators: EntityMutationValidatorConfiguration<
+  readonly mutationValidators: EntityMutationTrigger<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
-  >;
+  >[];
   readonly mutationTriggers: EntityMutationTriggerConfiguration<
     TFields,
     TID,
@@ -104,7 +101,7 @@ export class EntityCompanionDefinition<
     entityClass,
     entityConfiguration,
     privacyPolicyClass,
-    mutationValidators = {},
+    mutationValidators = [],
     mutationTriggers = {},
     entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
   }: {
@@ -118,13 +115,13 @@ export class EntityCompanionDefinition<
     >;
     entityConfiguration: EntityConfiguration<TFields>;
     privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
-    mutationValidators?: EntityMutationValidatorConfiguration<
+    mutationValidators?: EntityMutationTrigger<
       TFields,
       TID,
       TViewerContext,
       TEntity,
       TSelectedFields
-    >;
+    >[];
     mutationTriggers?: EntityMutationTriggerConfiguration<
       TFields,
       TID,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -1,7 +1,10 @@
 import { IEntityClass } from './Entity';
 import EntityCompanion, { IPrivacyPolicyClass } from './EntityCompanion';
 import EntityConfiguration from './EntityConfiguration';
-import { EntityMutationTriggerConfiguration } from './EntityMutationTrigger';
+import {
+  EntityMutationTriggerConfiguration,
+  EntityMutationValidatorConfiguration,
+} from './EntityMutationTrigger';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import IEntityCacheAdapterProvider from './IEntityCacheAdapterProvider';
 import IEntityDatabaseAdapterProvider from './IEntityDatabaseAdapterProvider';
@@ -81,6 +84,13 @@ export class EntityCompanionDefinition<
   >;
   readonly entityConfiguration: EntityConfiguration<TFields>;
   readonly privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+  readonly mutationValidators: EntityMutationValidatorConfiguration<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >;
   readonly mutationTriggers: EntityMutationTriggerConfiguration<
     TFields,
     TID,
@@ -94,6 +104,7 @@ export class EntityCompanionDefinition<
     entityClass,
     entityConfiguration,
     privacyPolicyClass,
+    mutationValidators = {},
     mutationTriggers = {},
     entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
   }: {
@@ -107,6 +118,13 @@ export class EntityCompanionDefinition<
     >;
     entityConfiguration: EntityConfiguration<TFields>;
     privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+    mutationValidators?: EntityMutationValidatorConfiguration<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >;
     mutationTriggers?: EntityMutationTriggerConfiguration<
       TFields,
       TID,
@@ -119,6 +137,7 @@ export class EntityCompanionDefinition<
     this.entityClass = entityClass;
     this.entityConfiguration = entityConfiguration;
     this.privacyPolicyClass = privacyPolicyClass;
+    this.mutationValidators = mutationValidators;
     this.mutationTriggers = mutationTriggers;
     this.entitySelectedFields = entitySelectedFields;
   }
@@ -201,6 +220,7 @@ export default class EntityCompanionProvider {
         entityCompanionDefinition.entityClass,
         tableDataCoordinator,
         entityCompanionDefinition.privacyPolicyClass,
+        entityCompanionDefinition.mutationValidators,
         entityCompanionDefinition.mutationTriggers,
         this.metricsAdapter
       );

--- a/packages/entity/src/EntityMutationTrigger.ts
+++ b/packages/entity/src/EntityMutationTrigger.ts
@@ -2,19 +2,6 @@ import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 
-export interface EntityMutationValidatorConfiguration<
-  TFields,
-  TID,
-  TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
-> {
-  beforeCreate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
-  beforeUpdate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
-  beforeDelete?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
-  beforeAll?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
-}
-
 /**
  * Interface to define trigger behavior for entities.
  */

--- a/packages/entity/src/EntityMutationTrigger.ts
+++ b/packages/entity/src/EntityMutationTrigger.ts
@@ -2,6 +2,19 @@ import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 
+export interface EntityMutationValidatorConfiguration<
+  TFields,
+  TID,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> {
+  beforeCreate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeUpdate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeDelete?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeAll?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+}
+
 /**
  * Interface to define trigger behavior for entities.
  */

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -2,7 +2,7 @@ import Entity, { IEntityClass } from './Entity';
 import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
-import { EntityMutationTriggerConfiguration } from './EntityMutationTrigger';
+import { EntityMutationTriggerConfiguration, EntityMutationTrigger } from './EntityMutationTrigger';
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -37,13 +37,13 @@ export default class EntityMutatorFactory<
       TSelectedFields
     >,
     private readonly privacyPolicy: TPrivacyPolicy,
-    private readonly mutationValidators: EntityMutationTriggerConfiguration<
+    private readonly mutationValidators: EntityMutationTrigger<
       TFields,
       TID,
       TViewerContext,
       TEntity,
       TSelectedFields
-    >,
+    >[],
     private readonly mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
       TID,

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -37,6 +37,13 @@ export default class EntityMutatorFactory<
       TSelectedFields
     >,
     private readonly privacyPolicy: TPrivacyPolicy,
+    private readonly mutationValidators: EntityMutationTriggerConfiguration<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
     private readonly mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
       TID,
@@ -72,6 +79,7 @@ export default class EntityMutatorFactory<
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
+      this.mutationValidators,
       this.mutationTriggers,
       this.entityLoaderFactory,
       this.databaseAdapter,
@@ -95,6 +103,7 @@ export default class EntityMutatorFactory<
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
+      this.mutationValidators,
       this.mutationTriggers,
       this.entityLoaderFactory,
       this.databaseAdapter,
@@ -118,6 +127,7 @@ export default class EntityMutatorFactory<
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
+      this.mutationValidators,
       this.mutationTriggers,
       this.entityLoaderFactory,
       this.databaseAdapter,

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -19,7 +19,7 @@ describe(EntityCompanion, () => {
       TestEntity,
       instance(tableDataCoordinatorMock),
       TestEntityPrivacyPolicy,
-      {},
+      [],
       {},
       instance(mock<IEntityMetricsAdapter>())
     );

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -20,6 +20,7 @@ describe(EntityCompanion, () => {
       instance(tableDataCoordinatorMock),
       TestEntityPrivacyPolicy,
       {},
+      {},
       instance(mock<IEntityMetricsAdapter>())
     );
     expect(companion.getLoaderFactory()).toBeInstanceOf(EntityLoaderFactory);

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -185,18 +185,13 @@ const createEntityMutatorFactory = (
     keyof TestFields
   >;
 } => {
-  const mutatationValidators: EntityMutationTriggerConfiguration<
+  const mutatationValidators: EntityMutationTrigger<
     TestFields,
     string,
     ViewerContext,
     TestEntity,
     keyof TestFields
-  > = {
-    beforeCreate: [new TestMutationTrigger()],
-    beforeUpdate: [new TestMutationTrigger()],
-    beforeDelete: [new TestMutationTrigger()],
-    beforeAll: [new TestMutationTrigger()],
-  };
+  >[] = [];
   const mutationTriggers: EntityMutationTriggerConfiguration<
     TestFields,
     string,
@@ -669,7 +664,7 @@ describe(EntityMutatorFactory, () => {
       simpleTestEntityConfiguration,
       SimpleTestEntity,
       instance(privacyPolicyMock),
-      {},
+      [],
       {},
       entityLoaderFactory,
       databaseAdapter,
@@ -746,7 +741,7 @@ describe(EntityMutatorFactory, () => {
       simpleTestEntityConfiguration,
       SimpleTestEntity,
       privacyPolicy,
-      {},
+      [],
       {},
       entityLoaderFactory,
       instance(databaseAdapterMock),

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -185,6 +185,18 @@ const createEntityMutatorFactory = (
     keyof TestFields
   >;
 } => {
+  const mutatationValidators: EntityMutationTriggerConfiguration<
+    TestFields,
+    string,
+    ViewerContext,
+    TestEntity,
+    keyof TestFields
+  > = {
+    beforeCreate: [new TestMutationTrigger()],
+    beforeUpdate: [new TestMutationTrigger()],
+    beforeDelete: [new TestMutationTrigger()],
+    beforeAll: [new TestMutationTrigger()],
+  };
   const mutationTriggers: EntityMutationTriggerConfiguration<
     TestFields,
     string,
@@ -230,6 +242,7 @@ const createEntityMutatorFactory = (
     testEntityConfiguration,
     TestEntity,
     privacyPolicy,
+    mutatationValidators,
     mutationTriggers,
     entityLoaderFactory,
     databaseAdapter,
@@ -657,6 +670,7 @@ describe(EntityMutatorFactory, () => {
       SimpleTestEntity,
       instance(privacyPolicyMock),
       {},
+      {},
       entityLoaderFactory,
       databaseAdapter,
       metricsAdapter
@@ -732,6 +746,7 @@ describe(EntityMutatorFactory, () => {
       simpleTestEntityConfiguration,
       SimpleTestEntity,
       privacyPolicy,
+      {},
       {},
       entityLoaderFactory,
       instance(databaseAdapterMock),


### PR DESCRIPTION
# Why
Implements validation for entity mutations. Validators are specified by the user, and run before every create and update mutation. Validators are run before any triggers.

https://github.com/expo/entity/issues/25

# Tests

- [x] new unit tests pass (verifying validator call counts on different mutation operations)
- [x] new integration tests pass (verifying validators work as expected inside a txn)