### PR TITLE
fix!: add entity name to loader counter metric events

### DIFF
--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -57,12 +57,18 @@ export default class EntityDataManager<TFields> {
     fieldName: N,
     fieldValues: readonly NonNullable<TFields[N]>[]
   ): Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly Readonly<TFields>[]>> {
-    this.metricsAdapter.incrementDataManagerCacheLoadCount(fieldValues.length);
+    this.metricsAdapter.incrementDataManagerCacheLoadCount({
+      fieldValueCount: fieldValues.length,
+      entityClassName: this.entityClassName,
+    });
     return await this.entityCache.readManyThroughAsync(
       fieldName,
       fieldValues,
       async (fetcherValues) => {
-        this.metricsAdapter.incrementDataManagerDatabaseLoadCount(fieldValues.length);
+        this.metricsAdapter.incrementDataManagerDatabaseLoadCount({
+          fieldValueCount: fieldValues.length,
+          entityClassName: this.entityClassName,
+        });
         return await this.databaseAdapter.fetchManyWhereAsync(
           this.queryContextProvider.getQueryContext(),
           fieldName,
@@ -102,7 +108,10 @@ export default class EntityDataManager<TFields> {
       return await this.databaseAdapter.fetchManyWhereAsync(queryContext, fieldName, fieldValues);
     }
 
-    this.metricsAdapter.incrementDataManagerDataloaderLoadCount(fieldValues.length);
+    this.metricsAdapter.incrementDataManagerDataloaderLoadCount({
+      fieldValueCount: fieldValues.length,
+      entityClassName: this.entityClassName,
+    });
     const dataLoader = this.getFieldDataLoaderForFieldName(fieldName);
     const results = await dataLoader.loadMany(fieldValues);
     const [values, errors] = partitionErrors(results);

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -9,6 +9,7 @@ import {
   spy,
   anyString,
   resetCalls,
+  deepEqual,
 } from 'ts-mockito';
 
 import EntityDatabaseAdapter from '../../EntityDatabaseAdapter';
@@ -514,9 +515,30 @@ describe(EntityDataManager, () => {
       )
     ).once();
 
-    verify(metricsAdapterMock.incrementDataManagerDataloaderLoadCount(1)).once();
-    verify(metricsAdapterMock.incrementDataManagerCacheLoadCount(1)).once();
-    verify(metricsAdapterMock.incrementDataManagerDatabaseLoadCount(1)).once();
+    verify(
+      metricsAdapterMock.incrementDataManagerDataloaderLoadCount(
+        deepEqual({
+          fieldValueCount: 1,
+          entityClassName: TestEntity.name,
+        })
+      )
+    ).once();
+    verify(
+      metricsAdapterMock.incrementDataManagerCacheLoadCount(
+        deepEqual({
+          fieldValueCount: 1,
+          entityClassName: TestEntity.name,
+        })
+      )
+    ).once();
+    verify(
+      metricsAdapterMock.incrementDataManagerDatabaseLoadCount(
+        deepEqual({
+          fieldValueCount: 1,
+          entityClassName: TestEntity.name,
+        })
+      )
+    ).once();
 
     resetCalls(metricsAdapterMock);
 

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -23,6 +23,11 @@ export interface EntityMetricsMutationEvent {
   duration: number;
 }
 
+export interface IncrementLoadCountEvent {
+  fieldValueCount: number;
+  entityClassName: string;
+}
+
 /**
  * An interface for gathering metrics about the Entity framework. Information about
  * entity load and mutation operations is piped to an instance of this adapter.
@@ -45,7 +50,7 @@ export default interface IEntityMetricsAdapter {
    * load methods (not equality conjunction or raw).
    * @param fieldValueCount - count of field values being loaded for a field
    */
-  incrementDataManagerDataloaderLoadCount(fieldValueCount: number): void;
+  incrementDataManagerDataloaderLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
 
   /**
    * Called when a cache load is initiated via the standard
@@ -53,7 +58,7 @@ export default interface IEntityMetricsAdapter {
    * miss.
    * @param fieldValueCount - count of field values being loaded for a field
    */
-  incrementDataManagerCacheLoadCount(fieldValueCount: number): void;
+  incrementDataManagerCacheLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
 
   /**
    * Called when a database load is initiated via the standard
@@ -61,5 +66,5 @@ export default interface IEntityMetricsAdapter {
    * miss or when fetching an uncacheable field.
    * @param fieldValueCount - count of field values being loaded for a field
    */
-  incrementDataManagerDatabaseLoadCount(fieldValueCount: number): void;
+  incrementDataManagerDatabaseLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
 }

--- a/packages/entity/src/metrics/NoOpEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/NoOpEntityMetricsAdapter.ts
@@ -1,12 +1,15 @@
 import IEntityMetricsAdapter, {
   EntityMetricsLoadEvent,
   EntityMetricsMutationEvent,
+  IncrementLoadCountEvent,
 } from './IEntityMetricsAdapter';
 
 export default class NoOpEntityMetricsAdapter implements IEntityMetricsAdapter {
   logDataManagerLoadEvent(_loadEvent: EntityMetricsLoadEvent): void {}
   logMutatorMutationEvent(_mutationEvent: EntityMetricsMutationEvent): void {}
-  incrementDataManagerDataloaderLoadCount(_fieldValueCount: number): void {}
-  incrementDataManagerCacheLoadCount(_fieldValueCount: number): void {}
-  incrementDataManagerDatabaseLoadCount(_fieldValueCount: number): void {}
+  incrementDataManagerDataloaderLoadCount(
+    _incrementLoadCountEvent: IncrementLoadCountEvent
+  ): void {}
+  incrementDataManagerCacheLoadCount(_incrementLoadCountEvent: IncrementLoadCountEvent): void {}
+  incrementDataManagerDatabaseLoadCount(_incrementLoadCountEvent: IncrementLoadCountEvent): void {}
 }


### PR DESCRIPTION
# Why

https://github.com/expo/entity/pull/83 added this to the other events, but they're useful in the counter metric events as well. This is technically a breaking change since it requires small changes to upgrade.

# How

Add to interface.

# Test Plan

`yarn tsc`
`yarn test`
