### PR TITLE
[entity][entity-cache-adapter-redis] move transformer responsibility …

### DIFF
--- a/packages/entity/src/EntityCacheAdapter.ts
+++ b/packages/entity/src/EntityCacheAdapter.ts
@@ -1,5 +1,4 @@
 import EntityConfiguration from './EntityConfiguration';
-import { FieldTransformerMap } from './internal/EntityFieldTransformationUtils';
 import { CacheLoadResult } from './internal/ReadThroughEntityCache';
 
 /**
@@ -8,13 +7,6 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
  */
 export default abstract class EntityCacheAdapter<TFields> {
   constructor(protected readonly entityConfiguration: EntityConfiguration<TFields>) {}
-
-  /**
-   * Transformer definitions for field types. Used to modify values as they are read from or written to
-   * the cache. Override in concrete subclasses to change transformation behavior.
-   * If a field type is not present in the map, then fields of that type will not be transformed.
-   */
-  public abstract getFieldTransformerMap(): FieldTransformerMap;
 
   /**
    * Load many objects from cache.

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -3,11 +3,6 @@ import invariant from 'invariant';
 import EntityCacheAdapter from '../EntityCacheAdapter';
 import EntityConfiguration from '../EntityConfiguration';
 import { filterMap } from '../utils/collections/maps';
-import {
-  FieldTransformerMap,
-  transformCacheObjectToFields,
-  transformFieldsToCacheObject,
-} from './EntityFieldTransformationUtils';
 
 export enum CacheStatus {
   HIT,
@@ -32,14 +27,10 @@ export type CacheLoadResult =
  * {@link EntityCacheAdapter} within the {@link EntityDataManager}.
  */
 export default class ReadThroughEntityCache<TFields> {
-  private readonly fieldTransformerMap: FieldTransformerMap;
-
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly entityCacheAdapter: EntityCacheAdapter<TFields>
-  ) {
-    this.fieldTransformerMap = entityCacheAdapter.getFieldTransformerMap();
-  }
+  ) {}
 
   private isFieldCacheable<N extends keyof TFields>(fieldName: N): boolean {
     return this.entityConfiguration.cacheableKeys.has(fieldName);
@@ -91,13 +82,7 @@ export default class ReadThroughEntityCache<TFields> {
     const results: Map<NonNullable<TFields[N]>, readonly Readonly<TFields>[]> = new Map();
     cacheLoadResults.forEach((cacheLoadResult, fieldValue) => {
       if (cacheLoadResult.status === CacheStatus.HIT) {
-        results.set(fieldValue, [
-          transformCacheObjectToFields(
-            this.entityConfiguration,
-            this.fieldTransformerMap,
-            cacheLoadResult.item
-          ),
-        ]);
+        results.set(fieldValue, [cacheLoadResult.item as Readonly<TFields>]);
       }
     });
 
@@ -123,14 +108,7 @@ export default class ReadThroughEntityCache<TFields> {
         }
         const uniqueObject = objects[0];
         if (uniqueObject) {
-          objectsToCache.set(
-            fieldValue,
-            transformFieldsToCacheObject(
-              this.entityConfiguration,
-              this.fieldTransformerMap,
-              uniqueObject
-            )
-          );
+          objectsToCache.set(fieldValue, uniqueObject);
           results.set(fieldValue, [uniqueObject]);
         }
       }

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -191,44 +191,6 @@ describe(ReadThroughEntityCache, () => {
       verify(cacheAdapterMock.loadManyAsync('id', anything())).never();
       expect(result).toEqual(new Map([['wat', [{ id: 'wat' }]]]));
     });
-
-    /*     it('transforms fields for cache storage', async () => {
-      const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(
-        new Map([
-          [
-            UUIDField.name,
-            {
-              read: (val) => val.split('-')[0],
-              write: (val) => `${val}-in-cache`,
-            },
-          ],
-        ])
-      );
-      const cacheAdapter = instance(cacheAdapterMock);
-      const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
-      const fetcher = createIdFetcher(['wat', 'who']);
-
-      when(cacheAdapterMock.loadManyAsync('id', deepEqual(['wat', 'who']))).thenResolve(
-        new Map([
-          ['wat', { status: CacheStatus.MISS }],
-          ['who', { status: CacheStatus.HIT, item: { id: 'who-in-cache' } }],
-        ])
-      );
-
-      const result = await entityCache.readManyThroughAsync('id', ['wat', 'who'], fetcher);
-
-      verify(cacheAdapterMock.loadManyAsync('id', deepEqual(['wat', 'who']))).once();
-      verify(
-        cacheAdapterMock.cacheManyAsync('id', deepEqual(new Map([['wat', { id: 'wat-in-cache' }]])))
-      ).once();
-      expect(result).toEqual(
-        new Map([
-          ['wat', [{ id: 'wat' }]],
-          ['who', [{ id: 'who' }]],
-        ])
-      );
-    }); */
   });
 
   describe('invalidateManyAsync', () => {

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -40,7 +40,6 @@ describe(ReadThroughEntityCache, () => {
   describe('readManyThroughAsync', () => {
     it('fetches from DB upon cache miss and caches the result', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(new Map());
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher(['wat', 'who']);
@@ -77,7 +76,6 @@ describe(ReadThroughEntityCache, () => {
 
     it('does not fetch from the DB or cache results when all cache fetches are hits', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(new Map());
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher(['wat', 'who']);
@@ -114,7 +112,6 @@ describe(ReadThroughEntityCache, () => {
 
     it('negatively caches db misses', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(new Map());
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
 
@@ -135,7 +132,6 @@ describe(ReadThroughEntityCache, () => {
 
     it('does not return or fetch negatively cached results from DB', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(new Map());
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher([]);
@@ -153,7 +149,6 @@ describe(ReadThroughEntityCache, () => {
 
     it('does a mix and match of hit, miss, and negative', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(new Map());
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher(['wat', 'who', 'why']);
@@ -189,7 +184,6 @@ describe(ReadThroughEntityCache, () => {
 
     it('does not call into cache for field that is not cacheable', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
-      when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(new Map());
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(false), cacheAdapter);
       const fetcher = createIdFetcher(['wat']);
@@ -198,7 +192,7 @@ describe(ReadThroughEntityCache, () => {
       expect(result).toEqual(new Map([['wat', [{ id: 'wat' }]]]));
     });
 
-    it('transforms fields for cache storage', async () => {
+    /*     it('transforms fields for cache storage', async () => {
       const cacheAdapterMock = mock<EntityCacheAdapter<BlahFields>>();
       when(cacheAdapterMock.getFieldTransformerMap()).thenReturn(
         new Map([
@@ -234,7 +228,7 @@ describe(ReadThroughEntityCache, () => {
           ['who', [{ id: 'who' }]],
         ])
       );
-    });
+    }); */
   });
 
   describe('invalidateManyAsync', () => {


### PR DESCRIPTION
…to cache adapter

# Why

Move the cache object <=> entity object transformation to be the Cache Adapter's responsibility.  Followup to https://github.com/expo/universe/pull/9021#discussion_r794951790

# Test Plan

- [ ] new tests pass
