### PR TITLE
docs: add better docblocks for EntityCompanionDefinition and EntityConfiguration

### DIFF
--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -97,6 +97,9 @@ export class EntityCompanionDefinition<
     mutationTriggers = () => ({}),
     entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
   }: {
+    /**
+     * The concrete Entity class for which this is the definition.
+     */
     entityClass: IEntityClass<
       TFields,
       TID,
@@ -105,8 +108,17 @@ export class EntityCompanionDefinition<
       TPrivacyPolicy,
       TSelectedFields
     >;
+    /**
+     * The {@link EntityConfiguration} for this entity.
+     */
     entityConfiguration: EntityConfiguration<TFields>;
+    /**
+     * The {@link EntityPrivacyPolicy} class for this entity.
+     */
     privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
+    /**
+     * An optional list of {@link EntityMutationValidator} for this entity.
+     */
     mutationValidators?: () => EntityMutationValidator<
       TFields,
       TID,
@@ -114,6 +126,9 @@ export class EntityCompanionDefinition<
       TEntity,
       TSelectedFields
     >[];
+    /**
+     * An optional list of {@link EntityMutationTrigger} for this entity.
+     */
     mutationTriggers?: () => EntityMutationTriggerConfiguration<
       TFields,
       TID,
@@ -121,6 +136,11 @@ export class EntityCompanionDefinition<
       TEntity,
       TSelectedFields
     >;
+    /**
+     * An optional subset of fields defined in the {@link EntityConfiguration} which belong to this entity.
+     * For use when multiple types of entities are backed by a single table ({@link EntityConfiguration}) yet
+     * only expose a subset of the fields.
+     */
     entitySelectedFields?: TSelectedFields[];
   }) {
     this.entityClass = entityClass;

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -30,12 +30,40 @@ export default class EntityConfiguration<TFields> {
     databaseAdapterFlavor,
     cacheAdapterFlavor,
   }: {
+    /**
+     * The field used to identify this entity. Must be a unique field in the table.
+     */
     idField: keyof TFields;
+
+    /**
+     * The name of the table where entities of this type are stored.
+     */
     tableName: string;
+
+    /**
+     * Map from each entity field to an {@link EntityFieldDefinition} specifying information about the field.
+     */
     schema: Record<keyof TFields, EntityFieldDefinition<any>>;
+
+    /**
+     * List of other entity types that reference this type in {@link EntityFieldDefinition} associations.
+     */
     getInboundEdges?: () => IEntityClass<any, any, any, any, any, any>[];
+
+    /**
+     * Cache key version for this entity type. Should be bumped when a field is added to, removed from, or changed
+     * in this entity and the underlying database table.
+     */
     cacheKeyVersion?: number;
+
+    /**
+     * Backing database and transaction type for this entity.
+     */
     databaseAdapterFlavor: DatabaseAdapterFlavor;
+
+    /**
+     * Cache system for this entity.
+     */
     cacheAdapterFlavor: CacheAdapterFlavor;
   }) {
     this.idField = idField;


### PR DESCRIPTION
# Why

Noticed that these weren't documented on hover in vscode when using it in Expo's codebase.

# How

Add docs.

# Test Plan

n/a
