### PR TITLE
v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+
+### Features
+
+* allow null field values in loadManyByFieldEqualityConjunctionAsync ([#130](https://github.com/expo/entity/issues/130)) ([2f37dc6](https://github.com/expo/entity/commit/2f37dc6a37d368b12b3c8375e04f0777fd448797))
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.15.0"
+  "version": "0.16.0"
 }

--- a/packages/entity-cache-adapter-redis/CHANGELOG.md
+++ b/packages/entity-cache-adapter-redis/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+**Note:** Version bump only for package @expo/entity-cache-adapter-redis
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/entity-cache-adapter-redis",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Redis cache adapter for @expo/entity",
   "files": [
     "build",
@@ -32,6 +32,6 @@
     "ioredis": "^4.27.3"
   },
   "devDependencies": {
-    "@expo/entity": "^0.15.0"
+    "@expo/entity": "^0.16.0"
   }
 }

--- a/packages/entity-database-adapter-knex/CHANGELOG.md
+++ b/packages/entity-database-adapter-knex/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+
+### Features
+
+* allow null field values in loadManyByFieldEqualityConjunctionAsync ([#130](https://github.com/expo/entity/issues/130)) ([2f37dc6](https://github.com/expo/entity/commit/2f37dc6a37d368b12b3c8375e04f0777fd448797))
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/entity-database-adapter-knex",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Knex database adapter for @expo/entity",
   "files": [
     "build",
@@ -32,6 +32,6 @@
     "knex": "^0.95.6"
   },
   "devDependencies": {
-    "@expo/entity": "^0.15.0"
+    "@expo/entity": "^0.16.0"
   }
 }

--- a/packages/entity-example/CHANGELOG.md
+++ b/packages/entity-example/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+**Note:** Version bump only for package @expo/entity-example
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/packages/entity-example/package.json
+++ b/packages/entity-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@expo/entity-example",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "An example integration of the @expo/entity framework",
   "scripts": {
     "tsc": "tsc",
@@ -22,7 +22,7 @@
   "author": "Expo",
   "license": "MIT",
   "dependencies": {
-    "@expo/entity": "^0.15.0",
+    "@expo/entity": "^0.16.0",
     "apollo-server-koa": "^2.16.1",
     "graphql": "^15.3.0",
     "koa": "^2.13.0",

--- a/packages/entity-full-integration-tests/CHANGELOG.md
+++ b/packages/entity-full-integration-tests/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+**Note:** Version bump only for package @expo/entity-full-integration-tests
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/packages/entity-full-integration-tests/package.json
+++ b/packages/entity-full-integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@expo/entity-full-integration-tests",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Full redis and knex integration tests for the entity framework",
   "scripts": {
     "tsc": "tsc",
@@ -26,8 +26,8 @@
     "@expo/entity-database-adapter-knex": "*"
   },
   "devDependencies": {
-    "@expo/entity": "^0.15.0",
-    "@expo/entity-cache-adapter-redis": "^0.15.0",
-    "@expo/entity-database-adapter-knex": "^0.15.0"
+    "@expo/entity": "^0.16.0",
+    "@expo/entity-cache-adapter-redis": "^0.16.0",
+    "@expo/entity-database-adapter-knex": "^0.16.0"
   }
 }

--- a/packages/entity-secondary-cache-redis/CHANGELOG.md
+++ b/packages/entity-secondary-cache-redis/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+**Note:** Version bump only for package @expo/entity-secondary-cache-redis
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/entity-secondary-cache-redis",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Redis secondary cache for @expo/entity",
   "files": [
     "build",
@@ -33,8 +33,8 @@
     "ioredis": "^4.17.3"
   },
   "devDependencies": {
-    "@expo/entity": "^0.15.0",
-    "@expo/entity-cache-adapter-redis": "^0.15.0",
+    "@expo/entity": "^0.16.0",
+    "@expo/entity-cache-adapter-redis": "^0.16.0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/entity/CHANGELOG.md
+++ b/packages/entity/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.16.0](https://github.com/expo/entity/compare/v0.15.0...v0.16.0) (2021-07-07)
+
+
+### Features
+
+* allow null field values in loadManyByFieldEqualityConjunctionAsync ([#130](https://github.com/expo/entity/issues/130)) ([2f37dc6](https://github.com/expo/entity/commit/2f37dc6a37d368b12b3c8375e04f0777fd448797))
+
+
+
+
+
 # [0.15.0](https://github.com/expo/entity/compare/v0.14.1...v0.15.0) (2021-05-26)
 
 

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/entity",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A privacy-first data model",
   "files": [
     "build",


### PR DESCRIPTION
# Why

Releasing support for null-valued cache keys.

# How

Following the instructions in the README.

# Test Plan

`yarn test`