### PR TITLE
docs: fix docblock comment issue

### DIFF
--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -2,7 +2,7 @@ import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 
-/*
+/**
  * A validator is a way to specify entity mutation validation that runs within the
  * same transaction as the mutation itself before creating or updating an entity.
  */


### PR DESCRIPTION
# Why

This missing docblock star causes the docblock not to be included in .d.ts files or the typedoc generated documentation.

# How

Add `*`

# Test Plan

Wait for CI
