### PR TITLE
fix: remove cache and database adaptor flavor enums

### DIFF
--- a/packages/entity-cache-adapter-redis/README.md
+++ b/packages/entity-cache-adapter-redis/README.md
@@ -35,7 +35,7 @@ export const createDefaultEntityCompanionProvider = (
       ...
     },
     {
-      [CacheAdapterFlavor.REDIS]: {
+      ['redis']: {
         cacheAdapterProvider: new RedisCacheAdapterProvider(redisCacheAdapterContext),
       },
     }

--- a/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
@@ -1,10 +1,4 @@
-import {
-  CacheStatus,
-  UUIDField,
-  EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-} from '@expo/entity';
+import { CacheStatus, UUIDField, EntityConfiguration } from '@expo/entity';
 import { Redis, Pipeline } from 'ioredis';
 import { mock, when, instance, anything, verify } from 'ts-mockito';
 
@@ -20,8 +14,8 @@ const entityConfiguration = new EntityConfiguration<BlahFields>({
   schema: {
     id: new UUIDField({ columnName: 'id', cache: true }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 describe(RedisCacheAdapter, () => {

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -6,8 +6,6 @@ import {
   DateField,
   StringField,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   EntityCompanionDefinition,
   Entity,
 } from '@expo/entity';
@@ -85,8 +83,8 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
       columnName: 'date_field',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const redisTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-cache-adapter-redis/src/testfixtures/createRedisIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/createRedisIntegrationTestEntityCompanionProvider.ts
@@ -2,8 +2,6 @@ import {
   NoOpEntityMetricsAdapter,
   IEntityMetricsAdapter,
   EntityCompanionProvider,
-  CacheAdapterFlavor,
-  DatabaseAdapterFlavor,
   StubQueryContextProvider,
   StubDatabaseAdapterProvider,
 } from '@expo/entity';
@@ -17,16 +15,22 @@ export const createRedisIntegrationTestEntityCompanionProvider = (
 ): EntityCompanionProvider => {
   return new EntityCompanionProvider(
     metricsAdapter,
-    {
-      [DatabaseAdapterFlavor.POSTGRES]: {
-        adapterProvider: new StubDatabaseAdapterProvider(),
-        queryContextProvider: StubQueryContextProvider,
-      },
-    },
-    {
-      [CacheAdapterFlavor.REDIS]: {
-        cacheAdapterProvider: new RedisCacheAdapterProvider(redisCacheAdapterContext),
-      },
-    }
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new StubDatabaseAdapterProvider(),
+          queryContextProvider: StubQueryContextProvider,
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'redis',
+        {
+          cacheAdapterProvider: new RedisCacheAdapterProvider(redisCacheAdapterContext),
+        },
+      ],
+    ])
   );
 };

--- a/packages/entity-database-adapter-knex/README.md
+++ b/packages/entity-database-adapter-knex/README.md
@@ -29,7 +29,7 @@ export const createDefaultEntityCompanionProvider = (
     metricsAdapter,
     {
       // add the knex database adapter flavor
-      [DatabaseAdapterFlavor.POSTGRES]: {
+      ['postgres']: {
         adapter: PostgresEntityDatabaseAdapter,
         queryContextProvider: new PostgresEntityQueryContextProvider(knexInstance),
       },

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -3,7 +3,6 @@ import {
   createUnitTestEntityCompanionProvider,
   enforceResultsAsync,
   ViewerContext,
-  DatabaseAdapterFlavor,
 } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
 import Knex from 'knex';
@@ -95,17 +94,14 @@ describe('postgres entity integration', () => {
     const errorToThrow = new Error('Intentional error');
 
     await expect(
-      vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
-        DatabaseAdapterFlavor.POSTGRES,
-        async (queryContext) => {
-          // put another in the DB that will be rolled back due to error thrown
-          await enforceAsyncResult(
-            PostgresTestEntity.creator(vc1, queryContext).setField('name', 'hello').createAsync()
-          );
+      vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+        // put another in the DB that will be rolled back due to error thrown
+        await enforceAsyncResult(
+          PostgresTestEntity.creator(vc1, queryContext).setField('name', 'hello').createAsync()
+        );
 
-          throw errorToThrow;
-        }
-      )
+        throw errorToThrow;
+      })
     ).rejects.toEqual(errorToThrow);
 
     const entities = await enforceResultsAsync(

--- a/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
@@ -4,8 +4,6 @@ import {
   ViewerContext,
   StringField,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   EntityCompanionDefinition,
   Entity,
   NumberField,
@@ -168,8 +166,8 @@ export const ErrorsTestEntityConfiguration = new EntityConfiguration<ErrorsTestE
       columnName: 'non_existent_column',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const errorsTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -4,8 +4,6 @@ import {
   ViewerContext,
   StringField,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   EntityCompanionDefinition,
   Entity,
   NumberField,
@@ -104,8 +102,8 @@ export const invalidTestEntityConfiguration = new EntityConfiguration<InvalidTes
       columnName: 'name',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const invalidTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -11,8 +11,6 @@ import {
   DateField,
   MaybeJSONArrayField,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   EntityCompanionDefinition,
   Entity,
 } from '@expo/entity';
@@ -150,8 +148,8 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresT
       columnName: 'maybe_json_array_field',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -5,8 +5,6 @@ import {
   UUIDField,
   StringField,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   EntityCompanionDefinition,
   Entity,
   EntityMutationTrigger,
@@ -153,8 +151,8 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<
       columnName: 'name',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -5,8 +5,6 @@ import {
   UUIDField,
   StringField,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   EntityCompanionDefinition,
   Entity,
   EntityMutationTrigger,
@@ -135,8 +133,8 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<
       columnName: 'name',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({

--- a/packages/entity-database-adapter-knex/src/testfixtures/createKnexIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/createKnexIntegrationTestEntityCompanionProvider.ts
@@ -2,8 +2,6 @@ import {
   NoOpEntityMetricsAdapter,
   IEntityMetricsAdapter,
   EntityCompanionProvider,
-  CacheAdapterFlavor,
-  DatabaseAdapterFlavor,
   InMemoryFullCacheStubCacheAdapterProvider,
 } from '@expo/entity';
 import Knex from 'knex';
@@ -17,16 +15,22 @@ export const createKnexIntegrationTestEntityCompanionProvider = (
 ): EntityCompanionProvider => {
   return new EntityCompanionProvider(
     metricsAdapter,
-    {
-      [DatabaseAdapterFlavor.POSTGRES]: {
-        adapterProvider: new PostgresEntityDatabaseAdapterProvider(),
-        queryContextProvider: new PostgresEntityQueryContextProvider(knex),
-      },
-    },
-    {
-      [CacheAdapterFlavor.REDIS]: {
-        cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
-      },
-    }
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new PostgresEntityDatabaseAdapterProvider(),
+          queryContextProvider: new PostgresEntityQueryContextProvider(knex),
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'redis',
+        {
+          cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
+        },
+      ],
+    ])
   );
 };

--- a/packages/entity-example/src/data.ts
+++ b/packages/entity-example/src/data.ts
@@ -3,8 +3,6 @@ import {
   NoOpEntityMetricsAdapter,
   EntityCompanionProvider,
   InMemoryFullCacheStubCacheAdapterProvider,
-  CacheAdapterFlavor,
-  DatabaseAdapterFlavor,
 } from '@expo/entity';
 
 import { InMemoryDatabaseAdapterProvider } from './adapters/InMemoryDatabaseAdapter';
@@ -21,20 +19,26 @@ export const createEntityCompanionProvider = (
 ): EntityCompanionProvider => {
   return new EntityCompanionProvider(
     metricsAdapter,
-    {
-      // An in-memory DB is used for demonstration purposes, but generally this would be
-      // instantiated with PostgresEntityDatabaseAdapter and PostgresEntityQueryContextProvider
-      [DatabaseAdapterFlavor.POSTGRES]: {
-        adapterProvider: new InMemoryDatabaseAdapterProvider(),
-        queryContextProvider: new InMemoryQueryContextProvider(),
-      },
-    },
-    {
-      // An in-memory cache is used for demonstration purposes, but generally this would be
-      // instantiated with a RedisCacheAdapterProvider
-      [CacheAdapterFlavor.REDIS]: {
-        cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
-      },
-    }
+    new Map([
+      [
+        'postgres',
+        // An in-memory DB is used for demonstration purposes, but generally this would be
+        // instantiated with PostgresEntityDatabaseAdapter and PostgresEntityQueryContextProvider
+        {
+          adapterProvider: new InMemoryDatabaseAdapterProvider(),
+          queryContextProvider: new InMemoryQueryContextProvider(),
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'redis',
+        // An in-memory cache is used for demonstration purposes, but generally this would be
+        // instantiated with a RedisCacheAdapterProvider
+        {
+          cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
+        },
+      ],
+    ])
   );
 };

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -3,8 +3,6 @@ import {
   EntityCompanionDefinition,
   EntityConfiguration,
   UUIDField,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   StringField,
 } from '@expo/entity';
 
@@ -57,8 +55,8 @@ export const noteEntityCompanion = new EntityCompanionDefinition({
         columnName: 'body',
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   }),
   privacyPolicyClass: NotePrivacyPolicy,
 });

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -5,8 +5,6 @@ import {
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   UUIDField,
 } from '@expo/entity';
 import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
@@ -70,8 +68,8 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'third_string',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const testEntityCompanion = new EntityCompanionDefinition({
@@ -184,7 +182,7 @@ describe('Entity cache inconsistency', () => {
         openBarrier2!();
       })(),
       viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
-        DatabaseAdapterFlavor.POSTGRES,
+        'postgres',
         async (queryContext) => {
           await TestEntity.updater(entity1, queryContext)
             .setField('third_string', 'updated')

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -5,8 +5,6 @@ import {
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
   UUIDField,
   EntityEdgeDeletionBehavior,
 } from '@expo/entity';
@@ -90,8 +88,8 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         },
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   const categoryEntityCompanion = new EntityCompanionDefinition({
@@ -118,8 +116,8 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         },
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   const otherEntityCompanion = new EntityCompanionDefinition({

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -1,7 +1,5 @@
 import {
   AlwaysAllowPrivacyPolicyRule,
-  CacheAdapterFlavor,
-  DatabaseAdapterFlavor,
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
@@ -62,8 +60,8 @@ const childEntityConfiguration = new EntityConfiguration<ChildFields>({
       },
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const childEntityCompanion = new EntityCompanionDefinition({

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -1,7 +1,5 @@
 import {
   AlwaysAllowPrivacyPolicyRule,
-  CacheAdapterFlavor,
-  DatabaseAdapterFlavor,
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
@@ -53,8 +51,8 @@ const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
       cache: true,
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 const parentEntityCompanion = new EntityCompanionDefinition({

--- a/packages/entity-full-integration-tests/src/testfixtures/createFullIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-full-integration-tests/src/testfixtures/createFullIntegrationTestEntityCompanionProvider.ts
@@ -2,8 +2,6 @@ import {
   NoOpEntityMetricsAdapter,
   IEntityMetricsAdapter,
   EntityCompanionProvider,
-  CacheAdapterFlavor,
-  DatabaseAdapterFlavor,
 } from '@expo/entity';
 import {
   RedisCacheAdapterContext,
@@ -22,16 +20,22 @@ export const createFullIntegrationTestEntityCompanionProvider = (
 ): EntityCompanionProvider => {
   return new EntityCompanionProvider(
     metricsAdapter,
-    {
-      [DatabaseAdapterFlavor.POSTGRES]: {
-        adapterProvider: new PostgresEntityDatabaseAdapterProvider(),
-        queryContextProvider: new PostgresEntityQueryContextProvider(knex),
-      },
-    },
-    {
-      [CacheAdapterFlavor.REDIS]: {
-        cacheAdapterProvider: new RedisCacheAdapterProvider(redisCacheAdapterContext),
-      },
-    }
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new PostgresEntityDatabaseAdapterProvider(),
+          queryContextProvider: new PostgresEntityQueryContextProvider(knex),
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'redis',
+        {
+          cacheAdapterProvider: new RedisCacheAdapterProvider(redisCacheAdapterContext),
+        },
+      ],
+    ])
   );
 };

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -1,3 +1,5 @@
+import invariant from 'invariant';
+
 import { IEntityClass } from './Entity';
 import EntityCompanion, { IPrivacyPolicyClass } from './EntityCompanion';
 import EntityConfiguration from './EntityConfiguration';
@@ -222,11 +224,10 @@ export default class EntityCompanionProvider {
     databaseAdapterFlavor: DatabaseAdapterFlavor
   ): EntityQueryContextProvider {
     const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(databaseAdapterFlavor);
-    if (!entityDatabaseAdapterFlavor) {
-      throw new Error(
-        `No database adaptor configuration found for flavor: ${databaseAdapterFlavor}`
-      );
-    }
+    invariant(
+      entityDatabaseAdapterFlavor,
+      `No database adaptor configuration found for flavor: ${databaseAdapterFlavor}`
+    );
 
     return entityDatabaseAdapterFlavor.queryContextProvider;
   }
@@ -239,20 +240,18 @@ export default class EntityCompanionProvider {
       const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(
         entityConfiguration.databaseAdapterFlavor
       );
-      if (!entityDatabaseAdapterFlavor) {
-        throw new Error(
-          `No database adaptor configuration found for flavor: ${entityConfiguration.databaseAdapterFlavor}`
-        );
-      }
+      invariant(
+        entityDatabaseAdapterFlavor,
+        `No database adaptor configuration found for flavor: ${entityConfiguration.databaseAdapterFlavor}`
+      );
 
       const entityCacheAdapterFlavor = this.cacheAdapterFlavors.get(
         entityConfiguration.cacheAdapterFlavor
       );
-      if (!entityCacheAdapterFlavor) {
-        throw new Error(
-          `No cache adaptor configuration found for flavor: ${entityConfiguration.cacheAdapterFlavor}`
-        );
-      }
+      invariant(
+        entityCacheAdapterFlavor,
+        `No cache adaptor configuration found for flavor: ${entityConfiguration.cacheAdapterFlavor}`
+      );
 
       return new EntityTableDataCoordinator(
         entityConfiguration,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -16,25 +16,14 @@ import { computeIfAbsent } from './utils/collections/maps';
 /**
  * Backing database and transaction type for an entity. The definitions and implementations
  * are provided by injection in the root EntityCompanionProvider to allow for mocking and sharing.
- *
- * Note: this enum will likely be modified soon to be more flexible.
  */
-export enum DatabaseAdapterFlavor {
-  /**
-   * Knex postgres adapter, using postgres table and postgres transactions.
-   */
-  POSTGRES = 'postgres',
-}
+export type DatabaseAdapterFlavor = string;
 
 /**
  * Cache system for an entity. The definitions and implementations are provided by injection
  * in the root EntityCompanionProvider to allow for mocking and sharing.
- *
- * Note: this enum will likely be modified soon to be more flexible.
  */
-export enum CacheAdapterFlavor {
-  REDIS = 'redis',
-}
+export type CacheAdapterFlavor = string;
 
 /**
  * Defines a set interfaces for a entity database adapter flavor. An entity that uses a flavor
@@ -168,8 +157,11 @@ export default class EntityCompanionProvider {
    */
   constructor(
     private metricsAdapter: IEntityMetricsAdapter,
-    private databaseAdapterFlavors: Record<DatabaseAdapterFlavor, DatabaseAdapterFlavorDefinition>,
-    private cacheAdapterFlavors: Record<CacheAdapterFlavor, CacheAdapterFlavorDefinition>
+    private databaseAdapterFlavors: ReadonlyMap<
+      DatabaseAdapterFlavor,
+      DatabaseAdapterFlavorDefinition
+    >,
+    private cacheAdapterFlavors: ReadonlyMap<CacheAdapterFlavor, CacheAdapterFlavorDefinition>
   ) {}
 
   /**
@@ -229,7 +221,13 @@ export default class EntityCompanionProvider {
   getQueryContextProviderForDatabaseAdaptorFlavor(
     databaseAdapterFlavor: DatabaseAdapterFlavor
   ): EntityQueryContextProvider {
-    const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors[databaseAdapterFlavor];
+    const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(databaseAdapterFlavor);
+    if (!entityDatabaseAdapterFlavor) {
+      throw new Error(
+        `No database adaptor configuration found for flavor: ${databaseAdapterFlavor}`
+      );
+    }
+
     return entityDatabaseAdapterFlavor.queryContextProvider;
   }
 
@@ -238,12 +236,24 @@ export default class EntityCompanionProvider {
     entityClassName: string
   ): EntityTableDataCoordinator<TFields> {
     return computeIfAbsent(this.tableDataCoordinatorMap, entityConfiguration.tableName, () => {
-      const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors[
+      const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(
         entityConfiguration.databaseAdapterFlavor
-      ];
-      const entityCacheAdapterFlavor = this.cacheAdapterFlavors[
+      );
+      if (!entityDatabaseAdapterFlavor) {
+        throw new Error(
+          `No database adaptor configuration found for flavor: ${entityConfiguration.databaseAdapterFlavor}`
+        );
+      }
+
+      const entityCacheAdapterFlavor = this.cacheAdapterFlavors.get(
         entityConfiguration.cacheAdapterFlavor
-      ];
+      );
+      if (!entityCacheAdapterFlavor) {
+        throw new Error(
+          `No cache adaptor configuration found for flavor: ${entityConfiguration.cacheAdapterFlavor}`
+        );
+      }
+
       return new EntityTableDataCoordinator(
         entityConfiguration,
         entityDatabaseAdapterFlavor.adapterProvider,

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
 import { CreateMutator, UpdateMutator } from '../EntityMutator';
@@ -96,8 +92,8 @@ const testEntityConfiguration = new EntityConfiguration<TestEntityFields>({
       columnName: 'custom_id',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 class SimpleTestDenyUpdateEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -1,11 +1,7 @@
 import { enforceAsyncResult } from '@expo/results';
 
 import Entity from '../Entity';
-import EntityCompanionProvider, {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import EntityCompanionProvider, { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -100,8 +96,8 @@ const blahCompanion = new EntityCompanionDefinition({
         columnName: 'owner_id',
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   }),
   privacyPolicyClass: BlahEntityPrivacyPolicy,
 });

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import EntityCompanionProvider, {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import EntityCompanionProvider, { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { StringField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -22,8 +18,8 @@ const blahConfiguration = new EntityConfiguration<BlahFields>({
       columnName: 'hello',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 class Blah1Entity extends Entity<BlahFields, string, ViewerContext> {

--- a/packages/entity/src/__tests__/EntityDataConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityDataConfiguration-test.ts
@@ -1,4 +1,3 @@
-import { DatabaseAdapterFlavor, CacheAdapterFlavor } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField, StringField } from '../EntityFields';
 
@@ -28,15 +27,15 @@ describe(EntityConfiguration, () => {
         columnName: 'unique_but_not_cacheable',
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   it('returns correct fields', () => {
     expect(blahEntityConfiguration.idField).toEqual('id');
     expect(blahEntityConfiguration.tableName).toEqual('blah_table');
-    expect(blahEntityConfiguration.databaseAdapterFlavor).toEqual(DatabaseAdapterFlavor.POSTGRES);
-    expect(blahEntityConfiguration.cacheAdapterFlavor).toEqual(CacheAdapterFlavor.REDIS);
+    expect(blahEntityConfiguration.databaseAdapterFlavor).toEqual('postgres');
+    expect(blahEntityConfiguration.cacheAdapterFlavor).toEqual('redis');
   });
 
   it('filters cacheable fields', () => {
@@ -53,8 +52,8 @@ describe(EntityConfiguration, () => {
             columnName: 'id',
           }),
         },
-        databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-        cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
       });
       expect(entityConfiguration.cacheKeyVersion).toEqual(0);
     });
@@ -68,8 +67,8 @@ describe(EntityConfiguration, () => {
             columnName: 'id',
           }),
         },
-        databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-        cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
         cacheKeyVersion: 100,
       });
       expect(entityConfiguration.cacheKeyVersion).toEqual(100);

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField, EntityEdgeDeletionBehavior } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -96,8 +92,8 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         cache: true,
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   const childEntityConfiguration = new EntityConfiguration<ChildFields>({
@@ -118,8 +114,8 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         },
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   const grandChildEntityConfiguration = new EntityConfiguration<GrandChildFields>({
@@ -139,8 +135,8 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         },
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   const parentEntityCompanion = new EntityCompanionDefinition({

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -1,11 +1,7 @@
 import { mock, instance, spy, verify, anyOfClass } from 'ts-mockito';
 
 import Entity from '../Entity';
-import {
-  EntityCompanionDefinition,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
 import EntityPrivacyPolicy, {
@@ -234,8 +230,8 @@ const blahEntityCompanionDefinition = new EntityCompanionDefinition({
         columnName: 'id',
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   }),
   privacyPolicyClass: AlwaysDenyPolicy,
 });

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField, EntityEdgeDeletionBehavior } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -71,8 +67,8 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
         },
       }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
   const categoryEntityCompanion = new EntityCompanionDefinition({

--- a/packages/entity/src/__tests__/ViewerContext-test.ts
+++ b/packages/entity/src/__tests__/ViewerContext-test.ts
@@ -1,4 +1,3 @@
-import { DatabaseAdapterFlavor } from '../EntityCompanionProvider';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
@@ -8,9 +7,7 @@ describe(ViewerContext, () => {
     it('creates a new regular query context', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      const queryContext = viewerContext.getQueryContextForDatabaseAdaptorFlavor(
-        DatabaseAdapterFlavor.POSTGRES
-      );
+      const queryContext = viewerContext.getQueryContextForDatabaseAdaptorFlavor('postgres');
       expect(queryContext).toBeInstanceOf(EntityQueryContext);
       expect(queryContext.isInTransaction()).toBe(false);
     });
@@ -21,7 +18,7 @@ describe(ViewerContext, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
       const didCreateTransaction = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
-        DatabaseAdapterFlavor.POSTGRES,
+        'postgres',
         async (queryContext) => {
           return queryContext.isInTransaction();
         }

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -1,9 +1,5 @@
 import Entity from '../../Entity';
-import {
-  EntityCompanionDefinition,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-} from '../../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField, EnumField, StringField } from '../../EntityFields';
 import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
@@ -106,8 +102,8 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'entity_type',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -1,9 +1,5 @@
 import Entity from '../../Entity';
-import {
-  EntityCompanionDefinition,
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-} from '../../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField, StringField } from '../../EntityFields';
 import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
@@ -114,8 +110,8 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
       cache: true,
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -1,4 +1,3 @@
-import { DatabaseAdapterFlavor, CacheAdapterFlavor } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField, StringField } from '../../EntityFields';
 import {
@@ -38,8 +37,8 @@ const blahEntityConfiguration = new EntityConfiguration<BlahT>({
       columnName: 'transform_write',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 describe(getDatabaseFieldForEntityField, () => {

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -1,7 +1,6 @@
 import { verify, deepEqual, mock, instance, when, anything } from 'ts-mockito';
 
 import EntityCacheAdapter from '../../EntityCacheAdapter';
-import { DatabaseAdapterFlavor, CacheAdapterFlavor } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField } from '../../EntityFields';
 import ReadThroughEntityCache, { CacheStatus } from '../ReadThroughEntityCache';
@@ -17,8 +16,8 @@ const makeEntityConfiguration = (cacheIdField: boolean): EntityConfiguration<Bla
     schema: {
       id: new UUIDField({ columnName: 'id', cache: cacheIdField }),
     },
-    databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-    cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
   });
 
 const createIdFetcher = (ids: string[]) => async <N extends keyof BlahFields>(

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { DateField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -22,8 +18,8 @@ export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestF
       columnName: 'custom_id',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 export class DateIDTestEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -24,8 +20,8 @@ export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestF
       columnName: 'custom_id',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -1,11 +1,7 @@
 import { result, Result } from '@expo/results';
 
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField, StringField, DateField, NumberField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -45,8 +41,8 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields>({
       columnName: 'nullable_field',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -26,8 +22,8 @@ export const testEntity2Configuration = new EntityConfiguration<Test2Fields>({
       columnName: 'foreign_key',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 export class TestEntity2PrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -1,9 +1,5 @@
 import Entity from '../Entity';
-import {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-  EntityCompanionDefinition,
-} from '../EntityCompanionProvider';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { NumberField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
@@ -22,8 +18,8 @@ export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFie
       columnName: 'custom_id',
     }),
   },
-  databaseAdapterFlavor: DatabaseAdapterFlavor.POSTGRES,
-  cacheAdapterFlavor: CacheAdapterFlavor.REDIS,
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
 });
 
 export class NumberKeyPrivacyPolicy extends EntityPrivacyPolicy<

--- a/packages/entity/src/utils/testing/createUnitTestEntityCompanionProvider.ts
+++ b/packages/entity/src/utils/testing/createUnitTestEntityCompanionProvider.ts
@@ -1,7 +1,4 @@
-import EntityCompanionProvider, {
-  DatabaseAdapterFlavor,
-  CacheAdapterFlavor,
-} from '../../EntityCompanionProvider';
+import EntityCompanionProvider from '../../EntityCompanionProvider';
 import IEntityMetricsAdapter from '../../metrics/IEntityMetricsAdapter';
 import NoOpEntityMetricsAdapter from '../../metrics/NoOpEntityMetricsAdapter';
 import { InMemoryFullCacheStubCacheAdapterProvider } from './StubCacheAdapter';
@@ -17,16 +14,22 @@ export const createUnitTestEntityCompanionProvider = (
 ): EntityCompanionProvider => {
   return new EntityCompanionProvider(
     metricsAdapter,
-    {
-      [DatabaseAdapterFlavor.POSTGRES]: {
-        adapterProvider: new StubDatabaseAdapterProvider(),
-        queryContextProvider: StubQueryContextProvider,
-      },
-    },
-    {
-      [CacheAdapterFlavor.REDIS]: {
-        cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
-      },
-    }
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new StubDatabaseAdapterProvider(),
+          queryContextProvider: StubQueryContextProvider,
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'redis',
+        {
+          cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
+        },
+      ],
+    ])
   );
 };


### PR DESCRIPTION
# Why

Follow-up on https://github.com/expo/entity/pull/108#issuecomment-763825600 and an inline comment indicating that this would eventually just become a string.

This pattern of using a hardcoded enum wasn't flexible enough to support additional third-party/private adaptor implementations and/or multiple adaptors in the same application.

# How

Change it to a string and add definition validation to ensure definition is supplied for requested flavor.

# Test Plan

Run all tests.
