### PR TITLE
fix: add type generic default in test utils

### DIFF
--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -31,7 +31,7 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields
+  TSelectedFields extends keyof TFields = keyof TFields
 >(
   privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
   {
@@ -88,7 +88,7 @@ export const describePrivacyPolicyRule = <
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields
+  TSelectedFields extends keyof TFields = keyof TFields
 >(
   privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
   {


### PR DESCRIPTION
# Why

b8e07f9ddc4077768980c000d61f5ddcc824e2e3 added the TID narrowing, but without the default value for `TSelectedFields` consumers would have to specify `keyof TFields` manually. All public APIs for entity should have the default, and internal APIs shouldn't need to specify it since they're fully qualified. 

# How

Add defaults.

# Test Plan

`yarn tsc`
