### PR TITLE
feat: better typing on filterMap for use with predicates

### DIFF
--- a/packages/entity/src/utils/collections/__tests__/maps-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/maps-test.ts
@@ -117,4 +117,18 @@ describe(filterMap, () => {
     expect(filteredMap.get('a')).toBeUndefined();
     expect(filteredMap.get('b')).toBe(true);
   });
+
+  it('can use predicates', () => {
+    function truthy<TValue>(value: TValue | null | undefined): value is TValue {
+      return !!value;
+    }
+
+    const map = new Map<string, string | null>([
+      ['a', 'yes'],
+      ['b', null],
+    ]);
+
+    const filteredMap: Map<string, string> = filterMap(map, truthy);
+    expect(filteredMap.size).toBe(1);
+  });
 });

--- a/packages/entity/src/utils/collections/maps.ts
+++ b/packages/entity/src/utils/collections/maps.ts
@@ -83,10 +83,18 @@ export const reduceMapAsync = async <K, V, A>(
   return newAccumulator;
 };
 
-export const filterMap = <K, V>(
+export function filterMap<K, V, S extends V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => value is S
+): Map<K, S>;
+export function filterMap<K, V>(
   map: ReadonlyMap<K, V>,
   predicate: (value: V, key: K) => boolean
-): Map<K, V> => {
+): Map<K, V>;
+export function filterMap<K, V>(
+  map: ReadonlyMap<K, V>,
+  predicate: (value: V, key: K) => unknown
+): Map<K, V> {
   const resultingMap = new Map();
   map.forEach((v, k) => {
     if (predicate(v, k)) {
@@ -94,4 +102,4 @@ export const filterMap = <K, V>(
     }
   });
   return resultingMap;
-};
+}


### PR DESCRIPTION
# Why

When a map is filtered with a predicate, if the predicate signals a type using the `is` operator, then the resulting map should be have values of the type of the predicate result. For instance, if the type `Map<string, string | null>` is filtered with a `truthy` predicate, then the return type of `filterMap` should be `Map<string, string>`.

Array accomplishes this with a function declaration overload: https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts#L1176

# How

Add a function declaration overload.

# Test Plan

`yarn tsc`, also run new test.
