### PR TITLE
feat: add mutation type to validator and trigger execute functions

### DIFF
--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -1,3 +1,4 @@
+import { EntityMutationInfo } from './EntityMutator';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -78,7 +79,8 @@ export abstract class EntityMutationTrigger<
   abstract executeAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    entity: TEntity
+    entity: TEntity,
+    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void>;
 }
 
@@ -93,5 +95,9 @@ export abstract class EntityNonTransactionalMutationTrigger<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  abstract executeAsync(viewerContext: TViewerContext, entity: TEntity): Promise<void>;
+  abstract executeAsync(
+    viewerContext: TViewerContext,
+    entity: TEntity,
+    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+  ): Promise<void>;
 }

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -1,3 +1,4 @@
+import { EntityMutationInfo } from './EntityMutator';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -16,6 +17,7 @@ export default abstract class EntityMutationValidator<
   abstract executeAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    entity: TEntity
+    entity: TEntity,
+    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void>;
 }

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -109,7 +109,7 @@ export default class EntityMutatorFactory<
       this.entityLoaderFactory,
       this.databaseAdapter,
       this.metricsAdapter,
-      existingEntity.getAllDatabaseFields()
+      existingEntity
     );
   }
 


### PR DESCRIPTION
# Why

It's sometimes helpful to have information about what type of mutation is being executed when running validators/triggers, and in the case of update mutations what the previous value was. This is similar to the functionality expressible in rails with [ActiveModel::Dirty](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html).

Some examples:
- Only allow valid field state transitions on update mutations (finite state machine)
- Run only some logic on update in a validator

# How

Add mutation info object to trigger and validator execution functions

# Test Plan

Run tests.
