### PR TITLE
fix: remove any cast from EntityLoader

### DIFF
--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -23,8 +23,9 @@ import { ExampleViewerContext } from '../viewerContexts';
  */
 export default class AllowIfUserOwnerPrivacyRule<
   TFields,
-  TID,
-  TEntity extends ReadonlyEntity<TFields, TID, ExampleViewerContext>
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TEntity extends ReadonlyEntity<TFields, TID, ExampleViewerContext>,
+  TSelectedFields extends keyof TFields = keyof TFields
 > extends PrivacyPolicyRule<TFields, TID, ExampleViewerContext, TEntity> {
   constructor(private readonly entityOwnerField: keyof TFields) {
     super();

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -28,10 +28,18 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   ViewerContext,
   TestEntity
 > {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
 }
 
 class TestEntity extends Entity<TestFields, string, ViewerContext> {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -29,10 +29,18 @@ interface OtherFields {
 }
 
 class PrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any> {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+  ];
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -19,10 +19,18 @@ interface ChildFields {
 }
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
 }
 
 export default class ChildEntity extends Entity<ChildFields, string, ViewerContext> {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -17,10 +17,18 @@ interface ParentFields {
 }
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
 }
 
 export default class ParentEntity extends Entity<ParentFields, string, ViewerContext> {

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -11,7 +11,7 @@ import { mapMap } from './utils/collections/maps';
  */
 export default class EnforcingEntityLoader<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -27,7 +27,7 @@ import ViewerContext from './ViewerContext';
  */
 export default abstract class Entity<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields
 > extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields> {
@@ -39,7 +39,7 @@ export default abstract class Entity<
    */
   static creator<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -80,7 +80,7 @@ export default abstract class Entity<
    */
   static updater<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
@@ -121,7 +121,7 @@ export default abstract class Entity<
    */
   static deleteAsync<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
@@ -163,7 +163,7 @@ export default abstract class Entity<
    */
   static enforceDeleteAsync<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
@@ -216,7 +216,7 @@ export default abstract class Entity<
    */
   static async canViewerUpdateAsync<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
@@ -265,7 +265,7 @@ export default abstract class Entity<
    */
   static async canViewerDeleteAsync<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
@@ -309,7 +309,7 @@ export default abstract class Entity<
  */
 export interface IEntityClass<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -8,7 +8,7 @@ import ViewerContext from './ViewerContext';
 
 export default class EntityAssociationLoader<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields
@@ -25,7 +25,7 @@ export default class EntityAssociationLoader<
   async loadAssociatedEntityAsync<
     TIdentifyingField extends keyof Pick<TFields, TSelectedFields>,
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
       TAssociatedID,
@@ -87,7 +87,7 @@ export default class EntityAssociationLoader<
    */
   async loadManyAssociatedEntitiesAsync<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
       TAssociatedID,
@@ -140,7 +140,7 @@ export default class EntityAssociationLoader<
    */
   async loadAssociatedEntityByFieldEqualingAsync<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
       TAssociatedID,
@@ -197,7 +197,7 @@ export default class EntityAssociationLoader<
    */
   async loadManyAssociatedEntitiesByFieldEqualingAsync<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
       TAssociatedID,
@@ -253,7 +253,7 @@ export default class EntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2,
-    TID2,
+    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
@@ -287,7 +287,7 @@ export default class EntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2,
-    TID2,
+    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
@@ -297,7 +297,7 @@ export default class EntityAssociationLoader<
       TSelectedFields2
     >,
     TFields3,
-    TID3,
+    TID3 extends NonNullable<TFields3[TSelectedFields3]>,
     TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
       TFields3,
@@ -342,7 +342,7 @@ export default class EntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2,
-    TID2,
+    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
@@ -352,7 +352,7 @@ export default class EntityAssociationLoader<
       TSelectedFields2
     >,
     TFields3,
-    TID3,
+    TID3 extends NonNullable<TFields3[TSelectedFields3]>,
     TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
       TFields3,
@@ -362,7 +362,7 @@ export default class EntityAssociationLoader<
       TSelectedFields3
     >,
     TFields4,
-    TID4,
+    TID4 extends NonNullable<TFields4[TSelectedFields4]>,
     TEntity4 extends ReadonlyEntity<TFields4, TID4, TViewerContext, TSelectedFields4>,
     TPrivacyPolicy4 extends EntityPrivacyPolicy<
       TFields4,
@@ -478,7 +478,7 @@ export interface EntityLoadThroughDirective<
   TViewerContext extends ViewerContext,
   TFields,
   TAssociatedFields,
-  TAssociatedID,
+  TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
   TAssociatedEntity extends ReadonlyEntity<
     TAssociatedFields,
     TAssociatedID,

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -19,7 +19,7 @@ export interface IPrivacyPolicyClass<TPrivacyPolicy> {
  */
 export default class EntityCompanion<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -60,7 +60,7 @@ export interface CacheAdapterFlavorDefinition {
  */
 export class EntityCompanionDefinition<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -181,7 +181,7 @@ export default class EntityCompanionProvider {
    */
   getCompanionForEntity<
     TFields,
-    TID,
+    TID extends NonNullable<TFields[TSelectedFields]>,
     TViewerContext extends ViewerContext,
     TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
     TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/EntityErrors.ts
+++ b/packages/entity/src/EntityErrors.ts
@@ -9,7 +9,7 @@ export abstract class EntityError extends ES6Error {}
 
 export class EntityNotFoundError<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -40,7 +40,7 @@ export class EntityNotFoundError<
 
 export class EntityNotAuthorizedError<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -31,7 +31,7 @@ export enum EntityEdgeDeletionBehavior {
 export interface EntityAssociationDefinition<
   TViewerContext extends ViewerContext,
   TAssociatedFields,
-  TAssociatedID,
+  TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
   TAssociatedEntity extends ReadonlyEntity<
     TAssociatedFields,
     TAssociatedID,

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -18,7 +18,7 @@ import { mapMap, mapMapAsync } from './utils/collections/maps';
  */
 export default class EntityLoader<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -150,7 +150,7 @@ export default class EntityLoader<
     const entityResults = await this.loadManyByIDsAsync([id]);
     const entityResult = entityResults.get(id);
     if (entityResult === undefined) {
-      return result(new EntityNotFoundError(this.entityClass, this.idField, id as any));
+      return result(new EntityNotFoundError(this.entityClass, this.idField, id));
     }
     return entityResult;
   }
@@ -161,7 +161,7 @@ export default class EntityLoader<
    * @returns entity result for matching ID, or null if no entity exists for ID.
    */
   async loadByIDNullableAsync(id: TID): Promise<Result<TEntity> | null> {
-    return await this.loadByFieldEqualingAsync(this.idField, id as any);
+    return await this.loadByFieldEqualingAsync(this.idField, id);
   }
 
   /**
@@ -171,15 +171,13 @@ export default class EntityLoader<
    * @returns map from ID to corresponding entity result, where result error can be UnauthorizedError or EntityNotFoundError.
    */
   async loadManyByIDsAsync(ids: readonly TID[]): Promise<ReadonlyMap<TID, Result<TEntity>>> {
-    const entityResults = ((await this.loadManyByFieldEqualingManyAsync(
+    const entityResults = (await this.loadManyByFieldEqualingManyAsync(
       this.idField,
-      ids as any
-    )) as any) as ReadonlyMap<TID, readonly Result<TEntity>[]>;
+      ids
+    )) as ReadonlyMap<TID, readonly Result<TEntity>[]>;
     return mapMap(entityResults, (entityResultsForId, id) => {
       const entityResult = entityResultsForId[0];
-      return (
-        entityResult ?? result(new EntityNotFoundError(this.entityClass, this.idField, id as any))
-      );
+      return entityResult ?? result(new EntityNotFoundError(this.entityClass, this.idField, id));
     });
   }
 

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -11,7 +11,7 @@ import EntityDataManager from './internal/EntityDataManager';
  */
 export default class EntityLoaderFactory<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -7,7 +7,7 @@ import ViewerContext from './ViewerContext';
  */
 export default interface EntityMutationTriggerConfiguration<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
@@ -70,7 +70,7 @@ export default interface EntityMutationTriggerConfiguration<
  */
 export abstract class EntityMutationTrigger<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
@@ -88,7 +88,7 @@ export abstract class EntityMutationTrigger<
  */
 export abstract class EntityNonTransactionalMutationTrigger<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -8,7 +8,7 @@ import ViewerContext from './ViewerContext';
  */
 export default abstract class EntityMutationValidator<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -21,7 +21,7 @@ import { mapMapAsync } from './utils/collections/maps';
 
 abstract class BaseMutator<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -114,7 +114,7 @@ abstract class BaseMutator<
  */
 export class CreateMutator<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -239,7 +239,7 @@ export class CreateMutator<
  */
 export class UpdateMutator<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -428,7 +428,7 @@ export class UpdateMutator<
  */
 export class DeleteMutator<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
@@ -537,7 +537,7 @@ export class DeleteMutator<
       return authorizeDeleteResult;
     }
 
-    await DeleteMutator.processEntityDeletionForInboundEdgesAsync(
+    await this.processEntityDeletionForInboundEdgesAsync(
       this.entity,
       queryContext,
       processedEntityIdentifiersFromTransitiveDeletions
@@ -603,14 +603,8 @@ export class DeleteMutator<
    *
    * @param entity - entity to find all references to
    */
-  private static async processEntityDeletionForInboundEdgesAsync<
-    TMFields,
-    TMID,
-    TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
-    TMSelectedFields extends keyof TMFields
-  >(
-    entity: TMEntity,
+  private async processEntityDeletionForInboundEdgesAsync(
+    entity: TEntity,
     queryContext: EntityTransactionalQueryContext,
     processedEntityIdentifiers: Set<string>
   ): Promise<void> {
@@ -621,12 +615,12 @@ export class DeleteMutator<
     processedEntityIdentifiers.add(entity.getUniqueIdentifier());
 
     const companionDefinition = (entity.constructor as any).getCompanionDefinition() as EntityCompanionDefinition<
-      TMFields,
-      TMID,
-      TMViewerContext,
-      TMEntity,
-      EntityPrivacyPolicy<TMFields, TMID, TMViewerContext, TMEntity, TMSelectedFields>,
-      TMSelectedFields
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
     >;
     const entityConfiguration = companionDefinition.entityConfiguration;
     const inboundEdges = entityConfiguration.getInboundEdges();

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -15,7 +15,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  */
 export default class EntityMutatorFactory<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -12,7 +12,7 @@ export enum EntityPrivacyPolicyEvaluationMode {
 
 export type EntityPrivacyPolicyEvaluator<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
@@ -63,7 +63,7 @@ export enum EntityAuthorizationAction {
  */
 export default abstract class EntityPrivacyPolicy<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
@@ -265,7 +265,13 @@ export default abstract class EntityPrivacyPolicy<
       const ruleEvaluationResult = await rule.evaluateAsync(viewerContext, queryContext, entity);
       switch (ruleEvaluationResult) {
         case RuleEvaluationResult.DENY:
-          throw new EntityNotAuthorizedError(entity, viewerContext, action, i);
+          throw new EntityNotAuthorizedError<
+            TFields,
+            TID,
+            TViewerContext,
+            TEntity,
+            TSelectedFields
+          >(entity, viewerContext, action, i);
         case RuleEvaluationResult.SKIP:
           continue;
         case RuleEvaluationResult.ALLOW:
@@ -275,6 +281,11 @@ export default abstract class EntityPrivacyPolicy<
       }
     }
 
-    throw new EntityNotAuthorizedError(entity, viewerContext, action, -1);
+    throw new EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity, TSelectedFields>(
+      entity,
+      viewerContext,
+      action,
+      -1
+    );
   }
 }

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -19,7 +19,7 @@ import { pick } from './entityUtils';
  */
 export default abstract class ReadonlyEntity<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
@@ -124,7 +124,7 @@ export default abstract class ReadonlyEntity<
    */
   static getQueryContext<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -161,7 +161,7 @@ export default abstract class ReadonlyEntity<
   static async runInTransactionAsync<
     TResult,
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -199,7 +199,7 @@ export default abstract class ReadonlyEntity<
    */
   static loader<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -27,7 +27,7 @@ export default class ViewerContext {
 
   getViewerScopedEntityCompanionForClass<
     TMFields,
-    TMID,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -12,7 +12,7 @@ import ViewerScopedEntityMutatorFactory from './ViewerScopedEntityMutatorFactory
  */
 export default class ViewerScopedEntityCompanion<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -23,7 +23,7 @@ export default class ViewerScopedEntityCompanionProvider {
    */
   getViewerScopedCompanionForEntity<
     TFields,
-    TID,
+    TID extends NonNullable<TFields[TSelectedFields]>,
     TViewerContext extends ViewerContext,
     TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
     TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  */
 export default class ViewerScopedEntityLoaderFactory<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  */
 export default class ViewerScopedEntityMutatorFactory<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -106,10 +106,38 @@ class SimpleTestDenyUpdateEntityPrivacyPolicy extends EntityPrivacyPolicy<
   ViewerContext,
   SimpleTestDenyUpdateEntity
 > {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysDenyPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyUpdateEntity
+    >(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyUpdateEntity
+    >(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysDenyPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyUpdateEntity
+    >(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyUpdateEntity
+    >(),
+  ];
 }
 
 class SimpleTestDenyDeleteEntityPrivacyPolicy extends EntityPrivacyPolicy<
@@ -118,10 +146,38 @@ class SimpleTestDenyDeleteEntityPrivacyPolicy extends EntityPrivacyPolicy<
   ViewerContext,
   SimpleTestDenyDeleteEntity
 > {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysDenyPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyDeleteEntity
+    >(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyDeleteEntity
+    >(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyDeleteEntity
+    >(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysDenyPrivacyPolicyRule<
+      TestEntityFields,
+      string,
+      ViewerContext,
+      SimpleTestDenyDeleteEntity
+    >(),
+  ];
 }
 
 class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, ViewerContext> {

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -34,10 +34,18 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   any,
   any
 > {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, TestViewerContext, any, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, TestViewerContext, any, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, TestViewerContext, any, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, TestViewerContext, any, any>(),
+  ];
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -25,10 +25,18 @@ class CategoryPrivacyPolicy extends EntityPrivacyPolicy<
   any,
   any
 > {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+  ];
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -111,10 +111,18 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
 }
 
 class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -119,10 +119,18 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
-  protected readonly readRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly createRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly updateRules = [new AlwaysAllowPrivacyPolicyRule()];
-  protected readonly deleteRules = [new AlwaysAllowPrivacyPolicyRule()];
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+  ];
 }
 
 class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
  */
 export default class AlwaysAllowPrivacyPolicyRule<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
  */
 export default class AlwaysDenyPrivacyPolicyRule<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
  */
 export default class AlwaysSkipPrivacyPolicyRule<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -37,7 +37,7 @@ export enum RuleEvaluationResult {
  */
 export default abstract class PrivacyPolicyRule<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -5,7 +5,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from '../../rules/PrivacyPoli
 
 export interface Case<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields
@@ -17,7 +17,7 @@ export interface Case<
 
 type CaseMap<
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields
@@ -28,7 +28,7 @@ type CaseMap<
  */
 export const describePrivacyPolicyRuleWithAsyncTestCase = <
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields
@@ -85,7 +85,7 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
  */
 export const describePrivacyPolicyRule = <
   TFields,
-  TID,
+  TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields


### PR DESCRIPTION
# Why

In `EntityLoader` (https://github.com/expo/entity/blob/master/packages/entity/src/EntityLoader.ts#L153) we have an any cast to tell it that TID is of type keyof TFields, but we can actually just constrain the generic typedef by making `TID extends TFields[TSelectedFields]`. The non-nullable is to ensure that null can't be supplied as the ID type.

# How

Add generic constraints everywhere.

# Test Plan

`yarn tsc`
