### PR TITLE
chore: upgrade typescript to 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ts-mockito": "^2.6.1",
     "typedoc": "^0.17.6",
     "typedoc-plugin-lerna-packages": "^0.3.0",
-    "typescript": "^4.0.2",
+    "typescript": "^4.1.3",
     "uuid": "^8.3.0"
   },
   "dependencies": {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -157,12 +157,12 @@ describe('Entity cache inconsistency', () => {
       .loadByFieldEqualingAsync('other_string', 'hello');
 
     let openBarrier1: () => void;
-    const barrier1 = new Promise((resolve) => {
+    const barrier1 = new Promise<void>((resolve) => {
       openBarrier1 = resolve;
     });
 
     let openBarrier2: () => void;
-    const barrier2 = new Promise((resolve) => {
+    const barrier2 = new Promise<void>((resolve) => {
       openBarrier2 = resolve;
     });
 

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -75,7 +75,7 @@ export abstract class EntityMutationTrigger<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  abstract async executeAsync(
+  abstract executeAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entity: TEntity
@@ -93,5 +93,5 @@ export abstract class EntityNonTransactionalMutationTrigger<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  abstract async executeAsync(viewerContext: TViewerContext, entity: TEntity): Promise<void>;
+  abstract executeAsync(viewerContext: TViewerContext, entity: TEntity): Promise<void>;
 }

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -13,7 +13,7 @@ export default abstract class EntityMutationValidator<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  abstract async executeAsync(
+  abstract executeAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entity: TEntity

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -18,7 +18,7 @@ export abstract class EntityQueryContext {
     return this.queryInterface;
   }
 
-  abstract async runInTransactionIfNotInTransactionAsync<T>(
+  abstract runInTransactionIfNotInTransactionAsync<T>(
     transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<T>
   ): Promise<T>;
 }

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -8,11 +8,12 @@ import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
 import TestEntity, {
   TestEntityPrivacyPolicy,
   testEntityConfiguration,
+  TestFields,
 } from '../testfixtures/TestEntity';
 
 describe(EntityCompanion, () => {
   it('correctly instantiates mutator and loader factories', () => {
-    const tableDataCoordinatorMock = mock(EntityTableDataCoordinator);
+    const tableDataCoordinatorMock = mock<EntityTableDataCoordinator<TestFields>>();
     when(tableDataCoordinatorMock.entityConfiguration).thenReturn(testEntityConfiguration);
 
     const companion = new EntityCompanion(

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -227,7 +227,7 @@ describe(EntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock(EntityDataManager);
+    const dataManagerMock = mock<EntityDataManager<TestFields>>();
     const dataManagerInstance = instance(dataManagerMock);
 
     const entityLoader = new EntityLoader(
@@ -241,7 +241,7 @@ describe(EntityLoader, () => {
     await entityLoader.invalidateFieldsAsync({ customIdField: 'hello' } as any);
 
     verify(
-      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' }))
+      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' } as any))
     ).once();
   });
 
@@ -249,7 +249,7 @@ describe(EntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock(EntityDataManager);
+    const dataManagerMock = mock<EntityDataManager<TestFields>>();
     const dataManagerInstance = instance(dataManagerMock);
 
     const entityLoader = new EntityLoader(
@@ -262,7 +262,7 @@ describe(EntityLoader, () => {
     );
     await entityLoader.invalidateFieldsAsync({ customIdField: 'hello' } as any);
     verify(
-      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' }))
+      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' } as any))
     ).once();
   });
 
@@ -270,7 +270,7 @@ describe(EntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock(EntityDataManager);
+    const dataManagerMock = mock<EntityDataManager<TestFields>>();
     const dataManagerInstance = instance(dataManagerMock);
 
     const entityMock = mock(TestEntity);
@@ -287,7 +287,7 @@ describe(EntityLoader, () => {
     );
     await entityLoader.invalidateEntityAsync(entityInstance);
     verify(
-      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' }))
+      dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: 'hello' } as any))
     ).once();
   });
 
@@ -295,7 +295,7 @@ describe(EntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicyMock = mock(TestEntityPrivacyPolicy);
-    const dataManagerMock = mock(EntityDataManager);
+    const dataManagerMock = mock<EntityDataManager<TestFields>>();
 
     when(
       dataManagerMock.loadManyByFieldEqualingAsync(anything(), anything(), anything())
@@ -329,7 +329,7 @@ describe(EntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock(EntityDataManager);
+    const dataManagerMock = mock<EntityDataManager<TestFields>>();
 
     const error = new Error();
 

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -784,7 +784,7 @@ describe(EntityMutatorFactory, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicyMock = mock(SimpleTestEntityPrivacyPolicy);
-    const databaseAdapter = instance(mock(EntityDatabaseAdapter));
+    const databaseAdapter = instance(mock<EntityDatabaseAdapter<SimpleTestFields>>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const entityLoaderFactory = instance(
       mock<
@@ -864,7 +864,7 @@ describe(EntityMutatorFactory, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(SimpleTestEntityPrivacyPolicy));
-    const databaseAdapterMock = mock(EntityDatabaseAdapter);
+    const databaseAdapterMock = mock<EntityDatabaseAdapter<SimpleTestFields>>();
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const entityLoaderFactory = instance(
       mock<

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -442,12 +442,12 @@ describe(EntityDataManager, () => {
   });
 
   it('handles DB errors as expected', async () => {
-    const databaseAdapterMock = mock(EntityDatabaseAdapter);
+    const databaseAdapterMock = mock<EntityDatabaseAdapter<TestFields>>();
     when(databaseAdapterMock.fetchManyWhereAsync(anything(), anything(), anything())).thenReject(
       new Error('DB query failed')
     );
 
-    const databaseAdapter: EntityDatabaseAdapter<TestFields> = instance(databaseAdapterMock);
+    const databaseAdapter = instance(databaseAdapterMock);
     const cacheAdapterProvider = new NoCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -42,7 +42,7 @@ export default abstract class PrivacyPolicyRule<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  abstract async evaluateAsync(
+  abstract evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     entity: TEntity

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,17 +559,17 @@
     which "^1.3.1"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.10.0"
+  version "0.11.0"
   dependencies:
     ioredis "^4.17.3"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.10.0"
+  version "0.11.0"
   dependencies:
     knex "^0.21.5"
 
 "@expo/entity@file:packages/entity":
-  version "0.10.0"
+  version "0.11.0"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"
@@ -9333,10 +9333,10 @@ typedoc@^0.17.6:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.10.2"
 
-typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uglify-js@^3.1.4:
   version "3.9.1"


### PR DESCRIPTION
# Why

Just general cleanup before releasing new version. No TS4.1-specific features are used.

# How

Upgrade package, fix errors.

# Test Plan

`yarn tsc`, run all tests.
