### PR TITLE
fix: correct type of runInTransactionAsync

### DIFF
--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -5,7 +5,7 @@ import EntityAssociationLoader from './EntityAssociationLoader';
 import { EntityCompanionDefinition } from './EntityCompanionProvider';
 import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
-import { EntityQueryContext } from './EntityQueryContext';
+import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
 import { pick } from './entityUtils';
 
@@ -183,7 +183,7 @@ export default abstract class ReadonlyEntity<
       TMSelectedFields
     >,
     viewerContext: TMViewerContext2,
-    transactionScope: (queryContext: EntityQueryContext) => Promise<TResult>
+    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>
   ): Promise<TResult> {
     return await viewerContext
       .getViewerScopedEntityCompanionForClass(this)


### PR DESCRIPTION
# Why

Not sure why this wasn't an issue before but when upgraded to 0.7.0 this incorrect typing started showing up.

# How

Fix the typing to be more specific so that methods within transaction blocks that typehint to require a transaction (only take an `EntityTransactionalQueryContext` instead of the superclass `EntityQueryContext`) don't fail to compile.

# Test Plan

`yarn tsc`
