### PR TITLE
chore: refactor cachers to use an abstract class and interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### Chores
+
+* Refactor cachers to use an abstract class and interface  ([#157](https://github.com/expo/entity/pull/157)) 
+
 # [0.23.0](https://github.com/expo/entity/compare/v0.22.0...v0.23.0) (2022-02-09)
 
 ### Breaking changes

--- a/packages/entity-cache-adapter-redis/CHANGELOG.md
+++ b/packages/entity-cache-adapter-redis/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### Chores
+
+* Refactor cachers to use an abstract class and interface  ([#157](https://github.com/expo/entity/pull/157)) 
+
 # [0.23.0](https://github.com/expo/entity/compare/v0.22.0...v0.23.0) (2022-02-09)
 
 ### Chores

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -4,6 +4,7 @@ import {
   EntityConfiguration,
   transformCacheObjectToFields,
   transformFieldsToCacheObject,
+  IEntityGenericCacher,
 } from '@expo/entity';
 import { Redis } from 'ioredis';
 
@@ -33,7 +34,7 @@ export interface GenericRedisCacheContext {
   ttlSecondsNegative: number;
 }
 
-export default class GenericRedisCacher<TFields> {
+export default class GenericRedisCacher<TFields> implements IEntityGenericCacher<TFields> {
   constructor(
     private readonly context: GenericRedisCacheContext,
     private readonly entityConfiguration: EntityConfiguration<TFields>

--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -1,120 +1,20 @@
-import {
-  CacheStatus,
-  EntityConfiguration,
-  filterMap,
-  ISecondaryEntityCache,
-  zipToMap,
-} from '@expo/entity';
+import { EntityConfiguration, GenericSecondaryEntityCache } from '@expo/entity';
 import { GenericRedisCacheContext, GenericRedisCacher } from '@expo/entity-cache-adapter-redis';
-import invariant from 'invariant';
 
 /**
  * A custom secondary read-through entity cache is a way to add a custom second layer of caching for a particular
  * single entity load. One common way this may be used is to add a second layer of caching in a hot path that makes
  * a call to {@link EntityLoader.loadManyByFieldEqualityConjunctionAsync} is guaranteed to return at most one entity.
  */
-export default class RedisSecondaryEntityCache<TFields, TLoadParams>
-  implements ISecondaryEntityCache<TFields, TLoadParams>
-{
-  private readonly genericRedisCacher: GenericRedisCacher<TFields>;
-
+export default class RedisSecondaryEntityCache<
+  TFields,
+  TLoadParams
+> extends GenericSecondaryEntityCache<TFields, TLoadParams> {
   constructor(
     entityConfiguration: EntityConfiguration<TFields>,
     genericRedisCacheContext: GenericRedisCacheContext,
-    private readonly constructRedisKey: (params: Readonly<TLoadParams>) => string
+    constructRedisKey: (params: Readonly<TLoadParams>) => string
   ) {
-    this.genericRedisCacher = new GenericRedisCacher(genericRedisCacheContext, entityConfiguration);
-  }
-
-  /**
-   * Read-through cache function. Steps:
-   *
-   * 1. Check for cached objects
-   * 2. Query the fetcher for loadParams not in the cache
-   * 3. Cache the results from the fetcher
-   * 4. Negatively cache anything missing from the fetcher
-   * 5. Return the full set of data for the query.
-   *
-   * @param loadParamsArray - array of loadParams to load from the cache
-   * @param fetcher - closure used to provide underlying data source objects for loadParams
-   * @returns map from loadParams to the entity field object
-   */
-  public async loadManyThroughAsync(
-    loadParamsArray: readonly Readonly<TLoadParams>[],
-    fetcher: (
-      fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
-    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>>
-  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>> {
-    const redisKeys = loadParamsArray.map(this.constructRedisKey);
-    const redisKeyToLoadParamsMap = zipToMap(redisKeys, loadParamsArray);
-
-    const cacheLoadResults = await this.genericRedisCacher.loadManyAsync(redisKeys);
-
-    invariant(
-      cacheLoadResults.size === loadParamsArray.length,
-      `${this.constructor.name} loadMany should return a result for each key`
-    );
-
-    const redisKeysToFetch = Array.from(
-      filterMap(
-        cacheLoadResults,
-        (cacheLoadResult) => cacheLoadResult.status === CacheStatus.MISS
-      ).keys()
-    );
-
-    // put transformed cache hits in result map
-    const results: Map<Readonly<TLoadParams>, Readonly<TFields> | null> = new Map();
-    cacheLoadResults.forEach((cacheLoadResult, redisKey) => {
-      if (cacheLoadResult.status === CacheStatus.HIT) {
-        const loadParams = redisKeyToLoadParamsMap.get(redisKey);
-        invariant(loadParams !== undefined, 'load params should be in redis key map');
-        results.set(loadParams, cacheLoadResult.item);
-      }
-    });
-
-    // fetch any misses from DB, add DB objects to results, cache DB results, inform cache of any missing DB results
-    if (redisKeysToFetch.length > 0) {
-      const loadParamsToFetch = redisKeysToFetch.map((redisKey) => {
-        const loadParams = redisKeyToLoadParamsMap.get(redisKey);
-        invariant(loadParams !== undefined, 'load params should be in redis key map');
-        return loadParams;
-      });
-      const fetchResults = await fetcher(loadParamsToFetch);
-
-      const fetchMisses = loadParamsToFetch.filter((loadParams) => {
-        // all values of fetchResults should be field objects or undefined
-        return !fetchResults.get(loadParams);
-      });
-
-      for (const fetchMiss of fetchMisses) {
-        results.set(fetchMiss, null);
-      }
-
-      const objectsToCache: Map<string, Readonly<TFields>> = new Map();
-      for (const [loadParams, object] of fetchResults.entries()) {
-        if (object) {
-          objectsToCache.set(this.constructRedisKey(loadParams), object);
-          results.set(loadParams, object);
-        }
-      }
-
-      await Promise.all([
-        this.genericRedisCacher.cacheManyAsync(objectsToCache),
-        this.genericRedisCacher.cacheDBMissesAsync(fetchMisses.map(this.constructRedisKey)),
-      ]);
-    }
-
-    return results;
-  }
-
-  /**
-   * Invalidate the cache for objects cached by constructRedisKey(loadParams).
-   *
-   * @param loadParamsArray - load params to invalidate
-   */
-  public async invalidateManyAsync(
-    loadParamsArray: readonly Readonly<TLoadParams>[]
-  ): Promise<void> {
-    await this.genericRedisCacher.invalidateManyAsync(loadParamsArray.map(this.constructRedisKey));
+    super(new GenericRedisCacher(genericRedisCacheContext, entityConfiguration), constructRedisKey);
   }
 }

--- a/packages/entity/CHANGELOG.md
+++ b/packages/entity/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### Chores
+
+* Refactor cachers to use an abstract class and interface  ([#157](https://github.com/expo/entity/pull/157)) 
+
 # [0.23.0](https://github.com/expo/entity/compare/v0.22.0...v0.23.0) (2022-02-09)
 
 ### Breaking changes

--- a/packages/entity/src/GenericSecondaryEntityCache.ts
+++ b/packages/entity/src/GenericSecondaryEntityCache.ts
@@ -1,0 +1,96 @@
+import { CacheStatus, filterMap, ISecondaryEntityCache, zipToMap } from '@expo/entity';
+import invariant from 'invariant';
+
+import IEntityGenericCacher from './IEntityGenericCacher';
+
+/**
+ * A custom secondary read-through entity cache is a way to add a custom second layer of caching for a particular
+ * single entity load. One common way this may be used is to add a second layer of caching in a hot path that makes
+ * a call to {@link EntityLoader.loadManyByFieldEqualityConjunctionAsync} is guaranteed to return at most one entity.
+ */
+export default abstract class GenericSecondaryEntityCache<TFields, TLoadParams>
+  implements ISecondaryEntityCache<TFields, TLoadParams>
+{
+  constructor(
+    protected readonly cacher: IEntityGenericCacher<TFields>,
+    protected readonly constructCacheKey: (params: Readonly<TLoadParams>) => string
+  ) {}
+
+  public async loadManyThroughAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[],
+    fetcher: (
+      fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
+    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>>
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>> {
+    const cacheKeys = loadParamsArray.map(this.constructCacheKey);
+    const cacheKeyToLoadParamsMap = zipToMap(cacheKeys, loadParamsArray);
+
+    const cacheLoadResults = await this.cacher.loadManyAsync(cacheKeys);
+
+    invariant(
+      cacheLoadResults.size === loadParamsArray.length,
+      `${this.constructor.name} loadMany should return a result for each key`
+    );
+
+    const cacheKeysToFetch = Array.from(
+      filterMap(
+        cacheLoadResults,
+        (cacheLoadResult) => cacheLoadResult.status === CacheStatus.MISS
+      ).keys()
+    );
+
+    // put cache hits in result map
+    const results: Map<Readonly<TLoadParams>, Readonly<TFields> | null> = new Map();
+    cacheLoadResults.forEach((cacheLoadResult, cacheKey) => {
+      if (cacheLoadResult.status === CacheStatus.HIT) {
+        const loadParams = cacheKeyToLoadParamsMap.get(cacheKey);
+        invariant(loadParams !== undefined, 'load params should be in cache key map');
+        results.set(loadParams, cacheLoadResult.item);
+      }
+    });
+
+    // fetch any misses from DB, add DB objects to results, cache DB results, inform cache of any missing DB results
+    if (cacheKeysToFetch.length > 0) {
+      const loadParamsToFetch = cacheKeysToFetch.map((cacheKey) => {
+        const loadParams = cacheKeyToLoadParamsMap.get(cacheKey);
+        invariant(loadParams !== undefined, 'load params should be in cache key map');
+        return loadParams;
+      });
+      const fetchResults = await fetcher(loadParamsToFetch);
+
+      const fetchMisses = loadParamsToFetch.filter((loadParams) => {
+        // all values of fetchResults should be field objects or undefined
+        return !fetchResults.get(loadParams);
+      });
+
+      for (const fetchMiss of fetchMisses) {
+        results.set(fetchMiss, null);
+      }
+
+      const objectsToCache: Map<string, Readonly<TFields>> = new Map();
+      for (const [loadParams, object] of fetchResults.entries()) {
+        if (object) {
+          objectsToCache.set(this.constructCacheKey(loadParams), object);
+          results.set(loadParams, object);
+        }
+      }
+
+      await Promise.all([
+        this.cacher.cacheManyAsync(objectsToCache),
+        this.cacher.cacheDBMissesAsync(fetchMisses.map(this.constructCacheKey)),
+      ]);
+    }
+
+    return results;
+  }
+
+  /**
+   * Invalidate the cache for objects cached by constructCacheKey(loadParams).
+   *
+   * @param loadParamsArray - load params to invalidate
+   */
+  public invalidateManyAsync(loadParamsArray: readonly Readonly<TLoadParams>[]): Promise<void> {
+    const cacheKeys = loadParamsArray.map(this.constructCacheKey);
+    return this.cacher.invalidateManyAsync(cacheKeys);
+  }
+}

--- a/packages/entity/src/GenericSecondaryEntityCache.ts
+++ b/packages/entity/src/GenericSecondaryEntityCache.ts
@@ -1,7 +1,9 @@
-import { CacheStatus, filterMap, ISecondaryEntityCache, zipToMap } from '@expo/entity';
 import invariant from 'invariant';
 
+import { ISecondaryEntityCache } from './EntitySecondaryCacheLoader';
 import IEntityGenericCacher from './IEntityGenericCacher';
+import { CacheStatus } from './internal/ReadThroughEntityCache';
+import { filterMap, zipToMap } from './utils/collections/maps';
 
 /**
  * A custom secondary read-through entity cache is a way to add a custom second layer of caching for a particular

--- a/packages/entity/src/IEntityGenericCacher.ts
+++ b/packages/entity/src/IEntityGenericCacher.ts
@@ -1,0 +1,15 @@
+import { CacheLoadResult } from './internal/ReadThroughEntityCache';
+
+/**
+ * A cacher stores and loads key-value pairs. It also supports negative caching - it stores the absence
+ * of keys that don't exist in the backing datastore.
+ */
+export default interface IEntityGenericCacher<TFields> {
+  loadManyAsync(keys: readonly string[]): Promise<ReadonlyMap<string, CacheLoadResult<TFields>>>;
+
+  cacheManyAsync(objectMap: ReadonlyMap<string, Readonly<TFields>>): Promise<void>;
+
+  cacheDBMissesAsync(keys: string[]): Promise<void>;
+
+  invalidateManyAsync(keys: string[]): Promise<void>;
+}

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -4,6 +4,7 @@
  * @module @expo/entity
  */
 
+export { default as GenericSecondaryEntityCache } from './GenericSecondaryEntityCache';
 export { default as EnforcingEntityLoader } from './EnforcingEntityLoader';
 export { default as Entity } from './Entity';
 export * from './Entity';
@@ -43,6 +44,7 @@ export * from './EntityQueryContext';
 export { default as IEntityCacheAdapterProvider } from './IEntityCacheAdapterProvider';
 export { default as IEntityDatabaseAdapterProvider } from './IEntityDatabaseAdapterProvider';
 export { default as EntityQueryContextProvider } from './EntityQueryContextProvider';
+export { default as IEntityGenericCacher } from './IEntityGenericCacher';
 export { default as ReadonlyEntity } from './ReadonlyEntity';
 export { default as ViewerContext } from './ViewerContext';
 export { default as ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion';


### PR DESCRIPTION
# Why

Interfaces and abstract classes for generic cachers and secondary entity caches. Followup from https://github.com/expo/universe/pull/9106#pullrequestreview-879787342

The plan is to have:

- [GenericRedisCacher ](https://github.com/expo/entity/blob/master/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts)(from the entity package) and GenericLocalMemoryCacher implement GenericCacher?
- [SecondaryRedisEntityCache](https://github.com/expo/entity/blob/master/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts) (from the entity package) and LocalMemoryAndRedisSecondaryEntityCache extending GenericSecondaryEntityCache?

# Test Plan

- [x] current tests pass
