### PR TITLE
feat: use better QueryContext types for transactional triggers and validators

### DIFF
--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -1,5 +1,5 @@
 import { EntityMutationInfo } from './EntityMutator';
-import { EntityQueryContext } from './EntityQueryContext';
+import { EntityTransactionalQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 
@@ -78,7 +78,7 @@ export abstract class EntityMutationTrigger<
 > {
   abstract executeAsync(
     viewerContext: TViewerContext,
-    queryContext: EntityQueryContext,
+    queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
     mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void>;

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -1,5 +1,5 @@
 import { EntityMutationInfo } from './EntityMutator';
-import { EntityQueryContext } from './EntityQueryContext';
+import { EntityTransactionalQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 
@@ -16,7 +16,7 @@ export default abstract class EntityMutationValidator<
 > {
   abstract executeAsync(
     viewerContext: TViewerContext,
-    queryContext: EntityQueryContext,
+    queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
     mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void>;

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -115,7 +115,7 @@ abstract class BaseMutator<
       | EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
       | EntityMutationValidator<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
       | undefined,
-    queryContext: EntityQueryContext,
+    queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
     mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void> {


### PR DESCRIPTION
# Why

There is a use case for triggers to run in two phases:
1. Phase 1 runs during the transaction, and collects data for use in phase 2
2. Phase 2 runs after the transaction and operates on data collected in phase 1, but in a non-transactional context

The way to implement this is with a transactional trigger that calls `queryContext.appendPostTransactionCallback` for phase 2. That method is only available on `EntityTransactionalQueryContext`, and since we can be guaranteed that these types of triggers have a transactional query context we can type it as such.

# How

Update the types to match reality.

# Test Plan

`yarn tsc`
