### PR TITLE
feat: add ability to invalidate an entity manually

### DIFF
--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -285,9 +285,18 @@ export default class EntityLoader<
   }
 
   /**
+   * Invalidate all caches for an entity. One potential use case would be to keep the entity
+   * framework in sync with changes made to data outside of the framework.
+   * @param entity - entity to be invalidated
+   */
+  async invalidateEntityAsync(entity: TEntity): Promise<void> {
+    await this.invalidateFieldsAsync(entity.getAllDatabaseFields());
+  }
+
+  /**
    * Wrap entity construction in try/catch and return Results. Used to prevent constructor errors
    * thrown for one entity instantiation from interfering with other entity instantiatons of the same query.
-   * @param fieldsObject - array of entity data objects to construct entities
+   * @param fieldsObjects - array of entity data objects to construct entities
    */
   private tryConstructEntities(fieldsObjects: readonly TFields[]): readonly Result<TEntity>[] {
     return fieldsObjects.map((fieldsObject) => {

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -286,6 +286,7 @@ describe(EnforcingEntityLoader, () => {
     const knownLoaderOnlyDifferences = [
       'enforcing',
       'invalidateFieldsAsync',
+      'invalidateEntityAsync',
       'tryConstructEntities',
     ];
     expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -260,6 +260,31 @@ describe(EntityLoader, () => {
     ).once();
   });
 
+  it('invalidates upon invalidate by entity', async () => {
+    const viewerContext = instance(mock(ViewerContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
+    const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
+    const dataManagerMock = mock(EntityDataManager);
+    const dataManagerInstance = instance(dataManagerMock);
+
+    const entityMock = mock(TestEntity);
+    when(entityMock.getAllDatabaseFields()).thenReturn({ customIdField: 'hello' } as any);
+    const entityInstance = instance(entityMock);
+
+    const entityLoader = new EntityLoader(
+      viewerContext,
+      queryContext,
+      testEntityConfiguration.idField,
+      TestEntity,
+      privacyPolicy,
+      dataManagerInstance
+    );
+    await entityLoader.invalidateEntityAsync(entityInstance);
+    verify(
+      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' }))
+    ).once();
+  });
+
   it('returns error result when not allowed', async () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();


### PR DESCRIPTION
# Why

Closes https://github.com/expo/entity/issues/90.

This may be useful when a raw SQL update is run outside the entity framework, in cases like migrations or even in application code.

# How

Add method and test.

# Test Plan

Run test.
