### PR TITLE
feat: add pre-commit callbacks on EntityQueryContext

### DIFF
--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -1,6 +1,10 @@
 import EntityQueryContextProvider from './EntityQueryContextProvider';
 
 export type PostCommitCallback = (...args: any) => Promise<any>;
+export type PreCommitCallback = (
+  queryContext: EntityTransactionalQueryContext,
+  ...args: any
+) => Promise<any>;
 
 /**
  * Entity framework representation of transactional and non-transactional database
@@ -46,10 +50,20 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
   private readonly postCommitInvalidationCallbacks: PostCommitCallback[] = [];
   private readonly postCommitCallbacks: PostCommitCallback[] = [];
 
+  private readonly preCommitCallbacks: { callback: PreCommitCallback; order: number }[] = [];
+
+  /**
+   * Schedule a pre-commit callback. These will be run within the transaction.
+   * @param callback - callback to schedule
+   * @param order - order in which this should be run, with higher numbers running later than lower numbers
+   */
+  public appendPreCommitCallback(callback: PreCommitCallback, order: number): void {
+    this.preCommitCallbacks.push({ callback, order });
+  }
+
   /**
    * Schedule a post-commit cache invalidation callback. These are run before normal
    * post-commit callbacks in order to have cache consistency in normal post-commit callbacks.
-   *
    * @param callback - callback to schedule
    */
   public appendPostCommitInvalidationCallback(callback: PostCommitCallback): void {
@@ -63,6 +77,17 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
    */
   public appendPostCommitCallback(callback: PostCommitCallback): void {
     this.postCommitCallbacks.push(callback);
+  }
+
+  public async runPreCommitCallbacksAsync(): Promise<void> {
+    const callbacks = [...this.preCommitCallbacks]
+      .sort((a, b) => a.order - b.order)
+      .map((c) => c.callback);
+    this.preCommitCallbacks.length = 0;
+
+    for (const callback of callbacks) {
+      await callback(this);
+    }
   }
 
   public async runPostCommitCallbacksAsync(): Promise<void> {

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import EntityQueryContextProvider from './EntityQueryContextProvider';
 
 export type PostCommitCallback = (...args: any) => Promise<any>;
@@ -53,11 +55,18 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
   private readonly preCommitCallbacks: { callback: PreCommitCallback; order: number }[] = [];
 
   /**
-   * Schedule a pre-commit callback. These will be run within the transaction.
+   * Schedule a pre-commit callback. These will be run within the transaction right before it is
+   * committed, and will be run in the order specified. Ordering of callbacks scheduled with the
+   * same value for the order parameter is undefined within that ordering group.
    * @param callback - callback to schedule
-   * @param order - order in which this should be run, with higher numbers running later than lower numbers
+   * @param order - order in which this should be run relative to other scheduled pre-commit callbacks,
+   *                with higher numbers running later than lower numbers.
    */
   public appendPreCommitCallback(callback: PreCommitCallback, order: number): void {
+    assert(
+      order >= Number.MIN_SAFE_INTEGER && order <= Number.MAX_SAFE_INTEGER,
+      `Invalid order specified: ${order}`
+    );
     this.preCommitCallbacks.push({ callback, order });
   }
 

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -38,6 +38,7 @@ export default abstract class EntityQueryContextProvider {
     >()(async (queryInterface) => {
       const queryContext = new EntityTransactionalQueryContext(queryInterface);
       const result = await transactionScope(queryContext);
+      await queryContext.runPreCommitCallbacksAsync();
       return [result, queryContext];
     });
     await queryContext.runPostCommitCallbacksAsync();

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -1,0 +1,102 @@
+import invariant from 'invariant';
+
+import { EntityQueryContext } from '../EntityQueryContext';
+import ViewerContext from '../ViewerContext';
+import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
+
+describe(EntityQueryContext, () => {
+  describe('callbacks', () => {
+    it('calls all callbacks, and calls invalidation first', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      let preCommitFirstCallCount = 0;
+      let preCommitSecondCallCount = 0;
+      let postCommitCallCount = 0;
+      let postCommitInvalidationCallCount = 0;
+
+      const preCommitFirstCallback = async (): Promise<void> => {
+        preCommitFirstCallCount++;
+      };
+      const preCommitSecondCallback = async (): Promise<void> => {
+        preCommitSecondCallCount++;
+      };
+      const postCommitInvalidationCallback = async (): Promise<void> => {
+        postCommitInvalidationCallCount++;
+        invariant(
+          preCommitFirstCallCount === 1,
+          'preCommitInvalidation should be called before postCommits'
+        );
+        invariant(
+          preCommitSecondCallCount === 1,
+          'preCommitInvalidation should be called before postCommits'
+        );
+      };
+      const postCommitCallback = async (): Promise<void> => {
+        postCommitCallCount++;
+        invariant(
+          preCommitFirstCallCount === 1,
+          'preCommitInvalidation should be called before postCommits'
+        );
+        invariant(
+          preCommitSecondCallCount === 1,
+          'preCommitInvalidation should be called before postCommits'
+        );
+        invariant(
+          postCommitInvalidationCallCount === 1,
+          'postCommitInvalidation should be called before postCommit'
+        );
+      };
+
+      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          queryContext.appendPostCommitCallback(postCommitCallback);
+          queryContext.appendPostCommitInvalidationCallback(postCommitInvalidationCallback);
+          queryContext.appendPreCommitCallback(preCommitSecondCallback, 2);
+          queryContext.appendPreCommitCallback(preCommitFirstCallback, 1);
+        }
+      );
+
+      expect(preCommitFirstCallCount).toBe(1);
+      expect(preCommitSecondCallCount).toBe(1);
+      expect(postCommitCallCount).toBe(1);
+      expect(postCommitInvalidationCallCount).toBe(1);
+    });
+
+    it('prevents transaction from finishing when precommit throws (post commit callbacks are not called)', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      let preCommitCallCount = 0;
+      let postCommitCallCount = 0;
+      let postCommitInvalidationCallCount = 0;
+
+      const preCommitCallback = async (): Promise<void> => {
+        preCommitCallCount++;
+        throw new Error('wat');
+      };
+      const postCommitInvalidationCallback = async (): Promise<void> => {
+        postCommitInvalidationCallCount++;
+      };
+      const postCommitCallback = async (): Promise<void> => {
+        postCommitCallCount++;
+      };
+
+      await expect(
+        viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          'postgres',
+          async (queryContext) => {
+            queryContext.appendPostCommitCallback(postCommitCallback);
+            queryContext.appendPostCommitInvalidationCallback(postCommitInvalidationCallback);
+            queryContext.appendPreCommitCallback(preCommitCallback, 0);
+          }
+        )
+      ).rejects.toThrowError('wat');
+
+      expect(preCommitCallCount).toBe(1);
+      expect(postCommitCallCount).toBe(0);
+      expect(postCommitInvalidationCallCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
# Why

There are a lot of pieces of logic in our code that are similar in nature and contain all the following qualities:
- Execute during a postgres transaction (transactional query context)
- Non-transactional call to third-party service/dependency that throws when call is invalid or service is down. Think a call to stripe, bigquery log, etc.
- Critical for consistency. If the third party call throws, the transaction should roll back.
- Should be run as late as possible in the transaction. Or, put another way, if the transaction fails (code in transaction block throws) prior to this, this code should not be run.
- There are places where we have multiple of these types of calls and they need to be ordered according to some heuristic that the application determines.

Triggers unfortunately don't have the ability to specify when they should be run in relation to other triggers or during cascades (by design, I think, since it is tough to schedule cascading triggers). There are post-commit triggers/callbacks but those run outside the transaction.

# How

Introduce a new concept, a "Pre-commit callback". These will run serially in the order specified by the application right before the transaction commits. If one throws, subsequent ones won't be run and the transaction will be rolled-back.

# Test Plan

Run new tests.
