### PR TITLE
fix: mutation validator and trigger cyclic import structure

### DIFF
--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -159,7 +159,7 @@ const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: PostgresTriggerTestEntity,
   entityConfiguration: postgresTestEntityConfiguration,
   privacyPolicyClass: PostgresTriggerTestEntityPrivacyPolicy,
-  mutationTriggers: {
+  mutationTriggers: () => ({
     beforeCreate: [new ThrowConditionallyTrigger('name', 'beforeCreate')],
     afterCreate: [new ThrowConditionallyTrigger('name', 'afterCreate')],
     beforeUpdate: [new ThrowConditionallyTrigger('name', 'beforeUpdate')],
@@ -169,5 +169,5 @@ const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
     beforeAll: [new ThrowConditionallyTrigger('name', 'beforeAll')],
     afterAll: [new ThrowConditionallyTrigger('name', 'afterAll')],
     afterCommit: [new ThrowConditionallyNonTransactionalTrigger('name', 'afterCommit')],
-  },
+  }),
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -141,5 +141,5 @@ const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
   entityClass: PostgresValidatorTestEntity,
   entityConfiguration: postgresTestEntityConfiguration,
   privacyPolicyClass: PostgresValidatorTestEntityPrivacyPolicy,
-  mutationValidators: [new ThrowConditionallyTrigger('name', 'beforeCreateAndBeforeUpdate')],
+  mutationValidators: () => [new ThrowConditionallyTrigger('name', 'beforeCreateAndBeforeUpdate')],
 });

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -73,14 +73,14 @@ export class EntityCompanionDefinition<
   >;
   readonly entityConfiguration: EntityConfiguration<TFields>;
   readonly privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
-  readonly mutationValidators: EntityMutationValidator<
+  readonly mutationValidators: () => EntityMutationValidator<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
   >[];
-  readonly mutationTriggers: EntityMutationTriggerConfiguration<
+  readonly mutationTriggers: () => EntityMutationTriggerConfiguration<
     TFields,
     TID,
     TViewerContext,
@@ -93,8 +93,8 @@ export class EntityCompanionDefinition<
     entityClass,
     entityConfiguration,
     privacyPolicyClass,
-    mutationValidators = [],
-    mutationTriggers = {},
+    mutationValidators = () => [],
+    mutationTriggers = () => ({}),
     entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
   }: {
     entityClass: IEntityClass<
@@ -107,14 +107,14 @@ export class EntityCompanionDefinition<
     >;
     entityConfiguration: EntityConfiguration<TFields>;
     privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
-    mutationValidators?: EntityMutationValidator<
+    mutationValidators?: () => EntityMutationValidator<
       TFields,
       TID,
       TViewerContext,
       TEntity,
       TSelectedFields
     >[];
-    mutationTriggers?: EntityMutationTriggerConfiguration<
+    mutationTriggers?: () => EntityMutationTriggerConfiguration<
       TFields,
       TID,
       TViewerContext,
@@ -213,8 +213,8 @@ export default class EntityCompanionProvider {
         entityCompanionDefinition.entityClass,
         tableDataCoordinator,
         entityCompanionDefinition.privacyPolicyClass,
-        entityCompanionDefinition.mutationValidators,
-        entityCompanionDefinition.mutationTriggers,
+        entityCompanionDefinition.mutationValidators(),
+        entityCompanionDefinition.mutationTriggers(),
         this.metricsAdapter
       );
     });


### PR DESCRIPTION
# Why

Similar to https://github.com/expo/entity/pull/89 and https://github.com/expo/entity/pull/93, we need to do the same for validators and triggers in case those import entities themselves.

I tried rethinking this whole thing and just making the companion definition a function (`static getCompanionDefinition(): () => EntityCompanionDefinition`) but it made things less clean to define (had to remove top-level consts containing companion definitions to reap benefits) and made things less composable (because consts are no longer possible, can't be shared).

# How

Make the params functions similar to other PR examples above.

# Test Plan

Run all tests.
