### PR TITLE
fix: typescript typedef of EntityMutationInfo

### DIFF
--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -10,6 +10,7 @@ import {
   EntityMutationTrigger,
   EntityQueryContext,
   EntityNonTransactionalMutationTrigger,
+  EntityMutationInfo,
 } from '@expo/entity';
 import Knex from 'knex';
 
@@ -109,7 +110,13 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
   async executeAsync(
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
-    entity: PostgresTriggerTestEntity
+    entity: PostgresTriggerTestEntity,
+    _mutationInfo: EntityMutationInfo<
+      PostgresTriggerTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresTriggerTestEntity
+    >
   ): Promise<void> {
     if (entity.getField(this.fieldName) === this.badValue) {
       throw new Error(`${this.fieldName} cannot have value ${this.badValue}`);

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -9,6 +9,7 @@ import {
   Entity,
   EntityMutationTrigger,
   EntityQueryContext,
+  EntityMutationInfo,
 } from '@expo/entity';
 import Knex from 'knex';
 
@@ -111,7 +112,13 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
   async executeAsync(
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
-    entity: PostgresValidatorTestEntity
+    entity: PostgresValidatorTestEntity,
+    _mutationInfo: EntityMutationInfo<
+      PostgresValidatorTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresValidatorTestEntity
+    >
   ): Promise<void> {
     if (entity.getField(this.fieldName) === this.badValue) {
       throw new Error(`${this.fieldName} cannot have value ${this.badValue}`);

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -32,7 +32,7 @@ export type EntityMutationInfo<
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields
+  TSelectedFields extends keyof TFields = keyof TFields
 > =
   | {
       type: EntityMutationType.CREATE;


### PR DESCRIPTION
# Why

ef40fa5e9cdf53e25e78a9423c698e6d1c9737af didn't have a default for TSelectedFields, making implementors need to specify it unnecessarily in the default case.

# How

Add a default.

# Test Plan

`yarn tsc`
