### PR TITLE
fix: use column name instead of field name for redis cache key

### DIFF
--- a/packages/entity-cache-adapter-redis/src/RedisCacheAdapter.ts
+++ b/packages/entity-cache-adapter-redis/src/RedisCacheAdapter.ts
@@ -5,6 +5,7 @@ import {
   CacheLoadResult,
   CacheStatus,
 } from '@expo/entity';
+import invariant from 'invariant';
 import { Redis } from 'ioredis';
 
 import { redisTransformerMap } from './RedisCommon';
@@ -157,11 +158,13 @@ export default class RedisCacheAdapter<TFields> extends EntityCacheAdapter<TFiel
     fieldName: N,
     fieldValue: NonNullable<TFields[N]>
   ): string {
+    const columnName = this.entityConfiguration.entityToDBFieldsKeyMapping.get(fieldName);
+    invariant(columnName, `database field mapping missing for ${fieldName}`);
     return this.context.makeKeyFn(
       this.context.cacheKeyPrefix,
       this.entityConfiguration.tableName,
-      `v${this.entityConfiguration.cacheKeyVersion}`,
-      fieldName as string,
+      `v2.${this.entityConfiguration.cacheKeyVersion}`,
+      columnName,
       String(fieldValue)
     );
   }


### PR DESCRIPTION
# Why

Having the cache key on field name means that field renames need to bump the cache key for the entity itself, which is non-obvious (we've been bit by it twice at Expo). Instead, it makes more sense to cache keyed by column name which is much clearer that a cache key bump is needed when changed.

Closes https://github.com/expo/entity/issues/107.
Closes ENG-291.

# How

Change to use column name in key generation function.

Note that upgrading to a version that includes this change will cause a full entity cache invalidation of all entities. This should be fine for most applications but was why we were hesitant to make this change previously. Now the benefits outweigh the costs though.

# Test Plan

Run all tests.
