### PR TITLE
fix: separate post-commit invalidation callbacks from trigger and user callbacks

### DIFF
--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -250,7 +250,7 @@ export class CreateMutator<
     const insertResult = await this.databaseAdapter.insertAsync(queryContext, this.fieldsForEntity);
 
     const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, queryContext);
-    queryContext.appendPostCommitCallback(
+    queryContext.appendPostCommitInvalidationCallback(
       entityLoader.invalidateFieldsAsync.bind(entityLoader, insertResult)
     );
 
@@ -445,13 +445,13 @@ export class UpdateMutator<
 
     const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, queryContext);
 
-    queryContext.appendPostCommitCallback(
+    queryContext.appendPostCommitInvalidationCallback(
       entityLoader.invalidateFieldsAsync.bind(
         entityLoader,
         this.originalEntity.getAllDatabaseFields()
       )
     );
-    queryContext.appendPostCommitCallback(
+    queryContext.appendPostCommitInvalidationCallback(
       entityLoader.invalidateFieldsAsync.bind(entityLoader, this.fieldsForEntity)
     );
 
@@ -633,7 +633,7 @@ export class DeleteMutator<
     }
 
     const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, queryContext);
-    queryContext.appendPostCommitCallback(
+    queryContext.appendPostCommitInvalidationCallback(
       entityLoader.invalidateFieldsAsync.bind(entityLoader, this.entity.getAllDatabaseFields())
     );
 

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -1,0 +1,105 @@
+import Entity from '../Entity';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField } from '../EntityFields';
+import { EntityNonTransactionalMutationTrigger } from '../EntityMutationTriggerConfiguration';
+import { EntityMutationType, EntityMutationInfo } from '../EntityMutator';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import ViewerContext from '../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
+import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
+
+type BlahFields = {
+  id: string;
+};
+
+class BlahEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  protected override readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+  ];
+  protected override readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+  ];
+  protected override readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+  ];
+  protected override readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+  ];
+}
+
+class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    BlahFields,
+    string,
+    ViewerContext,
+    BlahEntity,
+    BlahEntityPrivacyPolicy
+  > {
+    return blahCompanion;
+  }
+}
+
+const blahCompanion = new EntityCompanionDefinition({
+  entityClass: BlahEntity,
+  entityConfiguration: new EntityConfiguration<BlahFields>({
+    idField: 'id',
+    tableName: 'blah_table',
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+        cache: true,
+      }),
+    },
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
+  }),
+  privacyPolicyClass: BlahEntityPrivacyPolicy,
+  mutationTriggers: () => ({
+    afterCommit: [new TestNonTransactionalMutationTrigger()],
+  }),
+});
+
+class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutationTrigger<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  async executeAsync(
+    viewerContext: ViewerContext,
+    entity: BlahEntity,
+    mutationInfo: EntityMutationInfo<BlahFields, string, ViewerContext, BlahEntity>
+  ): Promise<void> {
+    if (mutationInfo.type === EntityMutationType.DELETE) {
+      const entityLoaded = await BlahEntity.loader(viewerContext)
+        .enforcing()
+        .loadByIDNullableAsync(entity.getID());
+      if (entityLoaded) {
+        throw new Error(
+          'should not have been able to re-load the entity after delete. this means the cache has not been cleared'
+        );
+      }
+    }
+  }
+}
+
+describe('EntityMutator', () => {
+  test('cache concistency with post-commit callbacks', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    // put it in cache
+    const entity = await BlahEntity.creator(viewerContext).enforceCreateAsync();
+    const entityLoaded = await BlahEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity.getID());
+
+    await BlahEntity.enforceDeleteAsync(entityLoaded);
+  });
+});

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -90,7 +90,7 @@ class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutation
 }
 
 describe('EntityMutator', () => {
-  test('cache concistency with post-commit callbacks', async () => {
+  test('cache consistency with post-commit callbacks', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
 


### PR DESCRIPTION
# Why

The issue we're seeing is:
- A post-commit trigger is calling load on data that was deleted. This call should be possible (using loadNullable).
- The cache still has data in it since the ordering of post-commit callbacks is undefined.
- The data is loaded even though it no longer exists.

# How

To fix this, add some strict ordering to post-commit callbacks to ensure that post-commit invalidations run before any other callbacks. This ensures that the post-commit callbacks that access the cache have consistent cache loads.

# Test Plan

- Run the new test without the fix, see that it fails (the exception is thrown)
- Run the new test with the fix, see that it passes.