### PR TITLE
feat: upgrade TypeScript to 4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "prettier": "^2.1.0",
     "ts-jest": "~26.4.4",
     "ts-mockito": "^2.6.1",
-    "typedoc": "^0.20.36",
-    "typescript": "^4.1.3",
+    "typedoc": "^0.21.9",
+    "typescript": "^4.4.2",
     "uuid": "^8.3.0"
   },
   "dependencies": {

--- a/packages/entity-cache-adapter-redis/README.md
+++ b/packages/entity-cache-adapter-redis/README.md
@@ -12,7 +12,7 @@ During `EntityCompanionProvider` instantiation:
 import Redis from 'ioredis';
 
 const redisCacheAdapterContext = {
-  redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+  redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
   makeKeyFn(...parts: string[]): string {
     const delimiter = ':';
     const escapedParts = parts.map((part) =>

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -1,7 +1,7 @@
 import { CacheLoadResult, CacheStatus } from '@expo/entity';
 import { Redis } from 'ioredis';
 
-import wrapNativeRedisCall from './errors/wrapNativeRedisCall';
+import wrapNativeRedisCallAsync from './errors/wrapNativeRedisCallAsync';
 
 // Sentinel value we store in Redis to negatively cache a database miss.
 // The sentinel value is distinct from any (positively) cached value.
@@ -36,7 +36,9 @@ export default class GenericRedisCacher {
       return new Map();
     }
 
-    const redisResults = await wrapNativeRedisCall(() => this.context.redisClient.mget(...keys));
+    const redisResults = await wrapNativeRedisCallAsync(() =>
+      this.context.redisClient.mget(...keys)
+    );
 
     const results = new Map<string, CacheLoadResult>();
     for (let i = 0; i < keys.length; i++) {
@@ -75,7 +77,7 @@ export default class GenericRedisCacher {
         this.context.ttlSecondsPositive
       );
     });
-    await wrapNativeRedisCall(() => redisTransaction.exec());
+    await wrapNativeRedisCallAsync(() => redisTransaction.exec());
   }
 
   public async cacheDBMissesAsync(keys: string[]): Promise<void> {
@@ -92,7 +94,7 @@ export default class GenericRedisCacher {
         this.context.ttlSecondsNegative
       );
     });
-    await wrapNativeRedisCall(() => redisTransaction.exec());
+    await wrapNativeRedisCallAsync(() => redisTransaction.exec());
   }
 
   public async invalidateManyAsync(keys: string[]): Promise<void> {
@@ -100,6 +102,6 @@ export default class GenericRedisCacher {
       return;
     }
 
-    await wrapNativeRedisCall(() => this.context.redisClient.del(...keys));
+    await wrapNativeRedisCallAsync(() => this.context.redisClient.del(...keys));
   }
 }

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -40,7 +40,7 @@ export default class GenericRedisCacher {
 
     const results = new Map<string, CacheLoadResult>();
     for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
+      const key = keys[i]!;
       const redisResult = redisResults[i];
 
       if (redisResult === DOES_NOT_EXIST_REDIS) {

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
@@ -15,7 +15,7 @@ describe(RedisCacheAdapter, () => {
 
   beforeAll(() => {
     redisCacheAdapterContext = {
-      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -13,7 +13,7 @@ describe(RedisCacheAdapter, () => {
 
   beforeAll(() => {
     redisCacheAdapterContext = {
-      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>

--- a/packages/entity-cache-adapter-redis/src/errors/__tests__/wrapNativeRedisCallAsync-test.ts
+++ b/packages/entity-cache-adapter-redis/src/errors/__tests__/wrapNativeRedisCallAsync-test.ts
@@ -1,0 +1,39 @@
+import { EntityCacheAdapterTransientError } from '@expo/entity';
+
+import wrapNativeRedisCallAsync from '../wrapNativeRedisCallAsync';
+
+describe(wrapNativeRedisCallAsync, () => {
+  it('rethrows literals', async () => {
+    const throwingFn = async (): Promise<void> => {
+      // eslint-disable-next-line no-throw-literal,@typescript-eslint/no-throw-literal
+      throw 'hello';
+    };
+
+    let capturedThrownThing: any;
+    try {
+      await wrapNativeRedisCallAsync(throwingFn);
+    } catch (e) {
+      capturedThrownThing = e;
+    }
+    expect(capturedThrownThing).not.toBeInstanceOf(Error);
+    expect(capturedThrownThing).toEqual('hello');
+  });
+
+  it('wraps errors with stacks', async () => {
+    const throwingFn = async (): Promise<void> => {
+      const e = new Error('hello');
+      e.stack = 'world';
+      throw e;
+    };
+
+    let capturedThrownThing: any;
+    try {
+      await wrapNativeRedisCallAsync(throwingFn);
+    } catch (e) {
+      capturedThrownThing = e;
+    }
+    expect(capturedThrownThing).toBeInstanceOf(EntityCacheAdapterTransientError);
+    expect(capturedThrownThing.message).toEqual('hello');
+    expect(capturedThrownThing.stack).toEqual('world');
+  });
+});

--- a/packages/entity-cache-adapter-redis/src/errors/wrapNativeRedisCall.ts
+++ b/packages/entity-cache-adapter-redis/src/errors/wrapNativeRedisCall.ts
@@ -4,8 +4,14 @@ export default async function wrapNativeRedisCall<T>(fn: () => Promise<T>): Prom
   try {
     return await fn();
   } catch (e) {
+    if (!(e instanceof Error)) {
+      throw e;
+    }
+
     const error = new EntityCacheAdapterTransientError(e.message, e);
-    error.stack = e.stack;
+    if (e.stack) {
+      error.stack = e.stack;
+    }
     throw error;
   }
 }

--- a/packages/entity-cache-adapter-redis/src/errors/wrapNativeRedisCallAsync.ts
+++ b/packages/entity-cache-adapter-redis/src/errors/wrapNativeRedisCallAsync.ts
@@ -1,6 +1,6 @@
 import { EntityCacheAdapterTransientError } from '@expo/entity';
 
-export default async function wrapNativeRedisCall<T>(fn: () => Promise<T>): Promise<T> {
+export default async function wrapNativeRedisCallAsync<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
   } catch (e) {

--- a/packages/entity-database-adapter-knex/README.md
+++ b/packages/entity-database-adapter-knex/README.md
@@ -14,11 +14,11 @@ import { knex, Knex } from 'knex';
 const knexInstance = knex({
   client: 'pg',
   connection: {
-    user: process.env.PGUSER,
-    password: process.env.PGPASSWORD,
-    host: process.env.PGHOST,
-    port: parseInt(process.env.PGPORT!, 10),
-    database: process.env.PGDATABASE,
+    user: process.env['PGUSER'],
+    password: process.env['PGPASSWORD'],
+    host: process.env['PGHOST'],
+    port: parseInt(process.env['PGPORT']!, 10),
+    database: process.env['PGDATABASE'],
   },
 });
 

--- a/packages/entity-database-adapter-knex/README.md
+++ b/packages/entity-database-adapter-knex/README.md
@@ -17,7 +17,7 @@ const knexInstance = knex({
     user: process.env['PGUSER'],
     password: process.env['PGPASSWORD'],
     host: process.env['PGHOST'],
-    port: parseInt(process.env['PGPORT']!, 10),
+    port: parseInt(nullthrows(process.env['PGPORT']), 10),
     database: process.env['PGDATABASE'],
   },
 });

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -10,7 +10,7 @@ import {
 } from '@expo/entity';
 import { Knex } from 'knex';
 
-import wrapNativePostgresCall from './errors/wrapNativePostgresCall';
+import wrapNativePostgresCallAsync from './errors/wrapNativePostgresCallAsync';
 
 export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDatabaseAdapter<TFields> {
   protected getFieldTransformerMap(): FieldTransformerMap {
@@ -45,7 +45,7 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
     tableField: string,
     tableValues: readonly any[]
   ): Promise<object[]> {
-    return await wrapNativePostgresCall(() =>
+    return await wrapNativePostgresCallAsync(() =>
       queryInterface
         .select()
         .from(tableName)
@@ -123,7 +123,7 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
     }
 
     query = this.applyQueryModifiersToQuery(query, querySelectionModifiers);
-    return await wrapNativePostgresCall(() => query);
+    return await wrapNativePostgresCallAsync(() => query);
   }
 
   protected async fetchManyByRawWhereClauseInternalAsync(
@@ -138,7 +138,7 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
       .from(tableName)
       .whereRaw(rawWhereClause, bindings as any);
     query = this.applyQueryModifiersToQuery(query, querySelectionModifiers);
-    return await wrapNativePostgresCall(() => query);
+    return await wrapNativePostgresCallAsync(() => query);
   }
 
   protected async insertInternalAsync(
@@ -146,7 +146,7 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
     tableName: string,
     object: object
   ): Promise<object[]> {
-    return await wrapNativePostgresCall(() =>
+    return await wrapNativePostgresCallAsync(() =>
       queryInterface.insert(object).into(tableName).returning('*')
     );
   }
@@ -158,7 +158,7 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
     id: any,
     object: object
   ): Promise<object[]> {
-    return await wrapNativePostgresCall(() =>
+    return await wrapNativePostgresCallAsync(() =>
       queryInterface.update(object).into(tableName).where(tableIdField, id).returning('*')
     );
   }
@@ -169,7 +169,7 @@ export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDataba
     tableIdField: string,
     id: any
   ): Promise<number> {
-    return await wrapNativePostgresCall(() =>
+    return await wrapNativePostgresCallAsync(() =>
       queryInterface.into(tableName).where(tableIdField, id).del()
     );
   }

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -23,7 +23,7 @@ describe('postgres entity integration', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
     });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -6,6 +6,7 @@ import {
 } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
 import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
 
 import PostgresTestEntity from '../testfixtures/PostgresTestEntity';
 import PostgresTriggerTestEntity from '../testfixtures/PostgresTriggerTestEntity';
@@ -19,11 +20,11 @@ describe('postgres entity integration', () => {
     knexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
     });
   });
@@ -263,7 +264,7 @@ describe('postgres entity integration', () => {
         .enforcing()
         .loadManyByFieldEqualityConjunctionAsync([{ fieldName: 'name', fieldValue: null }]);
       expect(results).toHaveLength(2);
-      expect(results[0].getField('name')).toBeNull();
+      expect(results[0]!.getField('name')).toBeNull();
 
       const results2 = await PostgresTestEntity.loader(vc1)
         .enforcing()

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -1,6 +1,7 @@
 import { ViewerContext } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
 import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
 
 import InvalidTestEntity from '../testfixtures/InvalidTestEntity';
 import { createKnexIntegrationTestEntityCompanionProvider } from '../testfixtures/createKnexIntegrationTestEntityCompanionProvider';
@@ -12,11 +13,11 @@ describe('postgres entity integration', () => {
     knexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
     });
   });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -16,7 +16,7 @@ describe('postgres entity integration', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
     });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -24,7 +24,7 @@ describe('postgres errors', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
     });
@@ -52,7 +52,7 @@ describe('postgres errors', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
       acquireConnectionTimeout: 1,

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -9,6 +9,7 @@ import {
   EntityDatabaseAdapterUnknownError,
 } from '@expo/entity';
 import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
 
 import ErrorsTestEntity from '../testfixtures/ErrorsTestEntity';
 import { createKnexIntegrationTestEntityCompanionProvider } from '../testfixtures/createKnexIntegrationTestEntityCompanionProvider';
@@ -20,11 +21,11 @@ describe('postgres errors', () => {
     knexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
     });
   });
@@ -48,11 +49,11 @@ describe('postgres errors', () => {
     const shortTimeoutKnexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
       acquireConnectionTimeout: 1,
     });

--- a/packages/entity-database-adapter-knex/src/errors/__tests__/wrapNativePostgresCallAsync-test.ts
+++ b/packages/entity-database-adapter-knex/src/errors/__tests__/wrapNativePostgresCallAsync-test.ts
@@ -1,0 +1,19 @@
+import wrapNativePostgresCallAsync from '../wrapNativePostgresCallAsync';
+
+describe(wrapNativePostgresCallAsync, () => {
+  it('rethrows literals', async () => {
+    const throwingFn = async (): Promise<void> => {
+      // eslint-disable-next-line no-throw-literal,@typescript-eslint/no-throw-literal
+      throw 'hello';
+    };
+
+    let capturedThrownThing: any;
+    try {
+      await wrapNativePostgresCallAsync(throwingFn);
+    } catch (e) {
+      capturedThrownThing = e;
+    }
+    expect(capturedThrownThing).not.toBeInstanceOf(Error);
+    expect(capturedThrownThing).toEqual('hello');
+  });
+});

--- a/packages/entity-database-adapter-knex/src/errors/wrapNativePostgresCall.ts
+++ b/packages/entity-database-adapter-knex/src/errors/wrapNativePostgresCall.ts
@@ -11,15 +11,17 @@ import {
 import { knex } from 'knex';
 
 function wrapNativePostgresError(
-  error: Error & { code: string | undefined }
+  error: Error & { code?: string }
 ): EntityDatabaseAdapterError & Error {
   const ret = translatePostgresError(error);
-  ret.stack = error.stack;
+  if (error.stack) {
+    ret.stack = error.stack;
+  }
   return ret;
 }
 
 function translatePostgresError(
-  error: Error & { code: string | undefined }
+  error: Error & { code?: string }
 ): EntityDatabaseAdapterError & Error {
   if (error instanceof knex.KnexTimeoutError) {
     return new EntityDatabaseAdapterTransientError(error.message, error);
@@ -45,6 +47,9 @@ export default async function wrapNativePostgresCall<T>(fn: () => Promise<T>): P
   try {
     return await fn();
   } catch (e) {
+    if (!(e instanceof Error)) {
+      throw e;
+    }
     throw wrapNativePostgresError(e);
   }
 }

--- a/packages/entity-database-adapter-knex/src/errors/wrapNativePostgresCallAsync.ts
+++ b/packages/entity-database-adapter-knex/src/errors/wrapNativePostgresCallAsync.ts
@@ -43,7 +43,7 @@ function translatePostgresError(
   }
 }
 
-export default async function wrapNativePostgresCall<T>(fn: () => Promise<T>): Promise<T> {
+export default async function wrapNativePostgresCallAsync<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
   } catch (e) {

--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -58,7 +58,7 @@ class InMemoryDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
       return 0;
     }
 
-    const currentOrderBy = orderBys[0];
+    const currentOrderBy = orderBys[0]!;
     const aField = objectA[currentOrderBy.columnName];
     const bField = objectB[currentOrderBy.columnName];
     switch (currentOrderBy.order) {
@@ -161,7 +161,7 @@ class InMemoryDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
       ...dbObjects[objectIndex],
       ...object,
     };
-    return [dbObjects[objectIndex]];
+    return [dbObjects[objectIndex]!];
   }
 
   protected async deleteInternalAsync(

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -11,6 +11,7 @@ import {
 import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
 import { URL } from 'url';
 
 import { createFullIntegrationTestEntityCompanionProvider } from '../testfixtures/createFullIntegrationTestEntityCompanionProvider';
@@ -107,15 +108,15 @@ describe('Entity cache inconsistency', () => {
     knexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
     });
     redisCacheAdapterContext = {
-      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -111,7 +111,7 @@ describe('Entity cache inconsistency', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
     });

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -44,7 +44,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
     });

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -2,6 +2,7 @@ import { ViewerContext } from '@expo/entity';
 import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
 import { URL } from 'url';
 
 import { createFullIntegrationTestEntityCompanionProvider } from '../testfixtures/createFullIntegrationTestEntityCompanionProvider';
@@ -40,15 +41,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
     knexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
     });
     redisCacheAdapterContext = {
-      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -11,6 +11,7 @@ import {
 import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -169,15 +170,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
     knexInstance = knex({
       client: 'pg',
       connection: {
-        user: process.env.PGUSER,
-        password: process.env.PGPASSWORD,
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env.PGPORT!, 10),
-        database: process.env.PGDATABASE,
+        port: parseInt(process.env['PGPORT']!, 10),
+        database: nullthrows(process.env['PGDATABASE']),
       },
     });
     redisCacheAdapterContext = {
-      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -173,7 +173,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         user: nullthrows(process.env['PGUSER']),
         password: nullthrows(process.env['PGPASSWORD']),
         host: 'localhost',
-        port: parseInt(process.env['PGPORT']!, 10),
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
         database: nullthrows(process.env['PGDATABASE']),
       },
     });

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -38,11 +38,15 @@ class TestSecondaryRedisCacheLoader extends EntitySecondaryCacheLoader<
       if (loadParams.id === FAKE_ID) {
         return null;
       }
-      return (
-        await this.entityLoader
-          .enforcing()
-          .loadManyByFieldEqualityConjunctionAsync([{ fieldName: 'id', fieldValue: loadParams.id }])
-      )[0].getAllFields();
+      return nullthrows(
+        (
+          await this.entityLoader
+            .enforcing()
+            .loadManyByFieldEqualityConjunctionAsync([
+              { fieldName: 'id', fieldValue: loadParams.id },
+            ])
+        )[0]
+      ).getAllFields();
     });
   }
 }
@@ -52,7 +56,7 @@ describe(RedisSecondaryEntityCache, () => {
 
   beforeAll(() => {
     redisCacheAdapterContext = {
-      redisClient: new Redis(new URL(process.env.REDIS_URL!).toString()),
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
       makeKeyFn(..._parts: string[]): string {
         throw new Error('should not be used by this test');
       },

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -69,12 +69,14 @@ export interface QuerySelectionModifiers<TFields> {
 }
 
 export interface TableQuerySelectionModifiers {
-  orderBy?: {
-    columnName: string;
-    order: OrderByOrdering;
-  }[];
-  offset?: number;
-  limit?: number;
+  orderBy:
+    | {
+        columnName: string;
+        order: OrderByOrdering;
+      }[]
+    | undefined;
+  offset: number | undefined;
+  limit: number | undefined;
 }
 
 /**
@@ -263,7 +265,7 @@ export default abstract class EntityDatabaseAdapter<TFields> {
     return transformDatabaseObjectToFields(
       this.entityConfiguration,
       this.fieldTransformerMap,
-      results[0]
+      results[0]!
     );
   }
 
@@ -315,7 +317,7 @@ export default abstract class EntityDatabaseAdapter<TFields> {
     return transformDatabaseObjectToFields(
       this.entityConfiguration,
       this.fieldTransformerMap,
-      results[0]
+      results[0]!
     );
   }
 

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -88,7 +88,7 @@ export interface EntityAssociationDefinition<
 export abstract class EntityFieldDefinition<T> {
   readonly columnName: string;
   readonly cache: boolean;
-  readonly association?: EntityAssociationDefinition<any, any, any, any, any, any>;
+  readonly association: EntityAssociationDefinition<any, any, any, any, any, any> | undefined;
   /**
    *
    * @param columnName - Column name in the database.

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -298,6 +298,9 @@ export default class EntityLoader<
       try {
         return result(new this.entityClass(this.viewerContext, fieldsObject));
       } catch (e) {
+        if (!(e instanceof Error)) {
+          throw e;
+        }
         return result(e);
       }
     });

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -261,7 +261,7 @@ export default abstract class EntityPrivacyPolicy<
     action: EntityAuthorizationAction
   ): Promise<TEntity> {
     for (let i = 0; i < ruleset.length; i++) {
-      const rule = ruleset[i];
+      const rule = ruleset[i]!;
       const ruleEvaluationResult = await rule.evaluateAsync(viewerContext, queryContext, entity);
       switch (ruleEvaluationResult) {
         case RuleEvaluationResult.DENY:

--- a/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
@@ -1,0 +1,175 @@
+import { instance, mock } from 'ts-mockito';
+
+import Entity from '../Entity';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { StringField } from '../EntityFields';
+import EntityLoader from '../EntityLoader';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import ViewerContext from '../ViewerContext';
+import EntityDataManager from '../internal/EntityDataManager';
+import ReadThroughEntityCache from '../internal/ReadThroughEntityCache';
+import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
+import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
+import { NoCacheStubCacheAdapterProvider } from '../utils/testing/StubCacheAdapter';
+import StubDatabaseAdapter from '../utils/testing/StubDatabaseAdapter';
+import StubQueryContextProvider from '../utils/testing/StubQueryContextProvider';
+
+export type TestFields = {
+  id: string;
+};
+
+export type TestFieldSelection = keyof TestFields;
+
+export const testEntityConfiguration = new EntityConfiguration<TestFields>({
+  idField: 'id',
+  tableName: 'test_entity_should_not_write_to_db',
+  schema: {
+    id: new StringField({
+      columnName: 'id',
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
+});
+
+export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  TestFields,
+  string,
+  ViewerContext,
+  TestEntity,
+  TestFieldSelection
+> {
+  protected readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestFields,
+      string,
+      ViewerContext,
+      TestEntity,
+      TestFieldSelection
+    >(),
+  ];
+  protected readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestFields,
+      string,
+      ViewerContext,
+      TestEntity,
+      TestFieldSelection
+    >(),
+  ];
+  protected readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestFields,
+      string,
+      ViewerContext,
+      TestEntity,
+      TestFieldSelection
+    >(),
+  ];
+  protected readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      TestFields,
+      string,
+      ViewerContext,
+      TestEntity,
+      TestFieldSelection
+    >(),
+  ];
+}
+
+const ID_SENTINEL_THROW_LITERAL = 'throw_literal';
+const ID_SENTINEL_THROW_ERROR = 'throw_error';
+
+export default class TestEntity extends Entity<
+  TestFields,
+  string,
+  ViewerContext,
+  TestFieldSelection
+> {
+  constructor(viewerContext: ViewerContext, rawFields: Readonly<TestFields>) {
+    if (rawFields.id === ID_SENTINEL_THROW_LITERAL) {
+      // eslint-disable-next-line no-throw-literal,@typescript-eslint/no-throw-literal
+      throw 'hello';
+    } else if (rawFields.id === ID_SENTINEL_THROW_ERROR) {
+      throw new Error('world');
+    }
+    super(viewerContext, rawFields);
+  }
+
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    TestFields,
+    string,
+    ViewerContext,
+    TestEntity,
+    TestEntityPrivacyPolicy,
+    TestFieldSelection
+  > {
+    return testEntityCompanion;
+  }
+}
+
+export const testEntityCompanion = new EntityCompanionDefinition({
+  entityClass: TestEntity,
+  entityConfiguration: testEntityConfiguration,
+  privacyPolicyClass: TestEntityPrivacyPolicy,
+});
+
+describe(EntityLoader, () => {
+  it('handles thrown errors and literals from constructor', async () => {
+    const viewerContext = instance(mock(ViewerContext));
+    const queryContext = StubQueryContextProvider.getQueryContext();
+
+    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      testEntityConfiguration,
+      StubDatabaseAdapter.convertFieldObjectsToDataStore(
+        testEntityConfiguration,
+        new Map([
+          [
+            testEntityConfiguration.tableName,
+            [
+              {
+                id: ID_SENTINEL_THROW_LITERAL,
+              },
+              {
+                id: ID_SENTINEL_THROW_ERROR,
+              },
+            ],
+          ],
+        ])
+      )
+    );
+    const privacyPolicy = new TestEntityPrivacyPolicy();
+    const cacheAdapterProvider = new NoCacheStubCacheAdapterProvider();
+    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+    const dataManager = new EntityDataManager(
+      databaseAdapter,
+      entityCache,
+      StubQueryContextProvider,
+      instance(mock<IEntityMetricsAdapter>()),
+      TestEntity.name
+    );
+    const entityLoader = new EntityLoader(
+      viewerContext,
+      queryContext,
+      testEntityConfiguration,
+      TestEntity,
+      privacyPolicy,
+      dataManager
+    );
+
+    let capturedThrownThing1: any;
+    try {
+      await entityLoader.loadByIDAsync(ID_SENTINEL_THROW_LITERAL);
+    } catch (e) {
+      capturedThrownThing1 = e;
+    }
+    expect(capturedThrownThing1).not.toBeInstanceOf(Error);
+    expect(capturedThrownThing1).toEqual('hello');
+
+    const result = await entityLoader.loadByIDAsync(ID_SENTINEL_THROW_ERROR);
+    expect(result.ok).toBe(false);
+    expect(result.enforceError().message).toEqual('world');
+  });
+});

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -125,15 +125,15 @@ const setUpMutationTriggerSpies = (
   keyof TestFields
 > => {
   return {
-    beforeCreate: [spy(mutationTriggers.beforeCreate![0])],
-    afterCreate: [spy(mutationTriggers.afterCreate![0])],
-    beforeUpdate: [spy(mutationTriggers.beforeUpdate![0])],
-    afterUpdate: [spy(mutationTriggers.afterUpdate![0])],
-    beforeDelete: [spy(mutationTriggers.beforeDelete![0])],
-    afterDelete: [spy(mutationTriggers.afterDelete![0])],
-    beforeAll: [spy(mutationTriggers.beforeAll![0])],
-    afterAll: [spy(mutationTriggers.afterAll![0])],
-    afterCommit: [spy(mutationTriggers.afterCommit![0])],
+    beforeCreate: [spy(mutationTriggers.beforeCreate![0]!)],
+    afterCreate: [spy(mutationTriggers.afterCreate![0]!)],
+    beforeUpdate: [spy(mutationTriggers.beforeUpdate![0]!)],
+    afterUpdate: [spy(mutationTriggers.afterUpdate![0]!)],
+    beforeDelete: [spy(mutationTriggers.beforeDelete![0]!)],
+    afterDelete: [spy(mutationTriggers.afterDelete![0]!)],
+    beforeAll: [spy(mutationTriggers.beforeAll![0]!)],
+    afterAll: [spy(mutationTriggers.afterAll![0]!)],
+    afterCommit: [spy(mutationTriggers.afterCommit![0]!)],
   };
 };
 
@@ -189,7 +189,7 @@ const verifyTriggerCounts = (
   });
 
   verify(
-    mutationTriggerSpies.beforeAll![0].executeAsync(
+    mutationTriggerSpies.beforeAll![0]!.executeAsync(
       viewerContext,
       anyOfClass(EntityTransactionalQueryContext),
       anyOfClass(TestEntity),
@@ -198,7 +198,7 @@ const verifyTriggerCounts = (
   ).once();
 
   verify(
-    mutationTriggerSpies.afterAll![0].executeAsync(
+    mutationTriggerSpies.afterAll![0]!.executeAsync(
       viewerContext,
       anyOfClass(EntityTransactionalQueryContext),
       anyOfClass(TestEntity),
@@ -207,7 +207,7 @@ const verifyTriggerCounts = (
   ).once();
 
   verify(
-    mutationTriggerSpies.afterCommit![0].executeAsync(
+    mutationTriggerSpies.afterCommit![0]!.executeAsync(
       viewerContext,
       anyOfClass(TestEntity),
       deepEqual(mutationInfo)

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -45,8 +45,8 @@ describe('Two entities backed by the same table', () => {
     expect(successfulManyResults).toHaveLength(1);
     expect(failedManyResults).toHaveLength(1);
 
-    expect(successfulManyResults[0].enforceValue().getID()).toEqual(one.getID());
-    expect(failedManyResults[0].enforceError().message).toEqual(
+    expect(successfulManyResults[0]!.enforceValue().getID()).toEqual(one.getID());
+    expect(failedManyResults[0]!.enforceError().message).toEqual(
       'OneTestEntity must be instantiated with one data'
     );
 

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -125,7 +125,8 @@ export default class EntityDataManager<TFields> {
     const results = await dataLoader.loadMany(fieldValues);
     const [values, errors] = partitionErrors(results);
     if (errors.length > 0) {
-      throw errors[0];
+      const error = errors[0]!;
+      throw error;
     }
 
     return zipToMap(fieldValues, values);

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -298,7 +298,7 @@ describe(EntityDataManager, () => {
     );
     const queryContext = StubQueryContextProvider.getQueryContext();
 
-    const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1];
+    const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1]!;
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
@@ -337,7 +337,7 @@ describe(EntityDataManager, () => {
     );
     const queryContext = StubQueryContextProvider.getQueryContext();
 
-    const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1];
+    const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1]!;
 
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -71,7 +71,7 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
       return 0;
     }
 
-    const currentOrderBy = orderBys[0];
+    const currentOrderBy = orderBys[0]!;
     const aField = objectA[currentOrderBy.columnName];
     const bField = objectB[currentOrderBy.columnName];
     switch (currentOrderBy.order) {
@@ -211,7 +211,7 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
       ...objectCollection[objectIndex],
       ...object,
     };
-    return [objectCollection[objectIndex]];
+    return [objectCollection[objectIndex]!];
   }
 
   protected async deleteInternalAsync(

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -247,7 +247,7 @@ describe(StubDatabaseAdapter, () => {
         {}
       );
       expect(results).toHaveLength(2);
-      expect(results[0].nullableField).toBeNull();
+      expect(results[0]!.nullableField).toBeNull();
 
       const results2 = await databaseAdapter.fetchManyByFieldEqualityConjunctionAsync(
         queryContext,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
     "esModuleInterop": true,
     "types": ["jest", "node"]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,22 +508,22 @@
     minimist "^1.2.0"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.14.1"
+  version "0.17.0"
   dependencies:
     ioredis "^4.27.3"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.14.1"
+  version "0.17.0"
   dependencies:
     knex "^0.95.6"
 
 "@expo/entity-secondary-cache-redis@file:packages/entity-secondary-cache-redis":
-  version "0.14.1"
+  version "0.17.0"
   dependencies:
     ioredis "^4.17.3"
 
 "@expo/entity@file:packages/entity":
-  version "0.14.1"
+  version "0.17.0"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"
@@ -3265,11 +3265,6 @@ colorette@1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -4776,7 +4771,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.6:
+glob@^7.1.6, glob@^7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -6135,6 +6130,13 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -6613,10 +6615,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.5.tgz#2d15c759b9497b0e7b5b57f4c2edabe1002ef9e7"
-  integrity sha512-yfCEUXmKhBPLOzEC7c+tc4XZdIeTdGoRCZakFMkCxodr7wDXqoapIME4wjcpBPJLNyUnKJ3e8rb8wlAgnLnaDw==
+marked@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.2.tgz#60ce97d6aec34dd882ab4bb4df82494666854e17"
+  integrity sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -8490,7 +8492,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.3, shelljs@^0.8.4:
+shelljs@^0.8.3:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -8504,13 +8506,14 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shiki@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.3.tgz#7bf7bcf3ed50ca525ec89cc09254abce4264d5ca"
-  integrity sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==
+shiki@^0.9.8:
+  version "0.9.10"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.10.tgz#feb8d4938b5dd71c5c8b1c1c7cd28fbbd37da087"
+  integrity sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==
   dependencies:
+    json5 "^2.2.0"
     onigasm "^2.2.5"
-    vscode-textmate "^5.2.0"
+    vscode-textmate "5.2.0"
 
 side-channel@^1.0.2:
   version "1.0.2"
@@ -9430,27 +9433,24 @@ typedoc-default-themes@^0.12.10:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
   integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
 
-typedoc@^0.20.36:
-  version "0.20.36"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.36.tgz#ee5523c32f566ad8283fc732aa8ea322d1a45f6a"
-  integrity sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==
+typedoc@^0.21.9:
+  version "0.21.9"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.9.tgz#6fbdc7152024a00f03af53a0ca40f44e91f0f129"
+  integrity sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==
   dependencies:
-    colors "^1.4.0"
-    fs-extra "^9.1.0"
+    glob "^7.1.7"
     handlebars "^4.7.7"
-    lodash "^4.17.21"
     lunr "^2.3.9"
-    marked "^2.0.3"
+    marked "^3.0.2"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.4"
-    shiki "^0.9.3"
+    shiki "^0.9.8"
     typedoc-default-themes "^0.12.10"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 uglify-js@^3.1.4:
   version "3.9.1"
@@ -9625,7 +9625,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-textmate@^5.2.0:
+vscode-textmate@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
   integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==


### PR DESCRIPTION
# Why

We're a few versions behind. This comes with quite a few new features, but the ones that affect this repo or are likely to affect it are:
- [`noPropertyAccessFromIndexSignature`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#--nopropertyaccessfromindexsignature): stricter rules around property access on not-well-specified object types. Helps with property misspellings mostly.
- [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess): stricter index access checks where array indexing can return undefined. This is much more in alignment with this codebase's style than unchecked, but I can see how it may not be appropriate for all codebases.
- [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes): Makes assigning undefined to an object property value need to specify it as a possible RHS value rather than the odd left-hand `?` operator. This is more along the lines of how I think about typesystems working with JS objects, and is how this codebase was written in most cases (fixes a couple). This helps with a rare but potential bug due to a difference between a property existing and being assigned to undefined and not existing.
- Always truthy promise checks https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#always-truthy-promise-checks - We already have a lint rule for this I believe, but this codifies it in the typechecker which is better.
- `override` (next PR): https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#override-and-the---noimplicitoverride-flag
- defaulting to `useUnknownInCatchVariables` in strict: Since JS can throw non-errors this is more correct, and even if we don't expect/allow first-party code to throw non-errors, libraries may still do it. This helps us catch odd bugs where that may be the case.

In addition to those, it is faster in general.

# How

Upgrade the package. Ensure all tests and docs generation pass.

# Test Plan

Wait for CI.
