### PR TITLE
feat: allow null field values in loadManyByFieldEqualityConjunctionAsync

### DIFF
--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -9,12 +9,12 @@ import {
 
 interface SingleValueFieldEqualityCondition<TFields, N extends keyof TFields = keyof TFields> {
   fieldName: N;
-  fieldValue: NonNullable<TFields[N]>;
+  fieldValue: TFields[N];
 }
 
 interface MultiValueFieldEqualityCondition<TFields, N extends keyof TFields = keyof TFields> {
   fieldName: N;
-  fieldValues: readonly NonNullable<TFields[N]>[];
+  fieldValues: readonly TFields[N][];
 }
 
 export type FieldEqualityCondition<TFields, N extends keyof TFields = keyof TFields> =

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -335,7 +335,7 @@ export default class EntityLoader<
 
   private validateFieldValues<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[]
+    fieldValues: readonly TFields[N][]
   ): void {
     const fieldDefinition = this.entityConfiguration.schema.get(fieldName);
     invariant(fieldDefinition, `must have field definition for field = ${fieldName}`);

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -75,20 +75,38 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
     const aField = objectA[currentOrderBy.columnName];
     const bField = objectB[currentOrderBy.columnName];
     switch (currentOrderBy.order) {
-      case OrderByOrdering.DESCENDING:
+      case OrderByOrdering.DESCENDING: {
         // simulate NULLS FIRST for DESC
+        if (aField === null && bField === null) {
+          return 0;
+        } else if (aField === null) {
+          return -1;
+        } else if (bField === null) {
+          return 1;
+        }
+
         return aField > bField || aField === null
           ? -1
           : aField < bField
           ? 1
           : this.compareByOrderBys(orderBys.slice(1), objectA, objectB);
-      case OrderByOrdering.ASCENDING:
+      }
+      case OrderByOrdering.ASCENDING: {
         // simulate NULLS LAST for ASC
+        if (aField === null && bField === null) {
+          return 0;
+        } else if (bField === null) {
+          return -1;
+        } else if (aField === null) {
+          return 1;
+        }
+
         return bField > aField || bField === null
           ? -1
           : bField < aField
           ? 1
           : this.compareByOrderBys(orderBys.slice(1), objectA, objectB);
+      }
     }
   }
 

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -85,7 +85,7 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
           return 1;
         }
 
-        return aField > bField || aField === null
+        return aField > bField
           ? -1
           : aField < bField
           ? 1
@@ -101,7 +101,7 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
           return 1;
         }
 
-        return bField > aField || bField === null
+        return bField > aField
           ? -1
           : bField < aField
           ? 1

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -76,13 +76,15 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
     const bField = objectB[currentOrderBy.columnName];
     switch (currentOrderBy.order) {
       case OrderByOrdering.DESCENDING:
-        return aField > bField
+        // simulate NULLS FIRST for DESC
+        return aField > bField || aField === null
           ? -1
           : aField < bField
           ? 1
           : this.compareByOrderBys(orderBys.slice(1), objectA, objectB);
       case OrderByOrdering.ASCENDING:
-        return bField > aField
+        // simulate NULLS LAST for ASC
+        return bField > aField || bField === null
           ? -1
           : bField < aField
           ? 1

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -228,9 +228,9 @@ describe(StubDatabaseAdapter, () => {
                   nullableField: null,
                 },
                 {
-                  customIdField: '3',
-                  testIndexedField: 'h3',
-                  numberField: 3,
+                  customIdField: '4',
+                  testIndexedField: 'h4',
+                  numberField: 4,
                   stringField: 'b',
                   dateField: new Date(),
                   nullableField: null,
@@ -392,5 +392,75 @@ describe(StubDatabaseAdapter, () => {
     await expect(databaseAdapter3.insertAsync(queryContext, {})).rejects.toThrowError(
       'Unsupported ID type for StubDatabaseAdapter: DateField'
     );
+  });
+
+  describe('compareByOrderBys', () => {
+    describe('comparison', () => {
+      it.each([
+        // nulls compare with 0
+        [OrderByOrdering.DESCENDING, null, 0, -1],
+        [OrderByOrdering.ASCENDING, null, 0, 1],
+        [OrderByOrdering.DESCENDING, 0, null, 1],
+        [OrderByOrdering.ASCENDING, 0, null, -1],
+
+        // nulls compare with nulls
+        [OrderByOrdering.DESCENDING, null, null, 0],
+        [OrderByOrdering.ASCENDING, null, null, 0],
+
+        // nulls compare with -1
+        [OrderByOrdering.DESCENDING, null, -1, -1],
+        [OrderByOrdering.ASCENDING, null, -1, 1],
+        [OrderByOrdering.DESCENDING, -1, null, 1],
+        [OrderByOrdering.ASCENDING, -1, null, -1],
+
+        // basic compares
+        [OrderByOrdering.ASCENDING, 'a', 'b', -1],
+        [OrderByOrdering.ASCENDING, 'b', 'a', 1],
+        [OrderByOrdering.DESCENDING, 'a', 'b', 1],
+        [OrderByOrdering.DESCENDING, 'b', 'a', -1],
+      ])('case (%p; %p; %p)', (order, v1, v2, expectedResult) => {
+        expect(
+          StubDatabaseAdapter['compareByOrderBys'](
+            [
+              {
+                columnName: 'hello',
+                order,
+              },
+            ],
+            {
+              hello: v1,
+            },
+            {
+              hello: v2,
+            }
+          )
+        ).toEqual(expectedResult);
+      });
+    });
+
+    describe('recursing', () => {
+      expect(
+        StubDatabaseAdapter['compareByOrderBys'](
+          [
+            {
+              columnName: 'hello',
+              order: OrderByOrdering.ASCENDING,
+            },
+            {
+              columnName: 'world',
+              order: OrderByOrdering.ASCENDING,
+            },
+          ],
+          {
+            hello: 'a',
+            world: 1,
+          },
+          {
+            hello: 'a',
+            world: 2,
+          }
+        )
+      ).toEqual(-1);
+    });
   });
 });

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -192,6 +192,81 @@ describe(StubDatabaseAdapter, () => {
       expect(results).toHaveLength(3);
       expect(results.map((e) => e.stringField)).toEqual(['c', 'b', 'a']);
     });
+
+    it('supports null field values', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+        testEntityConfiguration,
+        StubDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: '1',
+                  testIndexedField: 'h1',
+                  numberField: 1,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: 'a',
+                },
+                {
+                  customIdField: '2',
+                  testIndexedField: 'h2',
+                  numberField: 2,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: 'b',
+                },
+                {
+                  customIdField: '3',
+                  testIndexedField: 'h3',
+                  numberField: 3,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: '3',
+                  testIndexedField: 'h3',
+                  numberField: 3,
+                  stringField: 'b',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ])
+        )
+      );
+
+      const results = await databaseAdapter.fetchManyByFieldEqualityConjunctionAsync(
+        queryContext,
+        [{ fieldName: 'nullableField', fieldValue: null }],
+        {}
+      );
+      expect(results).toHaveLength(2);
+      expect(results[0].nullableField).toBeNull();
+
+      const results2 = await databaseAdapter.fetchManyByFieldEqualityConjunctionAsync(
+        queryContext,
+        [
+          { fieldName: 'nullableField', fieldValues: ['a', null] },
+          { fieldName: 'stringField', fieldValue: 'a' },
+        ],
+        {
+          orderBy: [
+            {
+              fieldName: 'nullableField',
+              order: OrderByOrdering.DESCENDING,
+            },
+          ],
+        }
+      );
+      expect(results2).toHaveLength(2);
+      expect(results2.map((e) => e.nullableField)).toEqual([null, 'a']);
+    });
   });
 
   describe('fetchManyByRawWhereClauseAsync', () => {


### PR DESCRIPTION
# Why

A feature request from @jkhales for an API endpoint within the Expo server. 

Since the results for this type of load aren't stored in a dataloader or cached, we can just pipe null fieldValues directly through to the database adapters for load, and it is their duty to handle them for this type of load.

# How

This ended up being slightly more difficult than anticipated but not too bad. Complications:
- `ANY(?)` cannot contain `NULL` so it needs to be split into separate `OR WHERE` but within the same conjunctive clause.
- Replicating the default `NULLS FIRST/LAST` postgres behavior in StubDatabaseAdapter required checking for null explicitly: https://www.postgresql.org/docs/8.3/queries-order.html#:~:text=The-,NULLS%20FIRST,-and%20NULLS%20LAST

# Test Plan

Run tests.
