### PR TITLE
fix: edge deletion behavior cyclic import structure again

### DIFF
--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -77,7 +77,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         columnName: 'parent_other_id',
         cache: true,
         association: {
-          associatedEntityClass: OtherEntity,
+          associatedEntityClass: () => OtherEntity,
           edgeDeletionBehavior,
         },
       }),
@@ -105,7 +105,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         columnName: 'parent_category_id',
         cache: true,
         association: {
-          associatedEntityClass: CategoryEntity,
+          associatedEntityClass: () => CategoryEntity,
           edgeDeletionBehavior,
         },
       }),

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -67,7 +67,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
   const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
     idField: 'id',
     tableName: categoriesTableName,
-    inboundEdges: () => [OtherEntity],
+    getInboundEdges: () => [OtherEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -77,7 +77,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         columnName: 'parent_other_id',
         cache: true,
         association: {
-          associatedEntityClass: () => OtherEntity,
+          getAssociatedEntityClass: () => OtherEntity,
           edgeDeletionBehavior,
         },
       }),
@@ -95,7 +95,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
   const otherEntityConfiguration = new EntityConfiguration<OtherFields>({
     idField: 'id',
     tableName: othersTableName,
-    inboundEdges: () => [CategoryEntity],
+    getInboundEdges: () => [CategoryEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -105,7 +105,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         columnName: 'parent_category_id',
         cache: true,
         association: {
-          associatedEntityClass: () => CategoryEntity,
+          getAssociatedEntityClass: () => CategoryEntity,
           edgeDeletionBehavior,
         },
       }),

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -49,7 +49,7 @@ const childEntityConfiguration = new EntityConfiguration<ChildFields>({
       columnName: 'parent_id',
       cache: true,
       association: {
-        associatedEntityClass: ParentEntity,
+        associatedEntityClass: () => ParentEntity,
         edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
       },
     }),

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -49,7 +49,7 @@ const childEntityConfiguration = new EntityConfiguration<ChildFields>({
       columnName: 'parent_id',
       cache: true,
       association: {
-        associatedEntityClass: () => ParentEntity,
+        getAssociatedEntityClass: () => ParentEntity,
         edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
       },
     }),

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -38,7 +38,7 @@ export default class ParentEntity extends Entity<ParentFields, string, ViewerCon
 const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
   idField: 'id',
   tableName: 'parents',
-  inboundEdges: () => [ChildEntity],
+  getInboundEdges: () => [ChildEntity],
   schema: {
     id: new UUIDField({
       columnName: 'id',

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -13,7 +13,7 @@ export default class EntityConfiguration<TFields> {
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly cacheKeyVersion: number;
 
-  readonly inboundEdges: () => IEntityClass<any, any, any, any, any, any>[];
+  readonly getInboundEdges: () => IEntityClass<any, any, any, any, any, any>[];
   readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition>;
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
@@ -25,7 +25,7 @@ export default class EntityConfiguration<TFields> {
     idField,
     tableName,
     schema,
-    inboundEdges = () => [],
+    getInboundEdges = () => [],
     cacheKeyVersion = 0,
     databaseAdapterFlavor,
     cacheAdapterFlavor,
@@ -33,7 +33,7 @@ export default class EntityConfiguration<TFields> {
     idField: keyof TFields;
     tableName: string;
     schema: Record<keyof TFields, EntityFieldDefinition>;
-    inboundEdges?: () => IEntityClass<any, any, any, any, any, any>[];
+    getInboundEdges?: () => IEntityClass<any, any, any, any, any, any>[];
     cacheKeyVersion?: number;
     databaseAdapterFlavor: DatabaseAdapterFlavor;
     cacheAdapterFlavor: CacheAdapterFlavor;
@@ -44,7 +44,7 @@ export default class EntityConfiguration<TFields> {
     this.databaseAdapterFlavor = databaseAdapterFlavor;
     this.cacheAdapterFlavor = cacheAdapterFlavor;
 
-    this.inboundEdges = inboundEdges;
+    this.getInboundEdges = getInboundEdges;
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -50,7 +50,7 @@ export interface EntityAssociationDefinition<
   /**
    * Class of entity on the other end of this edge.
    */
-  associatedEntityClass: () => IEntityClass<
+  getAssociatedEntityClass: () => IEntityClass<
     TAssociatedFields,
     TAssociatedID,
     TViewerContext,

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -50,7 +50,7 @@ export interface EntityAssociationDefinition<
   /**
    * Class of entity on the other end of this edge.
    */
-  associatedEntityClass: IEntityClass<
+  associatedEntityClass: () => IEntityClass<
     TAssociatedFields,
     TAssociatedID,
     TViewerContext,

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -629,7 +629,7 @@ export class DeleteMutator<
       TMSelectedFields
     >;
     const entityConfiguration = companionDefinition.entityConfiguration;
-    const inboundEdges = entityConfiguration.inboundEdges();
+    const inboundEdges = entityConfiguration.getInboundEdges();
     await Promise.all(
       inboundEdges.map(async (entityClass) => {
         return await mapMapAsync(
@@ -641,7 +641,7 @@ export class DeleteMutator<
             }
 
             const associatedConfiguration = association
-              .associatedEntityClass()
+              .getAssociatedEntityClass()
               .getCompanionDefinition().entityConfiguration;
             if (associatedConfiguration !== entityConfiguration) {
               return;

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -640,8 +640,9 @@ export class DeleteMutator<
               return;
             }
 
-            const associatedConfiguration = association.associatedEntityClass.getCompanionDefinition()
-              .entityConfiguration;
+            const associatedConfiguration = association
+              .associatedEntityClass()
+              .getCompanionDefinition().entityConfiguration;
             if (associatedConfiguration !== entityConfiguration) {
               return;
             }

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -105,7 +105,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         columnName: 'parent_id',
         cache: true,
         association: {
-          associatedEntityClass: ParentEntity,
+          associatedEntityClass: () => ParentEntity,
           edgeDeletionBehavior,
         },
       }),
@@ -126,7 +126,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         columnName: 'parent_id',
         cache: true,
         association: {
-          associatedEntityClass: ChildEntity,
+          associatedEntityClass: () => ChildEntity,
           edgeDeletionBehavior,
         },
       }),

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -81,7 +81,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
   const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
     idField: 'id',
     tableName: 'parents',
-    inboundEdges: () => [ChildEntity],
+    getInboundEdges: () => [ChildEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -95,7 +95,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
   const childEntityConfiguration = new EntityConfiguration<ChildFields>({
     idField: 'id',
     tableName: 'children',
-    inboundEdges: () => [GrandChildEntity],
+    getInboundEdges: () => [GrandChildEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -105,7 +105,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         columnName: 'parent_id',
         cache: true,
         association: {
-          associatedEntityClass: () => ParentEntity,
+          getAssociatedEntityClass: () => ParentEntity,
           edgeDeletionBehavior,
         },
       }),
@@ -126,7 +126,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         columnName: 'parent_id',
         cache: true,
         association: {
-          associatedEntityClass: () => ChildEntity,
+          getAssociatedEntityClass: () => ChildEntity,
           edgeDeletionBehavior,
         },
       }),

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -48,7 +48,7 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
   const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
     idField: 'id',
     tableName: 'categories',
-    inboundEdges: () => [CategoryEntity],
+    getInboundEdges: () => [CategoryEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -58,7 +58,7 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
         columnName: 'parent_category_id',
         cache: true,
         association: {
-          associatedEntityClass: () => CategoryEntity,
+          getAssociatedEntityClass: () => CategoryEntity,
           edgeDeletionBehavior,
         },
       }),

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -58,7 +58,7 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
         columnName: 'parent_category_id',
         cache: true,
         association: {
-          associatedEntityClass: CategoryEntity,
+          associatedEntityClass: () => CategoryEntity,
           edgeDeletionBehavior,
         },
       }),


### PR DESCRIPTION
# Why

Apparently https://github.com/expo/entity/pull/89 wasn't sufficient for all cases. With the way entities are encouraged to be written, it seems that even with one side of this cycle being defined as a function isn't sufficient to squash all import cycles. I think this is a fairly unique case though as it is literally defining a cycle so I still don't think that having the whole companion or configuration be a function is necessary (don't foresee any other future features needing to specify other entities in configurations).

# How

Make the other direction edge specification a function as well.

# Test Plan

This one is harder to repro using a simple test case. To test this, I `yarn link`'ed the `entity` package into Expo code where we're seeing the behavior and ensured it fixed it.