### PR TITLE
feat: transaction-scoped dataloaders

### DIFF
--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -284,6 +284,13 @@ export default class EntityLoader<
     await this.dataManager.invalidateObjectFieldsAsync(objectFields);
   }
 
+  async invalidateFieldsTransactionalAsync(objectFields: Readonly<TFields>): Promise<void> {
+    await this.dataManager.invalidateObjectFieldsTransactionalAsync(
+      this.queryContext,
+      objectFields
+    );
+  }
+
   /**
    * Invalidate all caches for an entity. One potential use case would be to keep the entity
    * framework in sync with changes made to data outside of the framework.

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -205,6 +205,7 @@ export class CreateMutator<
     queryContext.appendPostCommitCallback(
       entityLoader.invalidateFieldsAsync.bind(entityLoader, insertResult)
     );
+    await entityLoader.invalidateFieldsTransactionalAsync(insertResult);
 
     const unauthorizedEntityAfterInsert = new this.entityClass(this.viewerContext, insertResult);
     const newEntity = await entityLoader
@@ -395,6 +396,11 @@ export class UpdateMutator<
       entityLoader.invalidateFieldsAsync.bind(entityLoader, this.fieldsForEntity)
     );
 
+    await Promise.all([
+      entityLoader.invalidateFieldsTransactionalAsync(this.originalFieldsForEntity),
+      entityLoader.invalidateFieldsTransactionalAsync(this.fieldsForEntity),
+    ]);
+
     const unauthorizedEntityAfterUpdate = new this.entityClass(this.viewerContext, updateResult);
     const updatedEntity = await entityLoader
       .enforcing()
@@ -566,6 +572,7 @@ export class DeleteMutator<
     queryContext.appendPostCommitCallback(
       entityLoader.invalidateFieldsAsync.bind(entityLoader, this.entity.getAllDatabaseFields())
     );
+    await entityLoader.invalidateFieldsTransactionalAsync(this.entity.getAllDatabaseFields());
 
     await this.executeMutationTriggersOrValidatorsAsync(
       this.mutationTriggers.afterDelete,

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import EntityQueryContextProvider from './EntityQueryContextProvider';
 
 export type PostCommitCallback = (...args: any) => Promise<any>;
@@ -12,7 +14,7 @@ export type PostCommitCallback = (...args: any) => Promise<any>;
 export abstract class EntityQueryContext {
   constructor(private readonly queryInterface: any) {}
 
-  abstract isInTransaction(): boolean;
+  abstract isInTransaction(): this is EntityTransactionalQueryContext;
 
   getQueryInterface(): any {
     return this.queryInterface;
@@ -31,7 +33,7 @@ export class EntityNonTransactionalQueryContext extends EntityQueryContext {
     super(queryInterface);
   }
 
-  isInTransaction(): boolean {
+  isInTransaction(): this is EntityTransactionalQueryContext {
     return false;
   }
 
@@ -43,6 +45,8 @@ export class EntityNonTransactionalQueryContext extends EntityQueryContext {
 }
 
 export class EntityTransactionalQueryContext extends EntityQueryContext {
+  public readonly transactionID = uuidv4();
+
   private readonly postCommitCallbacks: PostCommitCallback[] = [];
 
   public appendPostCommitCallback(callback: PostCommitCallback): void {
@@ -55,7 +59,7 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
     await Promise.all(callbacks.map((callback) => callback()));
   }
 
-  isInTransaction(): boolean {
+  isInTransaction(): this is EntityTransactionalQueryContext {
     return true;
   }
 

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -287,6 +287,7 @@ describe(EnforcingEntityLoader, () => {
       'enforcing',
       'invalidateFieldsAsync',
       'invalidateEntityAsync',
+      'invalidateFieldsTransactionalAsync',
       'tryConstructEntities',
     ];
     expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));


### PR DESCRIPTION
# Why

An interesting idea from @ide: within a transaction, subsequent reads should be able to be cached locally as long as the local cache is kept consistent (not in the cache adapter though).

# How

Keep a separate dataloader per-transaction that is invalidated synchronously.

# Test Plan

Not tested yet.
