### PR TITLE
fix!: constuctor thrown exceptions for loadMany

### DIFF
--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -283,7 +283,11 @@ describe(EnforcingEntityLoader, () => {
     const loaderProperties = Object.getOwnPropertyNames(EntityLoader.prototype);
 
     // ensure known differences still exist for sanity check
-    const knownLoaderOnlyDifferences = ['enforcing', 'invalidateFieldsAsync'];
+    const knownLoaderOnlyDifferences = [
+      'enforcing',
+      'invalidateFieldsAsync',
+      'tryConstructEntities',
+    ];
     expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));
 
     const loaderPropertiesWithoutKnownDifferences = loaderProperties.filter(

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -53,6 +53,23 @@ describe('Two entities backed by the same table', () => {
     expect(failedManyResults[0].enforceError().message).toEqual(
       'OneTestEntity must be instantiated with one data'
     );
+
+    const fieldEqualityConjunctionResults = await OneTestEntity.loader(
+      viewerContext
+    ).loadManyByFieldEqualityConjunctionAsync([
+      {
+        fieldName: 'common_other_field',
+        fieldValue: 'wat',
+      },
+    ]);
+    const successfulfieldEqualityConjunctionResultsResults = successfulResults(
+      fieldEqualityConjunctionResults
+    );
+    const failedfieldEqualityConjunctionResultsResults = failedResults(
+      fieldEqualityConjunctionResults
+    );
+    expect(successfulfieldEqualityConjunctionResultsResults).toHaveLength(1);
+    expect(failedfieldEqualityConjunctionResultsResults).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
# Why

Closes #61.

The issue is that when this was called via a loadMany* method, the first instance of failure would cause the full call to fail. The better behavior is to wrap the constructor in a result-producing try/catch and propagate the result to the caller (except in the enforcing case obviously).

Note that this is a breaking change because it changes the behavior of non-enforcing loadMany* calls.

# How

1. surround constructor call with try/catch
1. return failed results now instead of throwing

# Test Plan

Run new test code.
