### PR TITLE
fix: edge deletion behavior cyclic import structure

### DIFF
--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -1,108 +1,12 @@
-import {
-  EntityPrivacyPolicy,
-  ViewerContext,
-  AlwaysAllowPrivacyPolicyRule,
-  Entity,
-  EntityCompanionDefinition,
-  EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  UUIDField,
-  EntityEdgeDeletionBehavior,
-} from '@expo/entity';
+import { ViewerContext } from '@expo/entity';
 import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
 import Redis from 'ioredis';
 import Knex from 'knex';
 import { URL } from 'url';
 
 import { createFullIntegrationTestEntityCompanionProvider } from '../testfixtures/createFullIntegrationTestEntityCompanionProvider';
-
-interface ParentFields {
-  id: string;
-}
-
-interface ChildFields {
-  id: string;
-  parent_id: string;
-}
-
-class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
-}
-
-class ParentEntity extends Entity<ParentFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
-    ParentFields,
-    string,
-    ViewerContext,
-    ParentEntity,
-    TestEntityPrivacyPolicy
-  > {
-    return parentEntityCompanion;
-  }
-}
-
-class ChildEntity extends Entity<ChildFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
-    ChildFields,
-    string,
-    ViewerContext,
-    ChildEntity,
-    TestEntityPrivacyPolicy
-  > {
-    return childEntityCompanion;
-  }
-}
-
-const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
-  idField: 'id',
-  tableName: 'parents',
-  inboundEdges: [ChildEntity],
-  schema: {
-    id: new UUIDField({
-      columnName: 'id',
-      cache: true,
-    }),
-  },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
-});
-
-const childEntityConfiguration = new EntityConfiguration<ChildFields>({
-  idField: 'id',
-  tableName: 'children',
-  schema: {
-    id: new UUIDField({
-      columnName: 'id',
-      cache: true,
-    }),
-    parent_id: new UUIDField({
-      columnName: 'parent_id',
-      cache: true,
-      association: {
-        associatedEntityClass: ParentEntity,
-        edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
-      },
-    }),
-  },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
-});
-
-const parentEntityCompanion = new EntityCompanionDefinition({
-  entityClass: ParentEntity,
-  entityConfiguration: parentEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-});
-
-const childEntityCompanion = new EntityCompanionDefinition({
-  entityClass: ChildEntity,
-  entityConfiguration: childEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-});
+import ChildEntity from './entities/ChildEntity';
+import ParentEntity from './entities/ParentEntity';
 
 async function createOrTruncatePostgresTables(knex: Knex): Promise<void> {
   await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'); // for uuid_generate_v4()

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -67,7 +67,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
   const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
     idField: 'id',
     tableName: categoriesTableName,
-    inboundEdges: [OtherEntity],
+    inboundEdges: () => [OtherEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -95,7 +95,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
   const otherEntityConfiguration = new EntityConfiguration<OtherFields>({
     idField: 'id',
     tableName: othersTableName,
-    inboundEdges: [CategoryEntity],
+    inboundEdges: () => [CategoryEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -1,0 +1,65 @@
+import {
+  AlwaysAllowPrivacyPolicyRule,
+  CacheAdapterFlavor,
+  DatabaseAdapterFlavor,
+  Entity,
+  EntityCompanionDefinition,
+  EntityConfiguration,
+  EntityEdgeDeletionBehavior,
+  EntityPrivacyPolicy,
+  UUIDField,
+  ViewerContext,
+} from '@expo/entity';
+
+import ParentEntity from './ParentEntity';
+
+interface ChildFields {
+  id: string;
+  parent_id: string;
+}
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+export default class ChildEntity extends Entity<ChildFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    ChildFields,
+    string,
+    ViewerContext,
+    ChildEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return childEntityCompanion;
+  }
+}
+
+const childEntityConfiguration = new EntityConfiguration<ChildFields>({
+  idField: 'id',
+  tableName: 'children',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    parent_id: new UUIDField({
+      columnName: 'parent_id',
+      cache: true,
+      association: {
+        associatedEntityClass: ParentEntity,
+        edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
+      },
+    }),
+  },
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+});
+
+const childEntityCompanion = new EntityCompanionDefinition({
+  entityClass: ChildEntity,
+  entityConfiguration: childEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+});

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -38,7 +38,7 @@ export default class ParentEntity extends Entity<ParentFields, string, ViewerCon
 const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
   idField: 'id',
   tableName: 'parents',
-  inboundEdges: [ChildEntity],
+  inboundEdges: () => [ChildEntity],
   schema: {
     id: new UUIDField({
       columnName: 'id',

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -1,0 +1,56 @@
+import {
+  AlwaysAllowPrivacyPolicyRule,
+  CacheAdapterFlavor,
+  DatabaseAdapterFlavor,
+  Entity,
+  EntityCompanionDefinition,
+  EntityConfiguration,
+  EntityPrivacyPolicy,
+  UUIDField,
+  ViewerContext,
+} from '@expo/entity';
+
+import ChildEntity from './ChildEntity';
+
+interface ParentFields {
+  id: string;
+}
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+}
+
+export default class ParentEntity extends Entity<ParentFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    ParentFields,
+    string,
+    ViewerContext,
+    ParentEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return parentEntityCompanion;
+  }
+}
+
+const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
+  idField: 'id',
+  tableName: 'parents',
+  inboundEdges: [ChildEntity],
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+  },
+  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
+  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+});
+
+const parentEntityCompanion = new EntityCompanionDefinition({
+  entityClass: ParentEntity,
+  entityConfiguration: parentEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+});

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -13,7 +13,7 @@ export default class EntityConfiguration<TFields> {
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly cacheKeyVersion: number;
 
-  readonly inboundEdges: IEntityClass<any, any, any, any, any, any>[];
+  readonly inboundEdges: () => IEntityClass<any, any, any, any, any, any>[];
   readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>;
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
@@ -25,7 +25,7 @@ export default class EntityConfiguration<TFields> {
     idField,
     tableName,
     schema,
-    inboundEdges = [],
+    inboundEdges = () => [],
     cacheKeyVersion = 0,
     databaseAdapterFlavor,
     cacheAdapterFlavor,
@@ -33,7 +33,7 @@ export default class EntityConfiguration<TFields> {
     idField: keyof TFields;
     tableName: string;
     schema: Record<keyof TFields, EntityFieldDefinition>;
-    inboundEdges?: IEntityClass<any, any, any, any, any, any>[];
+    inboundEdges?: () => IEntityClass<any, any, any, any, any, any>[];
     cacheKeyVersion?: number;
     databaseAdapterFlavor: DatabaseAdapterFlavor;
     cacheAdapterFlavor: CacheAdapterFlavor;

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -629,7 +629,7 @@ export class DeleteMutator<
       TMSelectedFields
     >;
     const entityConfiguration = companionDefinition.entityConfiguration;
-    const inboundEdges = entityConfiguration.inboundEdges;
+    const inboundEdges = entityConfiguration.inboundEdges();
     await Promise.all(
       inboundEdges.map(async (entityClass) => {
         return await mapMapAsync(

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -81,7 +81,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
   const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
     idField: 'id',
     tableName: 'parents',
-    inboundEdges: [ChildEntity],
+    inboundEdges: () => [ChildEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -95,7 +95,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
   const childEntityConfiguration = new EntityConfiguration<ChildFields>({
     idField: 'id',
     tableName: 'children',
-    inboundEdges: [GrandChildEntity],
+    inboundEdges: () => [GrandChildEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -48,7 +48,7 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
   const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
     idField: 'id',
     tableName: 'categories',
-    inboundEdges: [CategoryEntity],
+    inboundEdges: () => [CategoryEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',


### PR DESCRIPTION
# Why

The way this was created led to import cycles in top level module exports, causing them to resolve as undefined. (as described in https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de)

# How

Make one end of the reference cycle a function to prevent necessary resolution at module import time.

# Test Plan

1. Move integration test entities to different files in the first commit. Run `yarn integration`, ensure they fail with the following:

```
TypeError: Cannot read property 'getCompanionDefinition' of undefined

      634 |       inboundEdges.map(async (entityClass) => {
      635 |         return await mapMapAsync(
    > 636 |           entityClass.getCompanionDefinition().entityConfiguration.schema,
          |                       ^
      637 |           async (fieldDefinition, fieldName) => {
      638 |             const association = fieldDefinition.association;
      639 |             if (!association) {

      at ../entity/src/EntityMutator.ts:636:23
          at Array.map (<anonymous>)
      at Function.processEntityDeletionForInboundEdgesAsync (../entity/src/EntityMutator.ts:634:20)
      at DeleteMutator.deleteInternalAsync (../entity/src/EntityMutator.ts:540:25)
      at ../entity/src/EntityQueryContextProvider.ts:40:22
```
1. Apply fix described above. Re-run `yarn integration` and ensure the tests now pass.