### PR TITLE
fix: fix incorrect loader types for field selecitons

### DIFF
--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -38,7 +38,7 @@ export default class EnforcingEntityLoader<
    * Enforcing version of entity loader method by the same name.
    * @throws {@link EntityNotAuthorizedError} when viewer is not authorized to view one or more of the returned entities
    */
-  async loadManyByFieldEqualingManyAsync<N extends keyof TFields>(
+  async loadManyByFieldEqualingManyAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldName: N,
     fieldValues: readonly NonNullable<TFields[N]>[]
   ): Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly TEntity[]>> {
@@ -55,7 +55,7 @@ export default class EnforcingEntityLoader<
    * Enforcing version of entity loader method by the same name.
    * @throws {@link EntityNotAuthorizedError} when viewer is not authorized to view one or more of the returned entities
    */
-  async loadManyByFieldEqualingAsync<N extends keyof TFields>(
+  async loadManyByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldName: N,
     fieldValue: NonNullable<TFields[N]>
   ): Promise<readonly TEntity[]> {
@@ -71,7 +71,7 @@ export default class EnforcingEntityLoader<
    * @throws {@link EntityNotAuthorizedError} when viewer is not authorized to view the returned entity
    * @throws when multiple entities are found matching the condition
    */
-  async loadByFieldEqualingAsync<N extends keyof TFields>(
+  async loadByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     uniqueFieldName: N,
     fieldValue: NonNullable<TFields[N]>
   ): Promise<TEntity | null> {
@@ -114,7 +114,7 @@ export default class EnforcingEntityLoader<
    * Enforcing version of entity loader method by the same name.
    * @throws {@link EntityNotAuthorizedError} when viewer is not authorized to view one or more of the returned entities
    */
-  async loadManyByFieldEqualityConjunctionAsync<N extends keyof TFields>(
+  async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
     querySelectionModifiers: QuerySelectionModifiers<TFields> = {}
   ): Promise<readonly TEntity[]> {

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -99,7 +99,7 @@ export default class EntityAssociationLoader<
       TAssociatedPrivacyPolicy,
       TAssociatedSelectedFields
     >,
-    associatedEntityFieldContainingThisID: keyof TAssociatedFields,
+    associatedEntityFieldContainingThisID: keyof Pick<TAssociatedFields, TAssociatedSelectedFields>,
     queryContext: EntityQueryContext = this.entity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
@@ -153,7 +153,7 @@ export default class EntityAssociationLoader<
       TAssociatedPrivacyPolicy,
       TAssociatedSelectedFields
     >,
-    associatedEntityLookupByField: keyof TAssociatedFields,
+    associatedEntityLookupByField: keyof Pick<TAssociatedFields, TAssociatedSelectedFields>,
     queryContext: EntityQueryContext = this.entity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
@@ -207,7 +207,7 @@ export default class EntityAssociationLoader<
       TAssociatedPrivacyPolicy,
       TAssociatedSelectedFields
     >,
-    associatedEntityLookupByField: keyof TAssociatedFields,
+    associatedEntityLookupByField: keyof Pick<TAssociatedFields, TAssociatedSelectedFields>,
     queryContext: EntityQueryContext = this.entity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
@@ -491,5 +491,5 @@ export interface EntityLoadThroughDirective<
    * Field by which to load the instance of associatedEntityClass. If not provided, the
    * associatedEntityClass instance is fetched by its ID.
    */
-  associatedEntityLookupByField?: keyof TAssociatedFields;
+  associatedEntityLookupByField?: keyof Pick<TAssociatedFields, TAssociatedSelectedFields>;
 }

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -76,8 +76,15 @@ export default class EntityCompanion<
     metricsAdapter: IEntityMetricsAdapter
   ) {
     const privacyPolicy = new PrivacyPolicyClass();
-    this.entityLoaderFactory = new EntityLoaderFactory(
-      tableDataCoordinator.entityConfiguration.idField,
+    this.entityLoaderFactory = new EntityLoaderFactory<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >(
+      tableDataCoordinator.entityConfiguration.idField as keyof Pick<TFields, TSelectedFields>,
       entityClass,
       privacyPolicy,
       tableDataCoordinator.dataManager

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -33,7 +33,7 @@ export default class EntityLoader<
   constructor(
     private readonly viewerContext: TViewerContext,
     private readonly queryContext: EntityQueryContext,
-    private readonly idField: keyof TFields,
+    private readonly idField: keyof Pick<TFields, TSelectedFields>,
     private readonly entityClass: IEntityClass<
       TFields,
       TID,
@@ -69,7 +69,7 @@ export default class EntityLoader<
    * @returns map from fieldValue to entity results that match the query for that fieldValue,
    *          where result errors can be UnauthorizedError
    */
-  async loadManyByFieldEqualingManyAsync<N extends keyof TFields>(
+  async loadManyByFieldEqualingManyAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldName: N,
     fieldValues: readonly NonNullable<TFields[N]>[]
   ): Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly Result<TEntity>[]>> {
@@ -101,7 +101,7 @@ export default class EntityLoader<
    * @param fieldValue - fieldName field value being queried
    * @returns array of entity results that match the query for fieldValue, where result error can be UnauthorizedError
    */
-  async loadManyByFieldEqualingAsync<N extends keyof TFields>(
+  async loadManyByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldName: N,
     fieldValue: NonNullable<TFields[N]>
   ): Promise<readonly Result<TEntity>[]> {
@@ -121,7 +121,7 @@ export default class EntityLoader<
    * @returns entity result where uniqueFieldName equals fieldValue, or null if no entity matches the condition.
    * @throws when multiple entities match the condition
    */
-  async loadByFieldEqualingAsync<N extends keyof TFields>(
+  async loadByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     uniqueFieldName: N,
     fieldValue: NonNullable<TFields[N]>
   ): Promise<Result<TEntity> | null> {
@@ -189,7 +189,7 @@ export default class EntityLoader<
    * @param querySelectionModifiers - limit, offset, and orderBy for the query
    * @returns array of entity results that match the query, where result error can be UnauthorizedError
    */
-  async loadManyByFieldEqualityConjunctionAsync<N extends keyof TFields>(
+  async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
     querySelectionModifiers: QuerySelectionModifiers<TFields> = {}
   ): Promise<readonly Result<TEntity>[]> {

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -24,7 +24,7 @@ export default class EntityLoaderFactory<
   TSelectedFields extends keyof TFields
 > {
   constructor(
-    private readonly idField: keyof TFields,
+    private readonly idField: keyof Pick<TFields, TSelectedFields>,
     private readonly entityClass: IEntityClass<
       TFields,
       TID,


### PR DESCRIPTION
# Why

For entities with field selection, they should only be allowed to use the selected fields for loading. Closes #71.

# How

Update types, `yarn tsc`

# Test Plan

`yarn tsc`
