### PR TITLE
fix: move runInTransaction to ViewerContext

### DIFF
--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -3,6 +3,7 @@ import {
   createUnitTestEntityCompanionProvider,
   enforceResultsAsync,
   ViewerContext,
+  DatabaseAdapterFlavor,
 } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
 import Knex from 'knex';
@@ -94,14 +95,17 @@ describe('postgres entity integration', () => {
     const errorToThrow = new Error('Intentional error');
 
     await expect(
-      PostgresTestEntity.runInTransactionAsync(vc1, async (queryContext) => {
-        // put another in the DB that will be rolled back due to error thrown
-        await enforceAsyncResult(
-          PostgresTestEntity.creator(vc1, queryContext).setField('name', 'hello').createAsync()
-        );
+      vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+        DatabaseAdapterFlavor.POSTGRES,
+        async (queryContext) => {
+          // put another in the DB that will be rolled back due to error thrown
+          await enforceAsyncResult(
+            PostgresTestEntity.creator(vc1, queryContext).setField('name', 'hello').createAsync()
+          );
 
-        throw errorToThrow;
-      })
+          throw errorToThrow;
+        }
+      )
     ).rejects.toEqual(errorToThrow);
 
     const entities = await enforceResultsAsync(

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -183,16 +183,19 @@ describe('Entity cache inconsistency', () => {
 
         openBarrier2!();
       })(),
-      TestEntity.runInTransactionAsync(viewerContext, async (queryContext) => {
-        await TestEntity.updater(entity1, queryContext)
-          .setField('third_string', 'updated')
-          .enforceUpdateAsync();
+      viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        DatabaseAdapterFlavor.POSTGRES,
+        async (queryContext) => {
+          await TestEntity.updater(entity1, queryContext)
+            .setField('third_string', 'updated')
+            .enforceUpdateAsync();
 
-        openBarrier1();
+          openBarrier1();
 
-        // wait for to ensure the transaction isn't committed until after load above occurs
-        await barrier2;
-      }),
+          // wait for to ensure the transaction isn't committed until after load above occurs
+          await barrier2;
+        }
+      ),
     ]);
 
     // ensure cache consistency

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -226,6 +226,13 @@ export default class EntityCompanionProvider {
     });
   }
 
+  getQueryContextProviderForDatabaseAdaptorFlavor(
+    databaseAdapterFlavor: DatabaseAdapterFlavor
+  ): EntityQueryContextProvider {
+    const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors[databaseAdapterFlavor];
+    return entityDatabaseAdapterFlavor.queryContextProvider;
+  }
+
   private getTableDataCoordinatorForEntity<TFields>(
     entityConfiguration: EntityConfiguration<TFields>,
     entityClassName: string

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -5,7 +5,7 @@ import EntityAssociationLoader from './EntityAssociationLoader';
 import { EntityCompanionDefinition } from './EntityCompanionProvider';
 import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
-import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
+import { EntityQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
 import { pick } from './entityUtils';
 
@@ -116,80 +116,6 @@ export default abstract class ReadonlyEntity<
    */
   getAllDatabaseFields(): Readonly<TFields> {
     return { ...this.databaseFields };
-  }
-
-  /**
-   * Get the regular (non-transactional) query context for this entity.
-   * @param viewerContext - viewer context of calling user
-   */
-  static getQueryContext<
-    TMFields,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
-    TMViewerContext extends ViewerContext,
-    TMViewerContext2 extends TMViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<
-      TMFields,
-      TMID,
-      TMViewerContext,
-      TMEntity,
-      TMSelectedFields
-    >,
-    TMSelectedFields extends keyof TMFields = keyof TMFields
-  >(
-    this: IEntityClass<
-      TMFields,
-      TMID,
-      TMViewerContext,
-      TMEntity,
-      TMPrivacyPolicy,
-      TMSelectedFields
-    >,
-    viewerContext: TMViewerContext2
-  ): EntityQueryContext {
-    return viewerContext
-      .getViewerScopedEntityCompanionForClass(this)
-      .getQueryContextProvider()
-      .getQueryContext();
-  }
-
-  /**
-   * Start a transaction and execute the provided transaction-scoped closure within the transaction.
-   * @param viewerContext - viewer context of calling user
-   * @param transactionScope - async callback to execute within the transaction
-   */
-  static async runInTransactionAsync<
-    TResult,
-    TMFields,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
-    TMViewerContext extends ViewerContext,
-    TMViewerContext2 extends TMViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<
-      TMFields,
-      TMID,
-      TMViewerContext,
-      TMEntity,
-      TMSelectedFields
-    >,
-    TMSelectedFields extends keyof TMFields = keyof TMFields
-  >(
-    this: IEntityClass<
-      TMFields,
-      TMID,
-      TMViewerContext,
-      TMEntity,
-      TMPrivacyPolicy,
-      TMSelectedFields
-    >,
-    viewerContext: TMViewerContext2,
-    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>
-  ): Promise<TResult> {
-    return await viewerContext
-      .getViewerScopedEntityCompanionForClass(this)
-      .getQueryContextProvider()
-      .getQueryContext()
-      .runInTransactionIfNotInTransactionAsync(transactionScope);
   }
 
   /**

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -1,6 +1,7 @@
 import { IEntityClass } from './Entity';
-import EntityCompanionProvider from './EntityCompanionProvider';
+import EntityCompanionProvider, { DatabaseAdapterFlavor } from './EntityCompanionProvider';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerScopedEntityCompanion from './ViewerScopedEntityCompanion';
 import ViewerScopedEntityCompanionProvider from './ViewerScopedEntityCompanionProvider';
@@ -59,5 +60,33 @@ export default class ViewerContext {
       entityClass,
       entityClass.getCompanionDefinition()
     );
+  }
+
+  /**
+   * Get the regular (non-transactional) query context for a database adaptor flavor.
+   * @param databaseAdaptorFlavor - database adaptor flavor
+   */
+  getQueryContextForDatabaseAdaptorFlavor(
+    databaseAdaptorFlavor: DatabaseAdapterFlavor
+  ): EntityQueryContext {
+    return this.entityCompanionProvider
+      .getQueryContextProviderForDatabaseAdaptorFlavor(databaseAdaptorFlavor)
+      .getQueryContext();
+  }
+
+  /**
+   * Run a transaction of specified database adaptor flavor and execute the provided
+   * transaction-scoped closure within the transaction.
+   * @param databaseAdaptorFlavor - databaseAdaptorFlavor
+   * @param transactionScope - async callback to execute within the transaction
+   */
+  async runInTransactionForDatabaseAdaptorFlavorAsync<TResult>(
+    databaseAdaptorFlavor: DatabaseAdapterFlavor,
+    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>
+  ): Promise<TResult> {
+    return await this.entityCompanionProvider
+      .getQueryContextProviderForDatabaseAdaptorFlavor(databaseAdaptorFlavor)
+      .getQueryContext()
+      .runInTransactionIfNotInTransactionAsync(transactionScope);
   }
 }

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -2,7 +2,6 @@ import { instance, mock } from 'ts-mockito';
 
 import EntityAssociationLoader from '../EntityAssociationLoader';
 import EntityLoader from '../EntityLoader';
-import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
@@ -105,30 +104,6 @@ describe(ReadonlyEntity, () => {
       };
       const testEntity = new SimpleTestEntity(viewerContext, data);
       expect(testEntity.associationLoader()).toBeInstanceOf(EntityAssociationLoader);
-    });
-  });
-
-  describe('getRegularEntityQueryContext', () => {
-    it('creates a new regular query context', () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
-      const queryContext = SimpleTestEntity.getQueryContext(viewerContext);
-      expect(queryContext).toBeInstanceOf(EntityQueryContext);
-      expect(queryContext.isInTransaction()).toBe(false);
-    });
-  });
-
-  describe('runInTransactionAsync', () => {
-    it('creates a new transactional query context', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
-      const didCreateTransaction = await SimpleTestEntity.runInTransactionAsync(
-        viewerContext,
-        async (queryContext) => {
-          return queryContext.isInTransaction();
-        }
-      );
-      expect(didCreateTransaction).toBe(true);
     });
   });
 

--- a/packages/entity/src/__tests__/ViewerContext-test.ts
+++ b/packages/entity/src/__tests__/ViewerContext-test.ts
@@ -1,0 +1,32 @@
+import { DatabaseAdapterFlavor } from '../EntityCompanionProvider';
+import { EntityQueryContext } from '../EntityQueryContext';
+import ViewerContext from '../ViewerContext';
+import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
+
+describe(ViewerContext, () => {
+  describe('getQueryContextForDatabaseAdaptorFlavor', () => {
+    it('creates a new regular query context', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const queryContext = viewerContext.getQueryContextForDatabaseAdaptorFlavor(
+        DatabaseAdapterFlavor.POSTGRES
+      );
+      expect(queryContext).toBeInstanceOf(EntityQueryContext);
+      expect(queryContext.isInTransaction()).toBe(false);
+    });
+  });
+
+  describe('runInTransactionForDatabaseAdaptorFlavorAsync', () => {
+    it('creates a new transactional query context', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const didCreateTransaction = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        DatabaseAdapterFlavor.POSTGRES,
+        async (queryContext) => {
+          return queryContext.isInTransaction();
+        }
+      );
+      expect(didCreateTransaction).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Why

This has been suggested by @jkhales and @ide a few times as a better pattern. At its core this does the same thing as the previous implementation, it just removes the unnecessary association with concrete entity types.

# How

Move the methods to `ViewerContext`. Note that this will most likely be used in methods in `ViewerContext` subclasses in the following manner:

```typescript
// in ExpoViewerContext.ts

async runInPostgresTransactionAsync<TResult>(
  transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>
): Promise<TResult> {
  return await this.runInTransactionForDatabaseAdaptorFlavorAsync(
    DatabaseAdapterFlavor.POSTGRES,
    transactionScope
  );
}
```

so that callsites don't need to specify the `DatabaseAdapterFlavor`. 

# Questions for Reviewers

Do you think it's worth added these `DatabaseAdapterFlavor`-hardcoded methods to `ViewerContext`? Since the `DatabaseAdapterFlavor` is hardcoded in this package, it can be done cleanly. The upside is that consumers don't need to specify them. The downside is that the number of methods would grow if we add more `DatabaseAdapterFlavor`s.

# Test Plan

Run all tests.
