### PR TITLE
feat: secondary cache loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "root",
   "private": true,
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "tsc": "lerna run tsc",
     "clean": "lerna run clean",
@@ -28,6 +30,7 @@
     "eslint-plugin-tsdoc": "^0.2.11",
     "jest": "^26.6.3",
     "lerna": "^3.22.1",
+    "nullthrows": "^1.1.1",
     "pg": "^8.3.2",
     "prettier": "^2.1.0",
     "ts-jest": "~26.4.4",
@@ -39,6 +42,7 @@
   "dependencies": {
     "@expo/entity": "file:packages/entity",
     "@expo/entity-cache-adapter-redis": "file:packages/entity-cache-adapter-redis",
-    "@expo/entity-database-adapter-knex": "file:packages/entity-database-adapter-knex"
+    "@expo/entity-database-adapter-knex": "file:packages/entity-database-adapter-knex",
+    "@expo/entity-secondary-cache-redis": "file:packages/entity-secondary-cache-redis"
   }
 }

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf build coverage coverage-integration",
-    "lint": "eslint src --ext '.ts'",
+    "lint": "eslint src",
     "test": "jest --rootDir . --config ../../resources/jest.config.js",
     "integration": "../../resources/run-with-docker yarn integration-no-setup",
     "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -1,0 +1,105 @@
+import { CacheLoadResult, CacheStatus } from '@expo/entity';
+import { Redis } from 'ioredis';
+
+import wrapNativeRedisCall from './errors/wrapNativeRedisCall';
+
+// Sentinel value we store in Redis to negatively cache a database miss.
+// The sentinel value is distinct from any (positively) cached value.
+const DOES_NOT_EXIST_REDIS = '';
+
+export interface GenericRedisCacheContext {
+  /**
+   * Instance of ioredis.Redis
+   */
+  redisClient: Redis;
+
+  /**
+   * TTL for caching database hits. Successive entity loads within this TTL
+   * will be read from cache (unless invalidated).
+   */
+  ttlSecondsPositive: number;
+
+  /**
+   * TTL for negatively caching database misses. Successive entity loads within
+   * this TTL will be assumed not present in the database (unless invalidated).
+   */
+  ttlSecondsNegative: number;
+}
+
+export default class GenericRedisCacher {
+  constructor(private readonly context: GenericRedisCacheContext) {}
+
+  public async loadManyAsync(
+    keys: readonly string[]
+  ): Promise<ReadonlyMap<string, CacheLoadResult>> {
+    if (keys.length === 0) {
+      return new Map();
+    }
+
+    const redisResults = await wrapNativeRedisCall(() => this.context.redisClient.mget(...keys));
+
+    const results = new Map<string, CacheLoadResult>();
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const redisResult = redisResults[i];
+
+      if (redisResult === DOES_NOT_EXIST_REDIS) {
+        results.set(key, {
+          status: CacheStatus.NEGATIVE,
+        });
+      } else if (redisResult) {
+        results.set(key, {
+          status: CacheStatus.HIT,
+          item: JSON.parse(redisResult),
+        });
+      } else {
+        results.set(key, {
+          status: CacheStatus.MISS,
+        });
+      }
+    }
+    return results;
+  }
+
+  public async cacheManyAsync(objectMap: ReadonlyMap<string, object>): Promise<void> {
+    if (objectMap.size === 0) {
+      return;
+    }
+
+    let redisTransaction = this.context.redisClient.multi();
+    objectMap.forEach((object, key) => {
+      redisTransaction = redisTransaction.set(
+        key,
+        JSON.stringify(object),
+        'EX',
+        this.context.ttlSecondsPositive
+      );
+    });
+    await wrapNativeRedisCall(() => redisTransaction.exec());
+  }
+
+  public async cacheDBMissesAsync(keys: string[]): Promise<void> {
+    if (keys.length === 0) {
+      return;
+    }
+
+    let redisTransaction = this.context.redisClient.multi();
+    keys.forEach((key) => {
+      redisTransaction = redisTransaction.set(
+        key,
+        DOES_NOT_EXIST_REDIS,
+        'EX',
+        this.context.ttlSecondsNegative
+      );
+    });
+    await wrapNativeRedisCall(() => redisTransaction.exec());
+  }
+
+  public async invalidateManyAsync(keys: string[]): Promise<void> {
+    if (keys.length === 0) {
+      return;
+    }
+
+    await wrapNativeRedisCall(() => this.context.redisClient.del(...keys));
+  }
+}

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
@@ -38,21 +38,21 @@ describe(RedisCacheAdapter, () => {
   });
 
   it('has correct caching behavior', async () => {
-    const vc1 = new TestViewerContext(
+    const viewerContext = new TestViewerContext(
       createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
     );
-    const cacheAdapter = vc1.entityCompanionProvider.getCompanionForEntity(
+    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
       RedisTestEntity,
       RedisTestEntity.getCompanionDefinition()
     )['tableDataCoordinator']['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
-    const entity1Created = await RedisTestEntity.creator(vc1)
+    const entity1Created = await RedisTestEntity.creator(viewerContext)
       .setField('name', 'blah')
       .enforceCreateAsync();
 
     // loading an entity should put it in cache
-    const entity1 = await RedisTestEntity.loader(vc1)
+    const entity1 = await RedisTestEntity.loader(viewerContext)
       .enforcing()
       .loadByIDAsync(entity1Created.getID());
 
@@ -68,7 +68,9 @@ describe(RedisCacheAdapter, () => {
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
 
-    const entityNonExistentResult = await RedisTestEntity.loader(vc1).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult = await RedisTestEntity.loader(viewerContext).loadByIDAsync(
+      nonExistentId
+    );
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedValue = await redisCacheAdapterContext.redisClient.get(
@@ -77,11 +79,13 @@ describe(RedisCacheAdapter, () => {
     expect(nonExistentCachedValue).toEqual('');
 
     // load again through entities framework to ensure it reads negative result
-    const entityNonExistentResult2 = await RedisTestEntity.loader(vc1).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult2 = await RedisTestEntity.loader(viewerContext).loadByIDAsync(
+      nonExistentId
+    );
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly
-    await RedisTestEntity.loader(vc1).invalidateFieldsAsync(entity1.getAllFields());
+    await RedisTestEntity.loader(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
     const cachedValueNull = await redisCacheAdapterContext.redisClient.get(
       cacheKeyMaker('id', entity1.getID())
     );
@@ -89,16 +93,18 @@ describe(RedisCacheAdapter, () => {
   });
 
   it('caches and restores date fields', async () => {
-    const vc1 = new TestViewerContext(
+    const viewerContext = new TestViewerContext(
       createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
     );
     const date = new Date();
     const entity1 = await enforceAsyncResult(
-      RedisTestEntity.creator(vc1).setField('dateField', date).createAsync()
+      RedisTestEntity.creator(viewerContext).setField('dateField', date).createAsync()
     );
     expect(entity1.getField('dateField')).toEqual(date);
 
-    const entity2 = await RedisTestEntity.loader(vc1).enforcing().loadByIDAsync(entity1.getID());
+    const entity2 = await RedisTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity1.getID());
     expect(entity2.getField('dateField')).toEqual(date);
 
     // simulate new request
@@ -107,5 +113,27 @@ describe(RedisCacheAdapter, () => {
     );
     const entity3 = await RedisTestEntity.loader(vc2).enforcing().loadByIDAsync(entity1.getID());
     expect(entity3.getField('dateField')).toEqual(date);
+  });
+
+  it('caches and restores empty string field keys', async () => {
+    const viewerContext = new TestViewerContext(
+      createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
+    );
+    const entity1 = await enforceAsyncResult(
+      RedisTestEntity.creator(viewerContext).setField('name', '').createAsync()
+    );
+    const entity2 = await RedisTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByFieldEqualingAsync('name', '');
+    expect(entity2?.getID()).toEqual(entity1.getID());
+
+    // simulate new request
+    const vc2 = new TestViewerContext(
+      createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
+    );
+    const entity3 = await RedisTestEntity.loader(vc2)
+      .enforcing()
+      .loadByFieldEqualingAsync('name', '');
+    expect(entity3?.getID()).toEqual(entity1.getID());
   });
 });

--- a/packages/entity-cache-adapter-redis/src/index.ts
+++ b/packages/entity-cache-adapter-redis/src/index.ts
@@ -8,3 +8,5 @@ export { default as RedisCacheAdapter } from './RedisCacheAdapter';
 export * from './RedisCacheAdapter';
 export { default as RedisCacheAdapterProvider } from './RedisCacheAdapterProvider';
 export * from './RedisCommon';
+export { default as GenericRedisCacher } from './GenericRedisCacher';
+export * from './GenericRedisCacher';

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -78,6 +78,7 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
     }),
     name: new StringField({
       columnName: 'name',
+      cache: true,
     }),
     dateField: new DateField({
       columnName: 'date_field',

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf build coverage coverage-integration",
-    "lint": "eslint src --ext '.ts'",
+    "lint": "eslint src",
     "test": "jest --rootDir . --config ../../resources/jest.config.js --passWithNoTests",
     "integration": "../../resources/run-with-docker yarn integration-no-setup",
     "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",

--- a/packages/entity-example/package.json
+++ b/packages/entity-example/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf build coverage coverage-integration",
-    "lint": "eslint src --ext '.ts'",
+    "lint": "eslint src",
     "test": "jest --rootDir . --config ../../resources/jest.config.js",
     "integration": "../../resources/run-with-docker yarn integration-no-setup",
     "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",

--- a/packages/entity-full-integration-tests/package.json
+++ b/packages/entity-full-integration-tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf build coverage coverage-integration",
-    "lint": "eslint src --ext '.ts'",
+    "lint": "eslint src",
     "test": "jest --rootDir . --config ../../resources/jest.config.js --passWithNoTests",
     "integration": "../../resources/run-with-docker yarn integration-no-setup",
     "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",

--- a/packages/entity-secondary-cache-redis/CHANGELOG.md
+++ b/packages/entity-secondary-cache-redis/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+

--- a/packages/entity-secondary-cache-redis/README.md
+++ b/packages/entity-secondary-cache-redis/README.md
@@ -1,0 +1,25 @@
+# `@expo/entity-secondary-cache-redis`
+
+[ioredis](https://github.com/luin/ioredis) secondary cache for `@expo/entity`.
+
+[Documentation](https://expo.github.io/entity/modules/_expo_secondary_cache_redis.html)
+
+## Usage
+
+1. Create a concrete implementation of abstract class `EntitySecondaryCacheLoader`, in this example `TestEntitySecondaryCacheLoader`. The underlying data can come from anywhere, but an entity is constructed from the data and then authorized for the viewer.
+2. Create an instance of your `EntitySecondaryCacheLoader`, passing in a `RedisSecondaryEntityCache`.
+    ```typescript
+    const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
+      new RedisSecondaryEntityCache(
+        redisTestEntityConfiguration,
+        redisCacheAdapterContext,
+        (loadParams) => `${loadParams.id}`
+      ),
+      RedisTestEntity.loader(vc1)
+    );
+    ```
+3. Load entities through it:
+    ```typescript
+    const loadParams = { id: createdEntity.getID() };
+    const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    ```

--- a/packages/entity-secondary-cache-redis/README.md
+++ b/packages/entity-secondary-cache-redis/README.md
@@ -15,7 +15,7 @@
         redisCacheAdapterContext,
         (loadParams) => `${loadParams.id}`
       ),
-      RedisTestEntity.loader(vc1)
+      RedisTestEntity.loader(viewerContext)
     );
     ```
 3. Load entities through it:

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf build coverage coverage-integration",
-    "lint": "eslint src --ext '.ts'",
+    "lint": "eslint src",
     "test": "jest --rootDir . --config ../../resources/jest.config.js --passWithNoTests",
     "integration": "../../resources/run-with-docker yarn integration-no-setup",
     "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@expo/entity-secondary-cache-redis",
+  "version": "0.14.1",
+  "description": "Redis secondary cache for @expo/entity",
+  "files": [
+    "build",
+    "src"
+  ],
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "tsc": "tsc",
+    "clean": "rm -rf build coverage coverage-integration",
+    "lint": "eslint src --ext '.ts'",
+    "test": "jest --rootDir . --config ../../resources/jest.config.js --passWithNoTests",
+    "integration": "../../resources/run-with-docker yarn integration-no-setup",
+    "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",
+    "barrelsby": "barrelsby --directory src --location top --exclude tests__ --singleQuotes --exportDefault --delete"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "keywords": [
+    "entity"
+  ],
+  "author": "Expo",
+  "license": "MIT",
+  "peerDependencies": {
+    "@expo/entity": "*",
+    "@expo/entity-cache-adapter-redis": "*"
+  },
+  "dependencies": {
+    "ioredis": "^4.17.3"
+  },
+  "devDependencies": {
+    "@expo/entity": "^0.14.1",
+    "@expo/entity-cache-adapter-redis": "^0.14.1",
+    "nullthrows": "^1.1.1"
+  }
+}

--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -1,0 +1,130 @@
+import {
+  CacheStatus,
+  EntityConfiguration,
+  filterMap,
+  ISecondaryEntityCache,
+  transformCacheObjectToFields,
+  transformFieldsToCacheObject,
+  zipToMap,
+} from '@expo/entity';
+import {
+  GenericRedisCacheContext,
+  GenericRedisCacher,
+  redisTransformerMap,
+} from '@expo/entity-cache-adapter-redis';
+import invariant from 'invariant';
+
+/**
+ * A custom secondary read through entity cache is a way to add a custom second layer of caching for a particular
+ * single entity load. One common way this may be used is to add a second layer of caching in a hot path that makes
+ * a call to {@link EntityLoader.loadManyByFieldEqualityConjunctionAsync} that returns a single entity.
+ */
+export default class RedisSecondaryEntityCache<TFields, TLoadParams>
+  implements ISecondaryEntityCache<TFields, TLoadParams> {
+  private readonly genericRedisCacher: GenericRedisCacher;
+
+  constructor(
+    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    genericRedisCacheContext: GenericRedisCacheContext,
+    private readonly constructRedisKey: (params: Readonly<TLoadParams>) => string
+  ) {
+    this.genericRedisCacher = new GenericRedisCacher(genericRedisCacheContext);
+  }
+
+  /**
+   * Read-through cache function. Steps:
+   *
+   * 1. Check for cached objects
+   * 2. Query the fetcher for loadParams not in the cache
+   * 3. Cache the results from the fetcher
+   * 4. Negatively cache anything missing from the fetcher
+   * 5. Return the full set of data for the query.
+   *
+   * @param loadParamsArray - array of loadParams to load from the cache
+   * @param fetcher - closure used to provide underlying data source objects for loadParams
+   * @returns map from loadParams to the entity field object
+   */
+  public async loadManyThroughAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[],
+    fetcher: (
+      fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
+    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields>>>
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields>>> {
+    const redisKeys = loadParamsArray.map(this.constructRedisKey);
+    const redisKeyToLoadParamsMap = zipToMap(redisKeys, loadParamsArray);
+
+    const cacheLoadResults = await this.genericRedisCacher.loadManyAsync(redisKeys);
+
+    invariant(
+      cacheLoadResults.size === loadParamsArray.length,
+      `${this.constructor.name} loadMany should return a result for each key`
+    );
+
+    const redisKeysToFetch = Array.from(
+      filterMap(
+        cacheLoadResults,
+        (cacheLoadResult) => cacheLoadResult.status === CacheStatus.MISS
+      ).keys()
+    );
+
+    // put transformed cache hits in result map
+    const results: Map<Readonly<TLoadParams>, Readonly<TFields>> = new Map();
+    cacheLoadResults.forEach((cacheLoadResult, redisKey) => {
+      if (cacheLoadResult.status === CacheStatus.HIT) {
+        const loadParams = redisKeyToLoadParamsMap.get(redisKey);
+        invariant(loadParams !== undefined, 'load params should be in redis key map');
+        results.set(
+          loadParams,
+          transformCacheObjectToFields(
+            this.entityConfiguration,
+            redisTransformerMap,
+            cacheLoadResult.item
+          )
+        );
+      }
+    });
+
+    // fetch any misses from DB, add DB objects to results, cache DB results, inform cache of any missing DB results
+    if (redisKeysToFetch.length > 0) {
+      const loadParamsToFetch = redisKeysToFetch.map((redisKey) => {
+        const loadParams = redisKeyToLoadParamsMap.get(redisKey);
+        invariant(loadParams !== undefined, 'load params should be in redis key map');
+        return loadParams;
+      });
+      const fetchResults = await fetcher(loadParamsToFetch);
+
+      const fetchMisses = loadParamsToFetch.filter((loadParams) => {
+        return fetchResults.get(loadParams) === undefined;
+      });
+
+      const objectsToCache: Map<string, object> = new Map();
+      for (const [loadParams, object] of fetchResults.entries()) {
+        if (object) {
+          objectsToCache.set(
+            this.constructRedisKey(loadParams),
+            transformFieldsToCacheObject(this.entityConfiguration, redisTransformerMap, object)
+          );
+          results.set(loadParams, object);
+        }
+      }
+
+      await Promise.all([
+        this.genericRedisCacher.cacheManyAsync(objectsToCache),
+        this.genericRedisCacher.cacheDBMissesAsync(fetchMisses.map(this.constructRedisKey)),
+      ]);
+    }
+
+    return results;
+  }
+
+  /**
+   * Invalidate the cache for objects cached by constructRedisKey(loadParams).
+   *
+   * @param loadParamsArray - load params to invalidate
+   */
+  public async invalidateManyAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[]
+  ): Promise<void> {
+    await this.genericRedisCacher.invalidateManyAsync(loadParamsArray.map(this.constructRedisKey));
+  }
+}

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -1,0 +1,114 @@
+import { EntitySecondaryCacheLoader, mapMapAsync, ViewerContext } from '@expo/entity';
+import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
+import Redis from 'ioredis';
+import nullthrows from 'nullthrows';
+import { URL } from 'url';
+
+import RedisSecondaryEntityCache from '../RedisSecondaryEntityCache';
+import RedisTestEntity, {
+  redisTestEntityConfiguration,
+  RedisTestEntityFields,
+  RedisTestEntityPrivacyPolicy,
+} from '../testfixtures/RedisTestEntity';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../testfixtures/createRedisIntegrationTestEntityCompanionProvider';
+
+class TestViewerContext extends ViewerContext {}
+
+type TestLoadParams = { id: string };
+
+class TestSecondaryRedisCacheLoader extends EntitySecondaryCacheLoader<
+  TestLoadParams,
+  RedisTestEntityFields,
+  string,
+  TestViewerContext,
+  RedisTestEntity,
+  RedisTestEntityPrivacyPolicy
+> {
+  public loadCount = 0;
+
+  protected async fetchObjectsFromDatabaseAsync(
+    loadParamsArray: readonly Readonly<TestLoadParams>[]
+  ): Promise<ReadonlyMap<Readonly<TestLoadParams>, Readonly<RedisTestEntityFields>>> {
+    this.loadCount += loadParamsArray.length;
+
+    const emptyMap = new Map(loadParamsArray.map((p) => [p, null]));
+    return await mapMapAsync(emptyMap, async (_value, loadParams) => {
+      return (
+        await this.entityLoader
+          .enforcing()
+          .loadManyByFieldEqualityConjunctionAsync([{ fieldName: 'id', fieldValue: loadParams.id }])
+      )[0].getAllFields();
+    });
+  }
+}
+
+describe(RedisSecondaryEntityCache, () => {
+  let redisCacheAdapterContext: RedisCacheAdapterContext;
+
+  beforeAll(() => {
+    redisCacheAdapterContext = {
+      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      makeKeyFn(...parts: string[]): string {
+        const delimiter = ':';
+        const escapedParts = parts.map((part) =>
+          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
+        );
+        return escapedParts.join(delimiter);
+      },
+      cacheKeyPrefix: 'test-',
+      cacheKeyVersion: 1,
+      ttlSecondsPositive: 86400, // 1 day
+      ttlSecondsNegative: 600, // 10 minutes
+    };
+  });
+
+  beforeEach(async () => {
+    await redisCacheAdapterContext.redisClient.flushdb();
+  });
+  afterAll(async () => {
+    redisCacheAdapterContext.redisClient.disconnect();
+  });
+
+  it('Loads through secondary loader, caches, and invalidates', async () => {
+    const vc1 = new TestViewerContext(
+      createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
+    );
+
+    const createdEntity = await RedisTestEntity.creator(vc1)
+      .setField('name', 'wat')
+      .enforceCreateAsync();
+
+    const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
+      new RedisSecondaryEntityCache(
+        redisTestEntityConfiguration,
+        redisCacheAdapterContext,
+        (loadParams) => `test-key-${loadParams.id}`
+      ),
+      RedisTestEntity.loader(vc1)
+    );
+
+    const loadParams = { id: createdEntity.getID() };
+    const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(nullthrows(results.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID()
+    );
+
+    expect(secondaryCacheLoader.loadCount).toEqual(1);
+
+    const results2 = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(nullthrows(results2.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID()
+    );
+
+    expect(secondaryCacheLoader.loadCount).toEqual(1);
+
+    await secondaryCacheLoader.invalidateManyAsync([loadParams]);
+
+    const results3 = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(nullthrows(results3.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID()
+    );
+
+    expect(secondaryCacheLoader.loadCount).toEqual(2);
+  });
+});

--- a/packages/entity-secondary-cache-redis/src/index.ts
+++ b/packages/entity-secondary-cache-redis/src/index.ts
@@ -1,0 +1,7 @@
+/* eslint-disable tsdoc/syntax */
+/**
+ * @packageDocumentation
+ * @module @expo/entity-secondary-cache-redis
+ */
+
+export { default as RedisSecondaryEntityCache } from './RedisSecondaryEntityCache';

--- a/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
@@ -3,7 +3,6 @@ import {
   EntityPrivacyPolicy,
   ViewerContext,
   UUIDField,
-  DateField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
@@ -13,7 +12,6 @@ import {
 export type RedisTestEntityFields = {
   id: string;
   name: string;
-  dateField: Date | null;
 };
 
 export default class RedisTestEntity extends Entity<RedisTestEntityFields, string, ViewerContext> {
@@ -78,9 +76,6 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
     }),
     name: new StringField({
       columnName: 'name',
-    }),
-    dateField: new DateField({
-      columnName: 'date_field',
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
@@ -72,7 +72,6 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
   schema: {
     id: new UUIDField({
       columnName: 'id',
-      cache: true,
     }),
     name: new StringField({
       columnName: 'name',

--- a/packages/entity-secondary-cache-redis/src/testfixtures/createRedisIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-secondary-cache-redis/src/testfixtures/createRedisIntegrationTestEntityCompanionProvider.ts
@@ -1,0 +1,37 @@
+import {
+  NoOpEntityMetricsAdapter,
+  IEntityMetricsAdapter,
+  EntityCompanionProvider,
+  StubQueryContextProvider,
+  StubDatabaseAdapterProvider,
+} from '@expo/entity';
+import {
+  RedisCacheAdapterContext,
+  RedisCacheAdapterProvider,
+} from '@expo/entity-cache-adapter-redis';
+
+export const createRedisIntegrationTestEntityCompanionProvider = (
+  redisCacheAdapterContext: RedisCacheAdapterContext,
+  metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
+): EntityCompanionProvider => {
+  return new EntityCompanionProvider(
+    metricsAdapter,
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new StubDatabaseAdapterProvider(),
+          queryContextProvider: StubQueryContextProvider,
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'redis',
+        {
+          cacheAdapterProvider: new RedisCacheAdapterProvider(redisCacheAdapterContext),
+        },
+      ],
+    ])
+  );
+};

--- a/packages/entity-secondary-cache-redis/tsconfig.json
+++ b/packages/entity-secondary-cache-redis/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+  },
+  "include": ["src"]
+}

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf build coverage coverage-integration",
-    "lint": "eslint src --ext '.ts'",
+    "lint": "eslint src",
     "test": "jest --rootDir . --config ../../resources/jest.config.js",
     "integration": "../../resources/run-with-docker yarn integration-no-setup",
     "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -49,7 +49,7 @@ export default class EntityLoader<
       TSelectedFields
     >,
     private readonly privacyPolicy: TPrivacyPolicy,
-    public readonly dataManager: EntityDataManager<TFields>
+    private readonly dataManager: EntityDataManager<TFields>
   ) {}
 
   /**

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -21,8 +21,8 @@ export interface ISecondaryEntityCache<TFields, TLoadParams> {
     loadParamsArray: readonly Readonly<TLoadParams>[],
     fetcher: (
       fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
-    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields>>>
-  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields>>>;
+    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>>
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>>;
 
   /**
    * Invalidate the cache for objects cached by loadParams.
@@ -77,7 +77,7 @@ export default abstract class EntitySecondaryCacheLoader<
    */
   public async loadManyAsync(
     loadParamsArray: readonly Readonly<TLoadParams>[]
-  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Result<TEntity>>> {
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Result<TEntity> | null>> {
     const loadParamsToFieldObjects = await this.secondaryEntityCache.loadManyThroughAsync(
       loadParamsArray,
       this.fetchObjectsFromDatabaseAsync.bind(this)
@@ -85,9 +85,9 @@ export default abstract class EntitySecondaryCacheLoader<
 
     // convert value to and from array to reuse complex code
     const entitiesMap = await this.entityLoader.constructAndAuthorizeEntitiesAsync(
-      mapMap(loadParamsToFieldObjects, (fieldObject) => [fieldObject])
+      mapMap(loadParamsToFieldObjects, (fieldObject) => (fieldObject ? [fieldObject] : []))
     );
-    return mapMap(entitiesMap, (fieldObjects) => fieldObjects[0]);
+    return mapMap(entitiesMap, (fieldObjects) => fieldObjects[0] ?? null);
   }
 
   /**
@@ -108,5 +108,5 @@ export default abstract class EntitySecondaryCacheLoader<
    */
   protected abstract fetchObjectsFromDatabaseAsync(
     loadParamsArray: readonly Readonly<TLoadParams>[]
-  ): Promise<ReadonlyMap<Readonly<Readonly<TLoadParams>>, Readonly<TFields>>>;
+  ): Promise<ReadonlyMap<Readonly<Readonly<TLoadParams>>, Readonly<TFields> | null>>;
 }

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -1,0 +1,112 @@
+import { Result } from '@expo/results';
+
+import EntityLoader from './EntityLoader';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+import { mapMap } from './utils/collections/maps';
+
+/**
+ * An interface that knows how to load many objects from a cache by load params and invalidate
+ * those same load params.
+ */
+export interface ISecondaryEntityCache<TFields, TLoadParams> {
+  /**
+   * Read-through cache function.
+   * @param loadParamsArray - array of loadParams to load from the cache
+   * @param fetcher - closure used to provide underlying data source objects for loadParams
+   * @returns map from loadParams to the entity field object
+   */
+  loadManyThroughAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[],
+    fetcher: (
+      fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
+    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields>>>
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields>>>;
+
+  /**
+   * Invalidate the cache for objects cached by loadParams.
+   *
+   * @param loadParamsArray - array of load params objects to invalidate
+   */
+  invalidateManyAsync(loadParamsArray: readonly Readonly<TLoadParams>[]): Promise<void>;
+}
+
+/**
+ * A secondary cache loader allows for arbitrary cache keying for load params, which are a set of params used to load
+ * a single entity field object.
+ *
+ * Note that this cache cannot be automatically invalidated like other entity caches so it must be manually invalidated
+ * when the underlying data of a cache key could be stale.
+ *
+ * This is most commonly used to further optimize hot paths that cannot make use of normal entity cache loading
+ * due to use of a non-unique-field-based {@link EntityLoader} method like `loadManyByFieldEqualityConjunctionAsync` or
+ * `loadManyByRawWhereClauseAsync`.
+ */
+export default abstract class EntitySecondaryCacheLoader<
+  TLoadParams,
+  TFields,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields
+> {
+  constructor(
+    private readonly secondaryEntityCache: ISecondaryEntityCache<TFields, TLoadParams>,
+    protected readonly entityLoader: EntityLoader<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >
+  ) {}
+
+  /**
+   * Load many by load params objects
+   *
+   * @param loadParamsArray - array of loadParams to load through the cache
+   */
+  public async loadManyAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[]
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Result<TEntity>>> {
+    const loadParamsToFieldObjects = await this.secondaryEntityCache.loadManyThroughAsync(
+      loadParamsArray,
+      this.fetchObjectsFromDatabaseAsync.bind(this)
+    );
+
+    // convert value to and from array to reuse complex code
+    const entitiesMap = await this.entityLoader.constructAndAuthorizeEntitiesAsync(
+      mapMap(loadParamsToFieldObjects, (fieldObject) => [fieldObject])
+    );
+    return mapMap(entitiesMap, (fieldObjects) => fieldObjects[0]);
+  }
+
+  /**
+   * Invalidate the cache for objects cached by loadParams.
+   *
+   * @param loadParamsArray - array of load params objects to invalidate
+   */
+  public async invalidateManyAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[]
+  ): Promise<void> {
+    await this.secondaryEntityCache.invalidateManyAsync(loadParamsArray);
+  }
+
+  /**
+   * Load through method called to fetch objects when load params objects are not in the cache
+   *
+   * @param loadParamsArray - array of load params objects to load
+   */
+  protected abstract fetchObjectsFromDatabaseAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[]
+  ): Promise<ReadonlyMap<Readonly<Readonly<TLoadParams>>, Readonly<TFields>>>;
+}

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -289,6 +289,7 @@ describe(EnforcingEntityLoader, () => {
       'invalidateEntityAsync',
       'tryConstructEntities',
       'validateFieldValues',
+      'constructAndAuthorizeEntitiesAsync',
     ];
     expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));
 

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -89,6 +89,12 @@ describe(EntityLoader, () => {
     const entityResultNumber4 = await entityLoader.loadByFieldEqualingAsync('numberField', 4);
     expect(entityResultNumber4).toBeNull();
 
+    const entityResultDuplicateValues = await entityLoader
+      .enforcing()
+      .loadManyByFieldEqualingManyAsync('stringField', ['huh', 'huh']);
+    expect(entityResultDuplicateValues.size).toBe(1);
+    expect(entityResultDuplicateValues.get('huh')?.map((m) => m.getID())).toEqual([id1, id2]);
+
     await expect(entityLoader.loadByFieldEqualingAsync('stringField', 'huh')).rejects.toThrowError(
       'loadByFieldEqualing: Multiple entities of type TestEntity found for stringField=huh'
     );

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -1,0 +1,107 @@
+import { anyOfClass, anything, deepEqual, instance, mock, spy, verify, when } from 'ts-mockito';
+
+import { EntityNonTransactionalQueryContext } from '../EntityQueryContext';
+import EntitySecondaryCacheLoader, { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader';
+import ViewerContext from '../ViewerContext';
+import SimpleTestEntity, {
+  SimpleTestEntityPrivacyPolicy,
+  SimpleTestFields,
+} from '../testfixtures/SimpleTestEntity';
+import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
+
+type TestLoadParams = { id: string };
+
+class TestSecondaryRedisCacheLoader extends EntitySecondaryCacheLoader<
+  TestLoadParams,
+  SimpleTestFields,
+  string,
+  ViewerContext,
+  SimpleTestEntity,
+  SimpleTestEntityPrivacyPolicy
+> {
+  protected async fetchObjectsFromDatabaseAsync(
+    _loadParamsArray: readonly Readonly<TestLoadParams>[]
+  ): Promise<ReadonlyMap<Readonly<TestLoadParams>, Readonly<SimpleTestFields>>> {
+    // unused
+    return new Map();
+  }
+}
+
+describe(EntitySecondaryCacheLoader, () => {
+  describe('loadManyAsync', () => {
+    it('calls into secondary cache with correct params', async () => {
+      const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
+
+      const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();
+      const loadParams = { id: createdEntity.getID() };
+
+      const secondaryEntityCacheMock = mock<
+        ISecondaryEntityCache<SimpleTestFields, TestLoadParams>
+      >();
+      when(
+        secondaryEntityCacheMock.loadManyThroughAsync(deepEqual([loadParams]), anything())
+      ).thenResolve(new Map());
+      const secondaryEntityCache = instance(secondaryEntityCacheMock);
+
+      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
+        secondaryEntityCache,
+        SimpleTestEntity.loader(vc1)
+      );
+
+      await secondaryCacheLoader.loadManyAsync([loadParams]);
+
+      verify(
+        secondaryEntityCacheMock.loadManyThroughAsync(deepEqual([loadParams]), anything())
+      ).once();
+    });
+
+    it('constructs and authorizes entities', async () => {
+      const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
+
+      const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();
+      const loadParams = { id: createdEntity.getID() };
+
+      const secondaryEntityCacheMock = mock<
+        ISecondaryEntityCache<SimpleTestFields, TestLoadParams>
+      >();
+      when(
+        secondaryEntityCacheMock.loadManyThroughAsync(deepEqual([loadParams]), anything())
+      ).thenResolve(new Map([[loadParams, createdEntity.getAllFields()]]));
+      const secondaryEntityCache = instance(secondaryEntityCacheMock);
+
+      const loader = SimpleTestEntity.loader(vc1);
+      const spiedPrivacyPolicy = spy(loader['privacyPolicy']);
+      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(secondaryEntityCache, loader);
+
+      const result = await secondaryCacheLoader.loadManyAsync([loadParams]);
+      expect(result.get(loadParams)?.enforceValue().getID()).toEqual(createdEntity.getID());
+
+      verify(
+        spiedPrivacyPolicy.authorizeReadAsync(
+          vc1,
+          anyOfClass(EntityNonTransactionalQueryContext),
+          anything()
+        )
+      ).once();
+    });
+  });
+
+  describe('invalidateManyAsync', () => {
+    it('calls invalidate on the secondary cache loader', async () => {
+      const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
+
+      const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();
+      const loadParams = { id: createdEntity.getID() };
+
+      const secondaryEntityCacheMock = mock<
+        ISecondaryEntityCache<SimpleTestFields, TestLoadParams>
+      >();
+      const secondaryEntityCache = instance(secondaryEntityCacheMock);
+      const loader = SimpleTestEntity.loader(vc1);
+      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(secondaryEntityCache, loader);
+      await secondaryCacheLoader.invalidateManyAsync([loadParams]);
+
+      verify(secondaryEntityCacheMock.invalidateManyAsync(deepEqual([loadParams]))).once();
+    });
+  });
+});

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -87,7 +87,7 @@ describe(EntitySecondaryCacheLoader, () => {
   });
 
   describe('invalidateManyAsync', () => {
-    it('calls invalidate on the secondary cache loader', async () => {
+    it('calls invalidate on the secondary cache', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
       const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -28,6 +28,8 @@ export { default as EntityNotFoundError } from './errors/EntityNotFoundError';
 export * from './EntityFields';
 export { default as EntityLoader } from './EntityLoader';
 export { default as EntityLoaderFactory } from './EntityLoaderFactory';
+export { default as EntitySecondaryCacheLoader } from './EntitySecondaryCacheLoader';
+export * from './EntitySecondaryCacheLoader';
 export * from './EntityMutator';
 export { default as EntityMutationValidator } from './EntityMutationValidator';
 export * from './EntityMutationTriggerConfiguration';

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -28,7 +28,7 @@ export type CacheLoadResult =
     };
 
 /**
- * A read through entity cache is responsible for coordinating a {@link EntityDatabaseAdapter} and
+ * A read-through entity cache is responsible for coordinating {@link EntityDatabaseAdapter} and
  * {@link EntityCacheAdapter} within the {@link EntityDataManager}.
  */
 export default class ReadThroughEntityCache<TFields> {

--- a/packages/entity/src/utils/collections/__tests__/maps-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/maps-test.ts
@@ -7,6 +7,7 @@ import {
   reduceMap,
   filterMap,
   reduceMapAsync,
+  mapKeys,
 } from '../maps';
 
 describe(computeIfAbsent, () => {
@@ -41,6 +42,19 @@ describe(mapMapAsync, () => {
     const map = new Map<string, string>([['hello', 'world']]);
     const map2 = await mapMapAsync(map, async () => await Promise.resolve(2));
     expect(map2.get('hello')).toEqual(2);
+  });
+});
+
+describe(mapKeys, () => {
+  it('maps keys', async () => {
+    const map = new Map<string, string>([
+      ['hello', 'world'],
+      ['amphibian', 'creature'],
+    ]);
+    const map2 = await mapKeys(map, (k) => k.length);
+    expect(map2.size).toEqual(2);
+    expect(map2.get(5)).toEqual('world');
+    expect(map2.get(9)).toEqual('creature');
   });
 });
 

--- a/packages/entity/src/utils/collections/maps.ts
+++ b/packages/entity/src/utils/collections/maps.ts
@@ -1,5 +1,13 @@
 import invariant from 'invariant';
 
+/**
+ * If the specified key is not already associated with a value in this map, attempts to compute
+ * its value using the given mapping function and enters it into this map unless null.
+ *
+ * @param map - map from which to get the key's value or compute and associate
+ * @param key - key for which to get the value or with which the computed value is to be associated
+ * @param mappingFunction - function to compute a value for key
+ */
 export const computeIfAbsent = <K, V>(
   map: Map<K, V>,
   key: K,
@@ -12,6 +20,12 @@ export const computeIfAbsent = <K, V>(
   return map.get(key)!;
 };
 
+/**
+ * Create a new Map by associating the value of mapper executed for each key in the source map.
+ *
+ * @param map - source map
+ * @param mapper - function to compute a value in the resulting map for the source key and value
+ */
 export const mapMap = <K, V, M>(
   map: ReadonlyMap<K, V>,
   mapper: (value: V, key: K) => M
@@ -23,6 +37,12 @@ export const mapMap = <K, V, M>(
   return resultingMap;
 };
 
+/**
+ * Create a new Map by associating the value of mapper executed for each key in the source map.
+ *
+ * @param map - source map
+ * @param mapper - asynchronous function to compute a value in the resulting map for the source key and value
+ */
 export const mapMapAsync = async function <K, V, M>(
   map: ReadonlyMap<K, V>,
   mapper: (value: V, key: K) => Promise<M>
@@ -38,6 +58,15 @@ export const mapMapAsync = async function <K, V, M>(
   return resultingMap;
 };
 
+/**
+ * Create a new Map by associating the value of each key with mapper executed for each key in the source map.
+ * The opposite of {@link mapMap}. In the event two source keys map to the same result key, the second source key's
+ * value will overwrite the first, in which case the cardinality of the returned map may be smaller than the
+ * source map's.
+ *
+ * @param map - source map
+ * @param mapper - function to compute a key in the resulting map for the source key and value
+ */
 export const mapKeys = <K, V, K2>(
   map: ReadonlyMap<K, V>,
   mapper: (key: K, value: V) => K2
@@ -49,6 +78,17 @@ export const mapKeys = <K, V, K2>(
   return resultingMap;
 };
 
+/**
+ * Create a new Map from each member of keys to the corresponding member of values.
+ *
+ * @example
+ * ```
+ * zipToMap([1, 2], ['a', 'b']) => Map({1: 'a', 2: 'b'})
+ * ```
+ *
+ * @param keys - keys
+ * @param values - corresponding ordered values for keys
+ */
 export const zipToMap = <K, V>(keys: readonly K[], values: readonly V[]): Map<K, V> => {
   invariant(
     keys.length === values.length,
@@ -62,6 +102,11 @@ export const zipToMap = <K, V>(keys: readonly K[], values: readonly V[]): Map<K,
   return resultingMap;
 };
 
+/**
+ * Create a new Map by inverting keys and values of specified map.
+ *
+ * @param map - map to invert
+ */
 export const invertMap = <K, V>(map: ReadonlyMap<K, V>): Map<V, K> => {
   const resultingMap = new Map();
   for (const [k, v] of map) {
@@ -70,6 +115,14 @@ export const invertMap = <K, V>(map: ReadonlyMap<K, V>): Map<V, K> => {
   return resultingMap;
 };
 
+/**
+ * Execute a reducer function on each element of the source map, resulting in a single output value.
+ *
+ * @param map - source map
+ * @param reducer - reducer function that takes an accumulated value, current iteration value, and current
+ *                  iteration key and returns a new accumulated value
+ * @param initialValue - initial accumulated value
+ */
 export const reduceMap = <K, V, A>(
   map: ReadonlyMap<K, V>,
   reducer: (accumulator: A, value: V, key: K) => A,
@@ -82,6 +135,15 @@ export const reduceMap = <K, V, A>(
   return newAccumulator;
 };
 
+/**
+ * Execute an asynchronous reducer function on each element of the source map, resulting in a single output value.
+ * Note that this does not parallelize asynchronous reduce steps so it should be used with caution.
+ *
+ * @param map - source map
+ * @param reducer - asynchronous reducer function that takes an accumulated value, current iteration value, and
+ *                  current iteration key and returns a new accumulated value
+ * @param initialValue - initial accumulated value
+ */
 export const reduceMapAsync = async <K, V, A>(
   map: ReadonlyMap<K, V>,
   reducer: (accumulator: A, value: V, key: K) => Promise<A>,
@@ -94,14 +156,31 @@ export const reduceMapAsync = async <K, V, A>(
   return newAccumulator;
 };
 
+/**
+ * Create a new Map containing all elements from the source map that pass the provided test predicate.
+ * @param map - source map
+ * @param predicate - function to test each element of source map
+ */
 export function filterMap<K, V, S extends V>(
   map: ReadonlyMap<K, V>,
   predicate: (value: V, key: K) => value is S
 ): Map<K, S>;
+
+/**
+ * Create a new Map containing all elements from the source map that pass the provided test predicate.
+ * @param map - source map
+ * @param predicate - function to test each element of source map
+ */
 export function filterMap<K, V>(
   map: ReadonlyMap<K, V>,
   predicate: (value: V, key: K) => boolean
 ): Map<K, V>;
+
+/**
+ * Create a new Map containing all elements from the source map that pass the provided test predicate.
+ * @param map - source map
+ * @param predicate - function to test each element of source map
+ */
 export function filterMap<K, V>(
   map: ReadonlyMap<K, V>,
   predicate: (value: V, key: K) => unknown

--- a/packages/entity/src/utils/collections/maps.ts
+++ b/packages/entity/src/utils/collections/maps.ts
@@ -38,6 +38,17 @@ export const mapMapAsync = async function <K, V, M>(
   return resultingMap;
 };
 
+export const mapKeys = <K, V, K2>(
+  map: ReadonlyMap<K, V>,
+  mapper: (key: K, value: V) => K2
+): Map<K2, V> => {
+  const resultingMap = new Map();
+  for (const [k, v] of map) {
+    resultingMap.set(mapper(k, v), v);
+  }
+  return resultingMap;
+};
+
 export const zipToMap = <K, V>(keys: readonly K[], values: readonly V[]): Map<K, V> => {
   invariant(
     keys.length === values.length,

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,17 +582,22 @@
     which "^1.3.1"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.13.0"
+  version "0.14.1"
   dependencies:
     ioredis "^4.17.3"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.13.0"
+  version "0.14.1"
   dependencies:
     knex "^0.21.5"
 
+"@expo/entity-secondary-cache-redis@file:packages/entity-secondary-cache-redis":
+  version "0.14.1"
+  dependencies:
+    ioredis "^4.17.3"
+
 "@expo/entity@file:packages/entity":
-  version "0.13.0"
+  version "0.14.1"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"
@@ -7253,6 +7258,11 @@ npmlog@^4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+nullthrows@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
+  integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
 number-is-nan@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Why

This PR adds a concept, `EntitySecondaryCacheLoader` that allows for arbitrary entity caching and retrieval based on arbitrary load params and configurable backing store load.

The idea is that there are cases in which the standard entity caching mechanism can't be used, generally loads using `loadManyByFieldEqualityConjunctionAsync` or `loadManyByRawWhereClauseAsync` (both with limit 1), that a cache would still be useful; most commonly hot/critical paths where DB indexes aren't sufficient.

This PR adds a general purpose read-through cache for an arbitrary load of a single entity field object by any means, which then constructs and authorizes that entity as normal. Note that cache invalidation cannot be inferred for this cacher, so it must be done manually in consumer code.

For example, Expo needs to load the most recent manifest for an app. To do this, `loadManyByFieldEqualityConjunctionAsync` with an order by timestamp and limit 1 is used. With this PR, a custom `EntitySecondaryCacheLoader` can be created and used at the callsite, and it can be invalidated manually when appropriate (when new manifest is written to the DB).

# Test Plan

Run all tests (including some new ones).
