### PR TITLE
feat: add cascading deletion info

### DIFF
--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -10,7 +10,7 @@ import {
   EntityMutationTrigger,
   EntityQueryContext,
   EntityNonTransactionalMutationTrigger,
-  EntityMutationInfo,
+  EntityTriggerMutationInfo,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -111,7 +111,7 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
     entity: PostgresTriggerTestEntity,
-    _mutationInfo: EntityMutationInfo<
+    _mutationInfo: EntityTriggerMutationInfo<
       PostgresTriggerTestEntityFields,
       string,
       ViewerContext,

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -9,7 +9,7 @@ import {
   Entity,
   EntityMutationTrigger,
   EntityQueryContext,
-  EntityMutationInfo,
+  EntityValidatorMutationInfo,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -113,7 +113,7 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
     entity: PostgresValidatorTestEntity,
-    _mutationInfo: EntityMutationInfo<
+    _mutationInfo: EntityValidatorMutationInfo<
       PostgresValidatorTestEntityFields,
       string,
       ViewerContext,

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -1,0 +1,47 @@
+import Entity from './Entity';
+import ViewerContext from './ViewerContext';
+
+export enum EntityMutationType {
+  CREATE,
+  UPDATE,
+  DELETE,
+}
+
+export type EntityValidatorMutationInfo<
+  TFields,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> =
+  | {
+      type: EntityMutationType.CREATE;
+    }
+  | {
+      type: EntityMutationType.UPDATE;
+      previousValue: TEntity;
+    };
+
+export type EntityMutationTriggerDeleteCascadeInfo<> = {
+  entity: Entity<any, any, any, any>;
+  cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null;
+};
+
+export type EntityTriggerMutationInfo<
+  TFields,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> =
+  | {
+      type: EntityMutationType.CREATE;
+    }
+  | {
+      type: EntityMutationType.UPDATE;
+      previousValue: TEntity;
+    }
+  | {
+      type: EntityMutationType.DELETE;
+      cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null;
+    };

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -1,4 +1,4 @@
-import { EntityMutationInfo } from './EntityMutator';
+import { EntityTriggerMutationInfo } from './EntityMutationInfo';
 import { EntityTransactionalQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -80,7 +80,7 @@ export abstract class EntityMutationTrigger<
     viewerContext: TViewerContext,
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
-    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void>;
 }
 
@@ -98,6 +98,6 @@ export abstract class EntityNonTransactionalMutationTrigger<
   abstract executeAsync(
     viewerContext: TViewerContext,
     entity: TEntity,
-    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void>;
 }

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -1,4 +1,4 @@
-import { EntityMutationInfo } from './EntityMutator';
+import { EntityValidatorMutationInfo } from './EntityMutationInfo';
 import { EntityTransactionalQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -18,6 +18,12 @@ export default abstract class EntityMutationValidator<
     viewerContext: TViewerContext,
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
-    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+    mutationInfo: EntityValidatorMutationInfo<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >
   ): Promise<void>;
 }

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -93,9 +93,7 @@ abstract class BaseMutator<
   }
 
   protected async executeMutationValidatorsAsync(
-    validators:
-      | EntityMutationValidator<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
-      | undefined,
+    validators: EntityMutationValidator<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
     mutationInfo: EntityValidatorMutationInfo<
@@ -106,9 +104,6 @@ abstract class BaseMutator<
       TSelectedFields
     >
   ): Promise<void> {
-    if (!validators) {
-      return;
-    }
     await Promise.all(
       validators.map((validator) =>
         validator.executeAsync(this.viewerContext, queryContext, entity, mutationInfo)

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -7,6 +7,12 @@ import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import { EntityEdgeDeletionBehavior } from './EntityFieldDefinition';
 import EntityLoaderFactory from './EntityLoaderFactory';
+import {
+  EntityValidatorMutationInfo,
+  EntityMutationType,
+  EntityTriggerMutationInfo,
+  EntityMutationTriggerDeleteCascadeInfo,
+} from './EntityMutationInfo';
 import EntityMutationTriggerConfiguration, {
   EntityMutationTrigger,
   EntityNonTransactionalMutationTrigger,
@@ -20,30 +26,6 @@ import EntityInvalidFieldValueError from './errors/EntityInvalidFieldValueError'
 import { timeAndLogMutationEventAsync } from './metrics/EntityMetricsUtils';
 import IEntityMetricsAdapter, { EntityMetricsMutationType } from './metrics/IEntityMetricsAdapter';
 import { mapMapAsync } from './utils/collections/maps';
-
-export enum EntityMutationType {
-  CREATE,
-  UPDATE,
-  DELETE,
-}
-
-export type EntityMutationInfo<
-  TFields,
-  TID extends NonNullable<TFields[TSelectedFields]>,
-  TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields = keyof TFields
-> =
-  | {
-      type: EntityMutationType.CREATE;
-    }
-  | {
-      type: EntityMutationType.UPDATE;
-      previousValue: TEntity;
-    }
-  | {
-      type: EntityMutationType.DELETE;
-    };
 
 abstract class BaseMutator<
   TFields,
@@ -110,26 +92,49 @@ abstract class BaseMutator<
     }
   }
 
-  protected async executeMutationTriggersOrValidatorsAsync(
-    triggersOrValidators:
-      | EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
+  protected async executeMutationValidatorsAsync(
+    validators:
       | EntityMutationValidator<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
       | undefined,
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
-    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+    mutationInfo: EntityValidatorMutationInfo<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >
   ): Promise<void> {
-    if (!triggersOrValidators) {
+    if (!validators) {
       return;
     }
     await Promise.all(
-      triggersOrValidators.map((triggerOrValidator) =>
-        triggerOrValidator.executeAsync(this.viewerContext, queryContext, entity, mutationInfo)
+      validators.map((validator) =>
+        validator.executeAsync(this.viewerContext, queryContext, entity, mutationInfo)
       )
     );
   }
 
-  protected async executeNonTransactionalMutationTriggersOrValidatorsAsync(
+  protected async executeMutationTriggersAsync(
+    triggers:
+      | EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
+      | undefined,
+    queryContext: EntityTransactionalQueryContext,
+    entity: TEntity,
+    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+  ): Promise<void> {
+    if (!triggers) {
+      return;
+    }
+    await Promise.all(
+      triggers.map((trigger) =>
+        trigger.executeAsync(this.viewerContext, queryContext, entity, mutationInfo)
+      )
+    );
+  }
+
+  protected async executeNonTransactionalMutationTriggersAsync(
     triggers:
       | EntityNonTransactionalMutationTrigger<
           TFields,
@@ -140,7 +145,7 @@ abstract class BaseMutator<
         >[]
       | undefined,
     entity: TEntity,
-    mutationInfo: EntityMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>
   ): Promise<void> {
     if (!triggers) {
       return;
@@ -228,19 +233,19 @@ export class CreateMutator<
       return authorizeCreateResult;
     }
 
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationValidatorsAsync(
       this.mutationValidators,
       queryContext,
       temporaryEntityForPrivacyCheck,
       { type: EntityMutationType.CREATE }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeAll,
       queryContext,
       temporaryEntityForPrivacyCheck,
       { type: EntityMutationType.CREATE }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeCreate,
       queryContext,
       temporaryEntityForPrivacyCheck,
@@ -259,13 +264,13 @@ export class CreateMutator<
       .enforcing()
       .loadByIDAsync(unauthorizedEntityAfterInsert.getID());
 
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterCreate,
       queryContext,
       newEntity,
       { type: EntityMutationType.CREATE }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterAll,
       queryContext,
       newEntity,
@@ -273,7 +278,7 @@ export class CreateMutator<
     );
 
     queryContext.appendPostCommitCallback(
-      this.executeNonTransactionalMutationTriggersOrValidatorsAsync.bind(
+      this.executeNonTransactionalMutationTriggersAsync.bind(
         this,
         this.mutationTriggers.afterCommit,
         newEntity,
@@ -417,19 +422,19 @@ export class UpdateMutator<
       return authorizeUpdateResult;
     }
 
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationValidatorsAsync(
       this.mutationValidators,
       queryContext,
       entityAboutToBeUpdated,
       { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeAll,
       queryContext,
       entityAboutToBeUpdated,
       { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeUpdate,
       queryContext,
       entityAboutToBeUpdated,
@@ -460,13 +465,13 @@ export class UpdateMutator<
       .enforcing()
       .loadByIDAsync(unauthorizedEntityAfterUpdate.getID());
 
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterUpdate,
       queryContext,
       updatedEntity,
       { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterAll,
       queryContext,
       updatedEntity,
@@ -474,7 +479,7 @@ export class UpdateMutator<
     );
 
     queryContext.appendPostCommitCallback(
-      this.executeNonTransactionalMutationTriggersOrValidatorsAsync.bind(
+      this.executeNonTransactionalMutationTriggersAsync.bind(
         this,
         this.mutationTriggers.afterCommit,
         updatedEntity,
@@ -565,7 +570,7 @@ export class DeleteMutator<
       this.metricsAdapter,
       EntityMetricsMutationType.DELETE,
       this.entityClass.name
-    )(this.deleteInTransactionAsync());
+    )(this.deleteInTransactionAsync(new Set(), false, null));
   }
 
   /**
@@ -576,14 +581,16 @@ export class DeleteMutator<
   }
 
   private async deleteInTransactionAsync(
-    processedEntityIdentifiersFromTransitiveDeletions: Set<string> = new Set(),
-    skipDatabaseDeletion: boolean = false
+    processedEntityIdentifiersFromTransitiveDeletions: Set<string>,
+    skipDatabaseDeletion: boolean,
+    cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null
   ): Promise<Result<void>> {
     return await this.queryContext.runInTransactionIfNotInTransactionAsync((innerQueryContext) =>
       this.deleteInternalAsync(
         innerQueryContext,
         processedEntityIdentifiersFromTransitiveDeletions,
-        skipDatabaseDeletion
+        skipDatabaseDeletion,
+        cascadingDeleteCause
       )
     );
   }
@@ -591,7 +598,8 @@ export class DeleteMutator<
   private async deleteInternalAsync(
     queryContext: EntityTransactionalQueryContext,
     processedEntityIdentifiersFromTransitiveDeletions: Set<string>,
-    skipDatabaseDeletion: boolean
+    skipDatabaseDeletion: boolean,
+    cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null
   ): Promise<Result<void>> {
     const authorizeDeleteResult = await asyncResult(
       this.privacyPolicy.authorizeDeleteAsync(
@@ -608,20 +616,21 @@ export class DeleteMutator<
     await this.processEntityDeletionForInboundEdgesAsync(
       this.entity,
       queryContext,
-      processedEntityIdentifiersFromTransitiveDeletions
+      processedEntityIdentifiersFromTransitiveDeletions,
+      cascadingDeleteCause
     );
 
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeAll,
       queryContext,
       this.entity,
-      { type: EntityMutationType.DELETE }
+      { type: EntityMutationType.DELETE, cascadingDeleteCause }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeDelete,
       queryContext,
       this.entity,
-      { type: EntityMutationType.DELETE }
+      { type: EntityMutationType.DELETE, cascadingDeleteCause }
     );
 
     if (!skipDatabaseDeletion) {
@@ -637,25 +646,25 @@ export class DeleteMutator<
       entityLoader.invalidateFieldsAsync.bind(entityLoader, this.entity.getAllDatabaseFields())
     );
 
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterDelete,
       queryContext,
       this.entity,
-      { type: EntityMutationType.DELETE }
+      { type: EntityMutationType.DELETE, cascadingDeleteCause }
     );
-    await this.executeMutationTriggersOrValidatorsAsync(
+    await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterAll,
       queryContext,
       this.entity,
-      { type: EntityMutationType.DELETE }
+      { type: EntityMutationType.DELETE, cascadingDeleteCause }
     );
 
     queryContext.appendPostCommitCallback(
-      this.executeNonTransactionalMutationTriggersOrValidatorsAsync.bind(
+      this.executeNonTransactionalMutationTriggersAsync.bind(
         this,
         this.mutationTriggers.afterCommit,
         this.entity,
-        { type: EntityMutationType.DELETE }
+        { type: EntityMutationType.DELETE, cascadingDeleteCause }
       )
     );
 
@@ -679,7 +688,8 @@ export class DeleteMutator<
   private async processEntityDeletionForInboundEdgesAsync(
     entity: TEntity,
     queryContext: EntityTransactionalQueryContext,
-    processedEntityIdentifiers: Set<string>
+    processedEntityIdentifiers: Set<string>,
+    cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null
   ): Promise<void> {
     // prevent infinite reference cycles by keeping track of entities already processed
     if (processedEntityIdentifiers.has(entity.getUniqueIdentifier())) {
@@ -752,7 +762,11 @@ export class DeleteMutator<
                       .forDelete(inboundReferenceEntity, queryContext)
                       .deleteInTransactionAsync(
                         processedEntityIdentifiers,
-                        /* skipDatabaseDeletion */ true // deletion is handled by DB
+                        /* skipDatabaseDeletion */ true, // deletion is handled by DB
+                        {
+                          entity,
+                          cascadingDeleteCause,
+                        }
                       )
                   )
                 );
@@ -776,7 +790,11 @@ export class DeleteMutator<
                       .forDelete(inboundReferenceEntity, queryContext)
                       .deleteInTransactionAsync(
                         processedEntityIdentifiers,
-                        /* skipDatabaseDeletion */ false
+                        /* skipDatabaseDeletion */ false,
+                        {
+                          entity,
+                          cascadingDeleteCause,
+                        }
                       )
                   )
                 );

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -3,7 +3,10 @@ import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition';
 import { UUIDField } from '../EntityFields';
+import { EntityTriggerMutationInfo, EntityMutationType } from '../EntityMutationInfo';
+import { EntityMutationTrigger } from '../EntityMutationTriggerConfiguration';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import { EntityTransactionalQueryContext } from '../EntityQueryContext';
 import { CacheStatus } from '../internal/ReadThroughEntityCache';
 import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
 import TestViewerContext from '../testfixtures/TestViewerContext';
@@ -47,6 +50,125 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
+  const triggerExecutionCounts = {
+    parent: 0,
+    child: 0,
+    grandchild: 0,
+  };
+
+  class ParentCheckInfoTrigger extends EntityMutationTrigger<
+    ParentFields,
+    string,
+    TestViewerContext,
+    ParentEntity
+  > {
+    async executeAsync(
+      _viewerContext: TestViewerContext,
+      _queryContext: EntityTransactionalQueryContext,
+      _entity: ParentEntity,
+      mutationInfo: EntityTriggerMutationInfo<ParentFields, string, TestViewerContext, ParentEntity>
+    ): Promise<void> {
+      if (mutationInfo.type !== EntityMutationType.DELETE) {
+        return;
+      }
+
+      if (mutationInfo.cascadingDeleteCause !== null) {
+        throw new Error('Parent entity should not have casade delete cause');
+      }
+
+      triggerExecutionCounts.parent++;
+    }
+  }
+
+  class ChildCheckInfoTrigger extends EntityMutationTrigger<
+    ChildFields,
+    string,
+    TestViewerContext,
+    ChildEntity
+  > {
+    async executeAsync(
+      _viewerContext: TestViewerContext,
+      _queryContext: EntityTransactionalQueryContext,
+      _entity: ChildEntity,
+      mutationInfo: EntityTriggerMutationInfo<ChildFields, string, TestViewerContext, ChildEntity>
+    ): Promise<void> {
+      if (mutationInfo.type !== EntityMutationType.DELETE) {
+        return;
+      }
+
+      if (mutationInfo.cascadingDeleteCause === null) {
+        throw new Error('Child entity should have casade delete cause');
+      }
+
+      const cascadingDeleteCauseEntity = mutationInfo.cascadingDeleteCause.entity;
+      if (!(cascadingDeleteCauseEntity instanceof ParentEntity)) {
+        throw new Error('Child entity should have casade delete cause entity of type ParentEntity');
+      }
+
+      const secondLevelCascadingDeleteCause =
+        mutationInfo.cascadingDeleteCause.cascadingDeleteCause;
+      if (secondLevelCascadingDeleteCause) {
+        throw new Error('Child entity should not have two-level casade delete cause');
+      }
+
+      triggerExecutionCounts.child++;
+    }
+  }
+
+  class GrandChildCheckInfoTrigger extends EntityMutationTrigger<
+    GrandChildFields,
+    string,
+    TestViewerContext,
+    GrandChildEntity
+  > {
+    async executeAsync(
+      _viewerContext: TestViewerContext,
+      _queryContext: EntityTransactionalQueryContext,
+      _entity: GrandChildEntity,
+      mutationInfo: EntityTriggerMutationInfo<
+        GrandChildFields,
+        string,
+        TestViewerContext,
+        GrandChildEntity
+      >
+    ): Promise<void> {
+      if (mutationInfo.type !== EntityMutationType.DELETE) {
+        return;
+      }
+
+      if (mutationInfo.cascadingDeleteCause === null) {
+        throw new Error('GrandChild entity should have casade delete cause');
+      }
+
+      const cascadingDeleteCauseEntity = mutationInfo.cascadingDeleteCause.entity;
+      if (!(cascadingDeleteCauseEntity instanceof ChildEntity)) {
+        throw new Error(
+          'GrandChild entity should have casade delete cause entity of type ChildEntity'
+        );
+      }
+
+      const secondLevelCascadingDeleteCause =
+        mutationInfo.cascadingDeleteCause.cascadingDeleteCause;
+      if (!secondLevelCascadingDeleteCause) {
+        throw new Error('GrandChild entity should have two-level casade delete cause');
+      }
+
+      const secondLevelCascadingDeleteCauseEntity = secondLevelCascadingDeleteCause.entity;
+      if (!(secondLevelCascadingDeleteCauseEntity instanceof ParentEntity)) {
+        throw new Error(
+          'GrandChild entity should have second level casade delete cause entity of type ParentEntity'
+        );
+      }
+
+      const thirdLevelCascadingDeleteCause = secondLevelCascadingDeleteCause.cascadingDeleteCause;
+      if (thirdLevelCascadingDeleteCause) {
+        throw new Error('GrandChild entity should not have three-level casade delete cause');
+      }
+
+      triggerExecutionCounts.grandchild++;
+    }
+  }
+
   class ParentEntity extends Entity<ParentFields, string, TestViewerContext> {
     static getCompanionDefinition(): EntityCompanionDefinition<
       ParentFields,
@@ -144,33 +266,45 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     entityClass: ParentEntity,
     entityConfiguration: parentEntityConfiguration,
     privacyPolicyClass: TestEntityPrivacyPolicy,
+    mutationTriggers: () => ({
+      beforeDelete: [new ParentCheckInfoTrigger()],
+      afterDelete: [new ParentCheckInfoTrigger()],
+    }),
   });
 
   const childEntityCompanion = new EntityCompanionDefinition({
     entityClass: ChildEntity,
     entityConfiguration: childEntityConfiguration,
     privacyPolicyClass: TestEntityPrivacyPolicy,
+    mutationTriggers: () => ({
+      beforeDelete: [new ChildCheckInfoTrigger()],
+      afterDelete: [new ChildCheckInfoTrigger()],
+    }),
   });
 
   const grandChildEntityCompanion = new EntityCompanionDefinition({
     entityClass: GrandChildEntity,
     entityConfiguration: grandChildEntityConfiguration,
     privacyPolicyClass: TestEntityPrivacyPolicy,
+    mutationTriggers: () => ({
+      beforeDelete: [new GrandChildCheckInfoTrigger()],
+      afterDelete: [new GrandChildCheckInfoTrigger()],
+    }),
   });
 
   return {
     ParentEntity,
     ChildEntity,
     GrandChildEntity,
+    triggerExecutionCounts,
   };
 };
 
 describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
   describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     it('deletes', async () => {
-      const { ParentEntity, ChildEntity, GrandChildEntity } = makeEntityClasses(
-        EntityEdgeDeletionBehavior.CASCADE_DELETE
-      );
+      const { ParentEntity, ChildEntity, GrandChildEntity, triggerExecutionCounts } =
+        makeEntityClasses(EntityEdgeDeletionBehavior.CASCADE_DELETE);
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
@@ -203,14 +337,20 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       await expect(
         GrandChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(grandchild.getID())
       ).resolves.toBeNull();
+
+      // two calls for each trigger, one beforeDelete, one afterDelete
+      expect(triggerExecutionCounts).toMatchObject({
+        parent: 2,
+        child: 2,
+        grandchild: 2,
+      });
     });
   });
 
   describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
     it('sets null', async () => {
-      const { ParentEntity, ChildEntity, GrandChildEntity } = makeEntityClasses(
-        EntityEdgeDeletionBehavior.SET_NULL
-      );
+      const { ParentEntity, ChildEntity, GrandChildEntity, triggerExecutionCounts } =
+        makeEntityClasses(EntityEdgeDeletionBehavior.SET_NULL);
 
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
@@ -248,14 +388,21 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         .enforcing()
         .loadByIDAsync(grandchild.getID());
       expect(loadedGrandchild.getField('parent_id')).toEqual(loadedChild.getID());
+
+      // two calls for only parent trigger, one beforeDelete, one afterDelete
+      // when using set null the descendants aren't deleted
+      expect(triggerExecutionCounts).toMatchObject({
+        parent: 2,
+        child: 0,
+        grandchild: 0,
+      });
     });
   });
 
   describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     it('invalidates the cache', async () => {
-      const { ParentEntity, ChildEntity, GrandChildEntity } = makeEntityClasses(
-        EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE
-      );
+      const { ParentEntity, ChildEntity, GrandChildEntity, triggerExecutionCounts } =
+        makeEntityClasses(EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE);
 
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
@@ -319,6 +466,13 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       await expect(
         GrandChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(grandchild.getID())
       ).resolves.not.toBeNull();
+
+      // two calls for each trigger, one beforeDelete, one afterDelete
+      expect(triggerExecutionCounts).toMatchObject({
+        parent: 2,
+        child: 2,
+        grandchild: 2,
+      });
     });
   });
 });

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -137,13 +137,13 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       }
 
       if (mutationInfo.cascadingDeleteCause === null) {
-        throw new Error('GrandChild entity should have casade delete cause');
+        throw new Error('GrandChild entity should have cascade delete cause');
       }
 
       const cascadingDeleteCauseEntity = mutationInfo.cascadingDeleteCause.entity;
       if (!(cascadingDeleteCauseEntity instanceof ChildEntity)) {
         throw new Error(
-          'GrandChild entity should have casade delete cause entity of type ChildEntity'
+          'GrandChild entity should have cascade delete cause entity of type ChildEntity'
         );
       }
 

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -2,8 +2,8 @@ import Entity from '../Entity';
 import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
+import { EntityMutationType, EntityTriggerMutationInfo } from '../EntityMutationInfo';
 import { EntityNonTransactionalMutationTrigger } from '../EntityMutationTriggerConfiguration';
-import { EntityMutationType, EntityMutationInfo } from '../EntityMutator';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
 import ViewerContext from '../ViewerContext';
 import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
@@ -74,7 +74,7 @@ class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutation
   async executeAsync(
     viewerContext: ViewerContext,
     entity: BlahEntity,
-    mutationInfo: EntityMutationInfo<BlahFields, string, ViewerContext, BlahEntity>
+    mutationInfo: EntityTriggerMutationInfo<BlahFields, string, ViewerContext, BlahEntity>
   ): Promise<void> {
     if (mutationInfo.type === EntityMutationType.DELETE) {
       const entityLoaded = await BlahEntity.loader(viewerContext)

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -14,12 +14,16 @@ import { v4 as uuidv4 } from 'uuid';
 
 import EntityDatabaseAdapter from '../EntityDatabaseAdapter';
 import EntityLoaderFactory from '../EntityLoaderFactory';
+import {
+  EntityMutationType,
+  EntityTriggerMutationInfo,
+  EntityValidatorMutationInfo,
+} from '../EntityMutationInfo';
 import EntityMutationTriggerConfiguration, {
   EntityMutationTrigger,
   EntityNonTransactionalMutationTrigger,
 } from '../EntityMutationTriggerConfiguration';
 import EntityMutationValidator from '../EntityMutationValidator';
-import { EntityMutationInfo, EntityMutationType } from '../EntityMutator';
 import EntityMutatorFactory from '../EntityMutatorFactory';
 import { EntityTransactionalQueryContext, EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
@@ -53,7 +57,7 @@ class TestMutationTrigger extends EntityMutationTrigger<
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
     _entity: TestEntity,
-    _mutationInfo: EntityMutationInfo<
+    _mutationInfo: EntityTriggerMutationInfo<
       TestFields,
       string,
       ViewerContext,
@@ -95,7 +99,13 @@ const verifyValidatorCounts = (
     keyof TestFields
   >[],
   expectedCalls: number,
-  mutationInfo: EntityMutationInfo<TestFields, string, ViewerContext, TestEntity, keyof TestFields>
+  mutationInfo: EntityValidatorMutationInfo<
+    TestFields,
+    string,
+    ViewerContext,
+    TestEntity,
+    keyof TestFields
+  >
 ): void => {
   for (const validator of mutationValidatorSpies) {
     verify(
@@ -164,7 +174,13 @@ const verifyTriggerCounts = (
     >,
     boolean
   >,
-  mutationInfo: EntityMutationInfo<TestFields, string, ViewerContext, TestEntity, keyof TestFields>
+  mutationInfo: EntityTriggerMutationInfo<
+    TestFields,
+    string,
+    ViewerContext,
+    TestEntity,
+    keyof TestFields
+  >
 ): void => {
   Object.keys(executed).forEach((s) => {
     if ((executed as any)[s]) {
@@ -767,7 +783,7 @@ describe(EntityMutatorFactory, () => {
           beforeDelete: true,
           afterDelete: true,
         },
-        { type: EntityMutationType.DELETE }
+        { type: EntityMutationType.DELETE, cascadingDeleteCause: null }
       );
     });
 
@@ -796,7 +812,9 @@ describe(EntityMutatorFactory, () => {
 
       await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
 
-      verifyValidatorCounts(viewerContext, validatorSpies, 0, { type: EntityMutationType.DELETE });
+      verifyValidatorCounts(viewerContext, validatorSpies, 0, {
+        type: EntityMutationType.DELETE as any,
+      });
     });
   });
 

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -33,6 +33,7 @@ export { default as EntitySecondaryCacheLoader } from './EntitySecondaryCacheLoa
 export * from './EntitySecondaryCacheLoader';
 export * from './EntityMutator';
 export { default as EntityMutationValidator } from './EntityMutationValidator';
+export * from './EntityMutationInfo';
 export * from './EntityMutationTriggerConfiguration';
 export { default as EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration';
 export { default as EntityMutatorFactory } from './EntityMutatorFactory';


### PR DESCRIPTION
# Why

The use case for this is as follows:
- We have a trigger that we want to execute to prevent deletion of an entity in certain cases but not others.
- In a normal deletion case, we want to prevent deletion if it is the last remaining entity of its type.
- In a cascade deletion case, we want to allow deletion even if it is the last remaining entity of its type so that it doesn't become orphaned.

# How

This feature lets us solve this by inspecting the value of the cascade to see what case it's being deleted in. If it is being deleted in the normal case (no cascading info or different type of cascade) then we block the deletion in a beforeDelete trigger. If it is being deleted in a cascade deletion case we allow the deletion.

# Test Plan

Run tests.
