### PR TITLE
move responsibility of transformer to generic redis cacher

### DIFF
--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -1,0 +1,125 @@
+import { CacheStatus, ViewerContext } from '@expo/entity';
+import Redis from 'ioredis';
+import { URL } from 'url';
+
+import GenericRedisCacher from '../GenericRedisCacher';
+import { RedisCacheAdapterContext } from '../RedisCacheAdapter';
+import RedisTestEntity, {
+  redisTestEntityConfiguration,
+  RedisTestEntityFields,
+} from '../testfixtures/RedisTestEntity';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../testfixtures/createRedisIntegrationTestEntityCompanionProvider';
+
+class TestViewerContext extends ViewerContext {}
+
+describe(GenericRedisCacher, () => {
+  let redisCacheAdapterContext: RedisCacheAdapterContext;
+
+  beforeAll(() => {
+    redisCacheAdapterContext = {
+      redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
+      makeKeyFn(...parts: string[]): string {
+        const delimiter = ':';
+        const escapedParts = parts.map((part) =>
+          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
+        );
+        return escapedParts.join(delimiter);
+      },
+      cacheKeyPrefix: 'test-',
+      cacheKeyVersion: 1,
+      ttlSecondsPositive: 86400, // 1 day
+      ttlSecondsNegative: 600, // 10 minutes
+    };
+  });
+
+  beforeEach(async () => {
+    await redisCacheAdapterContext.redisClient.flushdb();
+  });
+  afterAll(async () => {
+    redisCacheAdapterContext.redisClient.disconnect();
+  });
+
+  it('has correct caching and loading behavior', async () => {
+    const viewerContext = new TestViewerContext(
+      createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
+    );
+    const genericRedisCacher = new GenericRedisCacher(
+      {
+        redisClient: redisCacheAdapterContext.redisClient,
+        ttlSecondsNegative: redisCacheAdapterContext.ttlSecondsNegative,
+        ttlSecondsPositive: redisCacheAdapterContext.ttlSecondsPositive,
+      },
+      redisTestEntityConfiguration
+    );
+    const date = new Date();
+    const entity1Created = await RedisTestEntity.creator(viewerContext)
+      .setField('name', 'blah')
+      .setField('dateField', date)
+      .enforceCreateAsync();
+    const testKey = `test-id-key-${entity1Created.getID()}`;
+    const objectMap = new Map<string, Readonly<RedisTestEntityFields>>([
+      [testKey, entity1Created.getAllFields()],
+    ]);
+    await genericRedisCacher.cacheManyAsync(objectMap);
+
+    const cachedJSON = await redisCacheAdapterContext.redisClient.get(testKey);
+    const cachedValue = JSON.parse(cachedJSON!);
+    expect(cachedValue).toMatchObject({
+      id: entity1Created.getID(),
+      dateField: date.toISOString(),
+    });
+
+    const loadedObjectMap = await genericRedisCacher.loadManyAsync([testKey]);
+    const cacheLoadResult = loadedObjectMap.get(testKey)!;
+    expect(cacheLoadResult).toMatchObject({
+      status: CacheStatus.HIT,
+      item: entity1Created.getAllFields(),
+    });
+    expect(loadedObjectMap.size).toBe(1);
+  });
+  it('has correct negative caching behaviour', async () => {
+    const genericRedisCacher = new GenericRedisCacher(
+      {
+        redisClient: redisCacheAdapterContext.redisClient,
+        ttlSecondsNegative: redisCacheAdapterContext.ttlSecondsNegative,
+        ttlSecondsPositive: redisCacheAdapterContext.ttlSecondsPositive,
+      },
+      redisTestEntityConfiguration
+    );
+
+    const testKey = `test-id-key-non-existent-id`;
+    await genericRedisCacher.cacheDBMissesAsync([testKey]);
+    const loadedObjectMap = await genericRedisCacher.loadManyAsync([testKey]);
+    const cacheLoadResult = loadedObjectMap.get(testKey)!;
+    expect(cacheLoadResult.status).toBe(CacheStatus.NEGATIVE);
+  });
+  it('has correct invalidation behaviour', async () => {
+    const viewerContext = new TestViewerContext(
+      createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
+    );
+    const genericRedisCacher = new GenericRedisCacher(
+      {
+        redisClient: redisCacheAdapterContext.redisClient,
+        ttlSecondsNegative: redisCacheAdapterContext.ttlSecondsNegative,
+        ttlSecondsPositive: redisCacheAdapterContext.ttlSecondsPositive,
+      },
+      redisTestEntityConfiguration
+    );
+    const date = new Date();
+    const entity1Created = await RedisTestEntity.creator(viewerContext)
+      .setField('name', 'blah')
+      .setField('dateField', date)
+      .enforceCreateAsync();
+    const testKey = `test-id-key-${entity1Created.getID()}`;
+    const objectMap = new Map<string, Readonly<RedisTestEntityFields>>([
+      [testKey, entity1Created.getAllFields()],
+    ]);
+    await genericRedisCacher.cacheManyAsync(objectMap);
+
+    await genericRedisCacher.invalidateManyAsync([testKey]);
+
+    const loadedObjectMap = await genericRedisCacher.loadManyAsync([testKey]);
+    const cacheLoadResult = loadedObjectMap.get(testKey)!;
+    expect(cacheLoadResult.status).toBe(CacheStatus.MISS);
+  });
+});

--- a/packages/entity/src/EntityCacheAdapter.ts
+++ b/packages/entity/src/EntityCacheAdapter.ts
@@ -1,5 +1,4 @@
 import EntityConfiguration from './EntityConfiguration';
-import { FieldTransformerMap } from './internal/EntityFieldTransformationUtils';
 import { CacheLoadResult } from './internal/ReadThroughEntityCache';
 
 /**
@@ -10,13 +9,6 @@ export default abstract class EntityCacheAdapter<TFields> {
   constructor(protected readonly entityConfiguration: EntityConfiguration<TFields>) {}
 
   /**
-   * Transformer definitions for field types. Used to modify values as they are read from or written to
-   * the cache. Override in concrete subclasses to change transformation behavior.
-   * If a field type is not present in the map, then fields of that type will not be transformed.
-   */
-  public abstract getFieldTransformerMap(): FieldTransformerMap;
-
-  /**
    * Load many objects from cache.
    * @param fieldName - object field being queried
    * @param fieldValues - fieldName field values being queried
@@ -25,7 +17,7 @@ export default abstract class EntityCacheAdapter<TFields> {
   public abstract loadManyAsync<N extends keyof TFields>(
     fieldName: N,
     fieldValues: readonly NonNullable<TFields[N]>[]
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult>>;
+  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>>;
 
   /**
    * Cache many objects fetched from the DB.
@@ -34,7 +26,7 @@ export default abstract class EntityCacheAdapter<TFields> {
    */
   public abstract cacheManyAsync<N extends keyof TFields>(
     fieldName: N,
-    objectMap: ReadonlyMap<NonNullable<TFields[N]>, object>
+    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>
   ): Promise<void>;
 
   /**

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -3,11 +3,6 @@ import invariant from 'invariant';
 import EntityCacheAdapter from '../EntityCacheAdapter';
 import EntityConfiguration from '../EntityConfiguration';
 import { filterMap } from '../utils/collections/maps';
-import {
-  FieldTransformerMap,
-  transformCacheObjectToFields,
-  transformFieldsToCacheObject,
-} from './EntityFieldTransformationUtils';
 
 export enum CacheStatus {
   HIT,
@@ -15,10 +10,10 @@ export enum CacheStatus {
   NEGATIVE,
 }
 
-export type CacheLoadResult =
+export type CacheLoadResult<TFields> =
   | {
       status: CacheStatus.HIT;
-      item: Readonly<object>;
+      item: Readonly<TFields>;
     }
   | {
       status: CacheStatus.MISS;
@@ -32,14 +27,10 @@ export type CacheLoadResult =
  * {@link EntityCacheAdapter} within the {@link EntityDataManager}.
  */
 export default class ReadThroughEntityCache<TFields> {
-  private readonly fieldTransformerMap: FieldTransformerMap;
-
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly entityCacheAdapter: EntityCacheAdapter<TFields>
-  ) {
-    this.fieldTransformerMap = entityCacheAdapter.getFieldTransformerMap();
-  }
+  ) {}
 
   private isFieldCacheable<N extends keyof TFields>(fieldName: N): boolean {
     return this.entityConfiguration.cacheableKeys.has(fieldName);
@@ -91,13 +82,7 @@ export default class ReadThroughEntityCache<TFields> {
     const results: Map<NonNullable<TFields[N]>, readonly Readonly<TFields>[]> = new Map();
     cacheLoadResults.forEach((cacheLoadResult, fieldValue) => {
       if (cacheLoadResult.status === CacheStatus.HIT) {
-        results.set(fieldValue, [
-          transformCacheObjectToFields(
-            this.entityConfiguration,
-            this.fieldTransformerMap,
-            cacheLoadResult.item
-          ),
-        ]);
+        results.set(fieldValue, [cacheLoadResult.item]);
       }
     });
 
@@ -110,7 +95,7 @@ export default class ReadThroughEntityCache<TFields> {
         return !objectsFromFulfillerForFv || objectsFromFulfillerForFv.length === 0;
       });
 
-      const objectsToCache: Map<NonNullable<TFields[N]>, object> = new Map();
+      const objectsToCache: Map<NonNullable<TFields[N]>, Readonly<TFields>> = new Map();
       for (const [fieldValue, objects] of dbFetchResults.entries()) {
         if (objects.length > 1) {
           // multiple objects received for what was supposed to be a unique query, don't add to return map nor cache
@@ -123,14 +108,7 @@ export default class ReadThroughEntityCache<TFields> {
         }
         const uniqueObject = objects[0];
         if (uniqueObject) {
-          objectsToCache.set(
-            fieldValue,
-            transformFieldsToCacheObject(
-              this.entityConfiguration,
-              this.fieldTransformerMap,
-              uniqueObject
-            )
-          );
+          objectsToCache.set(fieldValue, uniqueObject);
           results.set(fieldValue, [uniqueObject]);
         }
       }

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -3,7 +3,6 @@ import invariant from 'invariant';
 import EntityCacheAdapter from '../../EntityCacheAdapter';
 import EntityConfiguration from '../../EntityConfiguration';
 import IEntityCacheAdapterProvider from '../../IEntityCacheAdapterProvider';
-import { FieldTransformerMap } from '../../internal/EntityFieldTransformationUtils';
 import { CacheStatus, CacheLoadResult } from '../../internal/ReadThroughEntityCache';
 
 export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
@@ -62,10 +61,6 @@ export class InMemoryFullCacheStubCacheAdapter<TFields> extends EntityCacheAdapt
     readonly cache: Map<string, Readonly<TFields>>
   ) {
     super(entityConfiguration);
-  }
-
-  public getFieldTransformerMap(): FieldTransformerMap {
-    return new Map();
   }
 
   public async loadManyAsync<N extends keyof TFields>(


### PR DESCRIPTION
# Why

Move the cache object <=> entity object transformation to be the Generic Redis Cache Adapter's responsibility.  Followup from https://github.com/expo/entity/pull/152#pullrequestreview-873411001


# Test Plan

- [ ] new tests pass
