### PR TITLE
feat: add local memory cache package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@expo/entity": "file:packages/entity",
     "@expo/results": "^1.0.0",
+    "@types/lru-cache": "^5.1.1",
     "@types/invariant": "^2.2.33",
     "@types/ioredis": "^4.26.4",
     "@types/jest": "^26.0.10",
@@ -43,6 +44,7 @@
   },
   "dependencies": {
     "@expo/entity": "file:packages/entity",
+    "@expo/entity-cache-adapter-local-memory": "file:packages/entity-cache-adapter-local-memory",
     "@expo/entity-cache-adapter-redis": "file:packages/entity-cache-adapter-redis",
     "@expo/entity-database-adapter-knex": "file:packages/entity-database-adapter-knex",
     "@expo/entity-secondary-cache-redis": "file:packages/entity-secondary-cache-redis",

--- a/packages/entity-cache-adapter-local-memory/CHANGELOG.md
+++ b/packages/entity-cache-adapter-local-memory/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/entity-cache-adapter-local-memory/README.md
+++ b/packages/entity-cache-adapter-local-memory/README.md
@@ -1,0 +1,26 @@
+# `@expo/entity-cache-adapter-local-memory`
+
+Cross request [LRU](https://github.com/isaacs/node-lru-cache) cache adapter for `@expo/entity`.
+
+## Usage
+
+During `EntityCompanionProvider` instantiation:
+
+```typescript
+export const createDefaultEntityCompanionProvider = (
+  metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
+): EntityCompanionProvider => {
+  return new EntityCompanionProvider(
+    metricsAdapter,
+    {
+      ...
+    },
+    {
+      ['local-memory']: {
+        cacheAdapterProvider: new LocalMemoryCacheAdapterProvider.getProvider(),
+      },
+    }
+  );
+};
+
+```

--- a/packages/entity-cache-adapter-local-memory/README.md
+++ b/packages/entity-cache-adapter-local-memory/README.md
@@ -1,6 +1,24 @@
 # `@expo/entity-cache-adapter-local-memory`
 
-Cross request [LRU](https://github.com/isaacs/node-lru-cache) cache adapter for `@expo/entity`.
+Cross-request [LRU](https://github.com/isaacs/node-lru-cache) cache adapter for `@expo/entity`. Use
+this cache with caution - it is nonstandard. The cache is shared between requests in the node process.
+
+## Why NOT use this cache
+
+Because this is an in-memory cache, cross-box invalidation is not possible. Do not use this cache
+if you have the following use cases:
+
+- The objects stored have high mutability
+- Reading a stale object from the cache is not acceptable in your application
+- Cross-box invalidation is not possible
+
+## Typical use cases
+
+If your application sees many requests fetching the same objects, you can save a trip to your cache
+cluster and backing datastore by using this in-memory cache. Here are some good use cases:
+
+- The objects stored are mostly immutable
+- You have a low TTL setting in your cache
 
 ## Usage
 

--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@expo/entity-cache-adapter-local-memory",
+  "version": "0.23.0",
+  "description": "Cross request local memory cache adapter for @expo/entity",
+  "files": [
+    "build",
+    "src"
+  ],
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "tsc": "tsc",
+    "clean": "rm -rf build coverage coverage-integration",
+    "lint": "eslint src",
+    "lint-fix": "eslint src --fix",
+    "test": "jest --rootDir . --config ../../resources/jest.config.js",
+    "integration": "../../resources/run-with-docker yarn integration-no-setup",
+    "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",
+    "barrelsby": "barrelsby --directory src --location top --exclude tests__ --singleQuotes --exportDefault --delete"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "keywords": [
+    "entity"
+  ],
+  "author": "Expo",
+  "license": "MIT",
+  "peerDependencies": {
+    "@expo/entity": "*"
+  },
+  "dependencies": {
+    "lru-cache": "^7.3.1"
+  },
+  "devDependencies": {
+    "@expo/entity": "^0.23.0"
+  }
+}

--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@expo/entity-cache-adapter-local-memory",
   "version": "0.23.0",
-  "description": "Cross request local memory cache adapter for @expo/entity",
+  "description": "Cross-request local memory cache adapter for @expo/entity",
   "files": [
     "build",
     "src"

--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -8,53 +8,72 @@ type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_
 export type LocalMemoryCache<TFields> = LRUCache<string, LocalMemoryCacheValue<TFields>>;
 
 type LRUCacheOptionsV7<K, V> = {
-  // the number of most recently used items to keep.
-  // note that we may store fewer items than this if maxSize is hit.
+  /**
+   * the number of most recently used items to keep.
+   * note that we may store fewer items than this if maxSize is hit.
+   */
   max: number;
 
-  // if you wish to track item size, you must provide a maxSize
-  // note that we still will only keep up to max *actual items*,
-  // so size tracking may cause fewer than max items to be stored.
-  // At the extreme, a single item of maxSize size will cause everything
-  // else in the cache to be dropped when it is added.  Use with caution!
-  // Note also that size tracking can negatively impact performance,
-  // though for most cases, only minimally.
+  /**
+   * if you wish to track item size, you must provide a maxSize
+   * note that we still will only keep up to max *actual items*,
+   * so size tracking may cause fewer than max items to be stored.
+   * At the extreme, a single item of maxSize size will cause everything
+   * else in the cache to be dropped when it is added.  Use with caution!
+   * Note also that size tracking can negatively impact performance,
+   * though for most cases, only minimally.
+   */
+
   maxSize?: number;
 
-  // function to calculate size of items.  useful if storing strings or
-  // buffers or other items where memory size depends on the object itself.
-  // also note that oversized items do NOT immediately get dropped from
-  // the cache, though they will cause faster turnover in the storage.
+  /**
+   * function to calculate size of items.  useful if storing strings or
+   * buffers or other items where memory size depends on the object itself.
+   * also note that oversized items do NOT immediately get dropped from
+   * the cache, though they will cause faster turnover in the storage.
+   */
   sizeCalculation?: (value: V, key: K) => number;
 
-  // function to call when the item is removed from the cache
-  // Note that using this can negatively impact performance.
+  /**
+   * function to call when the item is removed from the cache
+   * Note that using this can negatively impact performance.
+   */
   dispose?: (value: V, key: K) => void;
 
-  // max time to live for items before they are considered stale
-  // note that stale items are NOT preemptively removed by default,
-  // and MAY live in the cache, contributing to its LRU max, long after
-  // they have expired.
-  // Also, as this cache is optimized for LRU/MRU operations, some of
-  // the staleness/TTL checks will reduce performance, as they will incur
-  // overhead by deleting items.
-  // Must be a positive integer in ms, defaults to 0, which means "no TTL"
+  /**
+   * max time to live for items before they are considered stale
+   * note that stale items are NOT preemptively removed by default,
+   * and MAY live in the cache, contributing to its LRU max, long after
+   * they have expired.
+   * Also, as this cache is optimized for LRU/MRU operations, some of
+   * the staleness/TTL checks will reduce performance, as they will incur
+   * overhead by deleting items.
+   * Must be a positive integer in ms, defaults to 0, which means "no TTL"
+   */
   ttl?: number;
 
-  // return stale items from cache.get() before disposing of them
-  // boolean, default false
+  /**
+   * return stale items from cache.get() before disposing of them
+   * boolean, default false
+   */
   allowStale?: boolean;
 
-  // update the age of items on cache.get(), renewing their TTL
-  // boolean, default false
+  /**
+   * update the age of items on cache.get(), renewing their TTL
+   * boolean, default false
+   */
   updateAgeOnGet?: boolean;
 
-  // update the age of items on cache.has(), renewing their TTL
-  // boolean, default false
+  /**
+   * update the age of items on cache.has(), renewing their TTL
+   * boolean, default false
+   */
   updateAgeOnHas?: boolean;
 
-  // update the "recently-used"-ness of items on cache.has()
-  // boolean, default false
+  /**
+   * update the "recently-used"-ness of items on cache.has()
+   * boolean, default false
+   */
   updateRecencyOnHas?: boolean;
 };
 
@@ -64,11 +83,11 @@ export default class GenericLocalMemoryCacher<TFields> {
   static createLRUCache<TFields>(
     options: { maxSize?: number; ttlSeconds?: number } = {}
   ): LocalMemoryCache<TFields> {
-    const LRU_CACHE_MAX_AGE_SECONDS = 10;
-    const ENTITIES_LRU_CACHE_SIZE = 10000;
-    const maxAgeSeconds = options.ttlSeconds ?? LRU_CACHE_MAX_AGE_SECONDS;
+    const DEFAULT_LRU_CACHE_MAX_AGE_SECONDS = 10;
+    const DEFAULT_LRU_CACHE_SIZE = 10000;
+    const maxAgeSeconds = options.ttlSeconds ?? DEFAULT_LRU_CACHE_MAX_AGE_SECONDS;
     const lruCacheOptions: LRUCacheOptionsV7<string, TFields> = {
-      max: options.maxSize ?? ENTITIES_LRU_CACHE_SIZE,
+      max: options.maxSize ?? DEFAULT_LRU_CACHE_SIZE,
       sizeCalculation: (value: LocalMemoryCacheValue<TFields>) =>
         value === DOES_NOT_EXIST_LOCAL_MEMORY_CACHE ? 0 : 1,
       ttl: maxAgeSeconds * 1000, // convert to ms

--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -1,0 +1,135 @@
+import { CacheLoadResult, CacheStatus } from '@expo/entity';
+import LRUCache from 'lru-cache';
+
+// Sentinel value we store in local memory to negatively cache a database miss.
+// The sentinel value is distinct from any (positively) cached value.
+export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
+type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
+export type LocalMemoryCache<TFields> = LRUCache<string, LocalMemoryCacheValue<TFields>>;
+
+type LRUCacheOptionsV7<K, V> = {
+  // the number of most recently used items to keep.
+  // note that we may store fewer items than this if maxSize is hit.
+  max: number;
+
+  // if you wish to track item size, you must provide a maxSize
+  // note that we still will only keep up to max *actual items*,
+  // so size tracking may cause fewer than max items to be stored.
+  // At the extreme, a single item of maxSize size will cause everything
+  // else in the cache to be dropped when it is added.  Use with caution!
+  // Note also that size tracking can negatively impact performance,
+  // though for most cases, only minimally.
+  maxSize?: number;
+
+  // function to calculate size of items.  useful if storing strings or
+  // buffers or other items where memory size depends on the object itself.
+  // also note that oversized items do NOT immediately get dropped from
+  // the cache, though they will cause faster turnover in the storage.
+  sizeCalculation?: (value: V, key: K) => number;
+
+  // function to call when the item is removed from the cache
+  // Note that using this can negatively impact performance.
+  dispose?: (value: V, key: K) => void;
+
+  // max time to live for items before they are considered stale
+  // note that stale items are NOT preemptively removed by default,
+  // and MAY live in the cache, contributing to its LRU max, long after
+  // they have expired.
+  // Also, as this cache is optimized for LRU/MRU operations, some of
+  // the staleness/TTL checks will reduce performance, as they will incur
+  // overhead by deleting items.
+  // Must be a positive integer in ms, defaults to 0, which means "no TTL"
+  ttl?: number;
+
+  // return stale items from cache.get() before disposing of them
+  // boolean, default false
+  allowStale?: boolean;
+
+  // update the age of items on cache.get(), renewing their TTL
+  // boolean, default false
+  updateAgeOnGet?: boolean;
+
+  // update the age of items on cache.has(), renewing their TTL
+  // boolean, default false
+  updateAgeOnHas?: boolean;
+
+  // update the "recently-used"-ness of items on cache.has()
+  // boolean, default false
+  updateRecencyOnHas?: boolean;
+};
+
+export default class GenericLocalMemoryCacher<TFields> {
+  constructor(private readonly lruCache: LocalMemoryCache<TFields>) {}
+
+  static createLRUCache<TFields>(
+    options: { maxSize?: number; ttlSeconds?: number } = {}
+  ): LocalMemoryCache<TFields> {
+    const LRU_CACHE_MAX_AGE_SECONDS = 10;
+    const ENTITIES_LRU_CACHE_SIZE = 10000;
+    const maxAgeSeconds = options.ttlSeconds ?? LRU_CACHE_MAX_AGE_SECONDS;
+    const lruCacheOptions: LRUCacheOptionsV7<string, TFields> = {
+      max: options.maxSize ?? ENTITIES_LRU_CACHE_SIZE,
+      sizeCalculation: (value: LocalMemoryCacheValue<TFields>) =>
+        value === DOES_NOT_EXIST_LOCAL_MEMORY_CACHE ? 0 : 1,
+      ttl: maxAgeSeconds * 1000, // convert to ms
+    };
+    return new LRUCache<string, LocalMemoryCacheValue<TFields>>(lruCacheOptions as any);
+  }
+
+  static createNoOpLRUCache<TFields>(): LocalMemoryCache<TFields> {
+    return new LRUCache<string, LocalMemoryCacheValue<TFields>>({
+      max: 0,
+      maxAge: -1,
+    });
+  }
+
+  public async loadManyAsync(
+    keys: readonly string[]
+  ): Promise<ReadonlyMap<string, CacheLoadResult<TFields>>> {
+    const cacheResults = new Map<string, CacheLoadResult<TFields>>();
+    for (const key of keys) {
+      const cacheResult = this.lruCache.get(key);
+      if (cacheResult === DOES_NOT_EXIST_LOCAL_MEMORY_CACHE) {
+        cacheResults.set(key, {
+          status: CacheStatus.NEGATIVE,
+        });
+      } else if (cacheResult) {
+        cacheResults.set(key, {
+          status: CacheStatus.HIT,
+          item: cacheResult as unknown as TFields,
+        });
+      } else {
+        cacheResults.set(key, {
+          status: CacheStatus.MISS,
+        });
+      }
+    }
+    return cacheResults;
+  }
+
+  public async cacheManyAsync(objectMap: ReadonlyMap<string, Readonly<TFields>>): Promise<void> {
+    for (const [key, item] of objectMap) {
+      this.lruCache.set(key, item);
+    }
+  }
+
+  public async cacheDBMissesAsync(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.lruCache.set(key, DOES_NOT_EXIST_LOCAL_MEMORY_CACHE);
+    }
+  }
+
+  public async invalidateManyAsync(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.lruCache.del(key);
+    }
+  }
+
+  public makeCacheKey(parts: string[]): string {
+    const delimiter = ':';
+    const escapedParts = parts.map((part) =>
+      part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
+    );
+    return escapedParts.join(delimiter);
+  }
+}

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapter.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapter.ts
@@ -1,0 +1,80 @@
+import { EntityCacheAdapter, CacheLoadResult, EntityConfiguration, mapKeys } from '@expo/entity';
+import invariant from 'invariant';
+
+import GenericLocalMemoryCacher, { LocalMemoryCache } from './GenericLocalMemoryCacher';
+
+export default class LocalMemoryCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+  private readonly genericLocalMemoryCacher: GenericLocalMemoryCacher<TFields>;
+
+  constructor(
+    entityConfiguration: EntityConfiguration<TFields>,
+    lruCache: LocalMemoryCache<TFields>
+  ) {
+    super(entityConfiguration);
+    this.genericLocalMemoryCacher = new GenericLocalMemoryCacher(lruCache);
+  }
+
+  public async loadManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
+    const localMemoryCacheKeyToFieldValueMapping = new Map(
+      fieldValues.map((fieldValue) => [this.makeCacheKey(fieldName, fieldValue), fieldValue])
+    );
+    const cacheResults = await this.genericLocalMemoryCacher.loadManyAsync(
+      Array.from(localMemoryCacheKeyToFieldValueMapping.keys())
+    );
+
+    return mapKeys(cacheResults, (cacheKey) => {
+      const fieldValue = localMemoryCacheKeyToFieldValueMapping.get(cacheKey);
+      invariant(
+        fieldValue !== undefined,
+        'Unspecified cache key %s returned from generic Local Memory cacher',
+        cacheKey
+      );
+      return fieldValue;
+    });
+  }
+
+  public async cacheManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>
+  ): Promise<void> {
+    await this.genericLocalMemoryCacher.cacheManyAsync(
+      mapKeys(objectMap, (fieldValue) => this.makeCacheKey(fieldName, fieldValue))
+    );
+  }
+
+  public async cacheDBMissesAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    await this.genericLocalMemoryCacher.cacheDBMissesAsync(
+      fieldValues.map((fieldValue) => this.makeCacheKey(fieldName, fieldValue))
+    );
+  }
+
+  public async invalidateManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    await this.genericLocalMemoryCacher.invalidateManyAsync(
+      fieldValues.map((fieldValue) => this.makeCacheKey(fieldName, fieldValue))
+    );
+  }
+
+  private makeCacheKey<N extends keyof TFields>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>
+  ): string {
+    const columnName = this.entityConfiguration.entityToDBFieldsKeyMapping.get(fieldName);
+    invariant(columnName, `database field mapping missing for ${fieldName}`);
+    const parts = [
+      this.entityConfiguration.tableName,
+      `${this.entityConfiguration.cacheKeyVersion}`,
+      columnName,
+      String(fieldValue),
+    ];
+    return this.genericLocalMemoryCacher.makeCacheKey(parts);
+  }
+}

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -1,0 +1,43 @@
+import {
+  computeIfAbsent,
+  EntityCacheAdapter,
+  EntityConfiguration,
+  IEntityCacheAdapterProvider,
+} from '@expo/entity';
+
+import GenericLocalMemoryCacher, { LocalMemoryCache } from './GenericLocalMemoryCacher';
+import LocalMemoryCacheAdapter from './LocalMemoryCacheAdapter';
+
+export class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvider {
+  // local memory cache adapters should be shared/reused across requests
+  static localMemoryCacheAdapterMap = new Map<string, LocalMemoryCacheAdapter<any>>();
+
+  static getNoOpProvider(): IEntityCacheAdapterProvider {
+    return new LocalMemoryCacheAdapterProvider(<TFields>() =>
+      GenericLocalMemoryCacher.createNoOpLRUCache<TFields>()
+    );
+  }
+
+  static getProvider(
+    options: { maxSize?: number; ttlSeconds?: number } = {}
+  ): IEntityCacheAdapterProvider {
+    return new LocalMemoryCacheAdapterProvider(<TFields>() =>
+      GenericLocalMemoryCacher.createLRUCache<TFields>(options)
+    );
+  }
+
+  private constructor(private readonly lruCacheCreator: <TFields>() => LocalMemoryCache<TFields>) {}
+
+  public getCacheAdapter<TFields>(
+    entityConfiguration: EntityConfiguration<TFields>
+  ): EntityCacheAdapter<TFields> {
+    return computeIfAbsent(
+      LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap,
+      entityConfiguration.tableName,
+      () => {
+        const lruCache = this.lruCacheCreator<TFields>();
+        return new LocalMemoryCacheAdapter(entityConfiguration, lruCache);
+      }
+    );
+  }
+}

--- a/packages/entity-cache-adapter-local-memory/src/__integration-tests__/LocalMemoryCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__integration-tests__/LocalMemoryCacheAdapter-integration-test.ts
@@ -1,0 +1,128 @@
+import { CacheStatus, ViewerContext } from '@expo/entity';
+import { v4 as uuidv4 } from 'uuid';
+
+import GenericLocalMemoryCacher from '../GenericLocalMemoryCacher';
+import LocalMemoryCacheAdapter from '../LocalMemoryCacheAdapter';
+import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
+import LocalMemoryTestEntity from '../testfixtures/LocalMemoryTestEntity';
+import { createLocalMemoryIntegrationTestEntityCompanionProvider } from '../testfixtures/createLocalMemoryIntegrationTestEntityCompanionProvider';
+
+class TestViewerContext extends ViewerContext {}
+
+describe(LocalMemoryCacheAdapter, () => {
+  beforeEach(async () => {
+    LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap.clear();
+  });
+
+  it('has correct caching behavior', async () => {
+    const viewerContext = new TestViewerContext(
+      createLocalMemoryIntegrationTestEntityCompanionProvider()
+    );
+    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
+      LocalMemoryTestEntity,
+      LocalMemoryTestEntity.getCompanionDefinition()
+    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
+
+    const date = new Date();
+    const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
+      .setField('name', 'blah')
+      .setField('dateField', date)
+      .enforceCreateAsync();
+
+    // loading an entity should put it in cache
+    const entity1 = await LocalMemoryTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity1Created.getID());
+
+    const entitySpecificGenericCacher =
+      LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap.get(
+        LocalMemoryTestEntity.getCompanionDefinition().entityConfiguration.tableName
+      )!['genericLocalMemoryCacher'];
+    const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
+      cacheKeyMaker('id', entity1.getID()),
+    ]);
+    const cachedValue = cachedResult.get(cacheKeyMaker('id', entity1.getID()))!;
+    expect(cachedValue).toMatchObject({
+      status: CacheStatus.HIT,
+      item: {
+        id: entity1.getID(),
+        name: 'blah',
+        dateField: date,
+      },
+    });
+
+    // simulate non existent db fetch, should write negative result ('') to cache
+    const nonExistentId = uuidv4();
+
+    const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext).loadByIDAsync(
+      nonExistentId
+    );
+    expect(entityNonExistentResult.ok).toBe(false);
+
+    const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([
+      cacheKeyMaker('id', nonExistentId),
+    ]);
+    expect(nonExistentCachedResult.get(cacheKeyMaker('id', nonExistentId))).toMatchObject({
+      status: CacheStatus.NEGATIVE,
+    });
+
+    // load again through entities framework to ensure it reads negative result
+    const entityNonExistentResult2 = await LocalMemoryTestEntity.loader(
+      viewerContext
+    ).loadByIDAsync(nonExistentId);
+    expect(entityNonExistentResult2.ok).toBe(false);
+
+    // invalidate from cache to ensure it invalidates correctly
+    await LocalMemoryTestEntity.loader(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
+    const cachedResultMiss = await entitySpecificGenericCacher.loadManyAsync([
+      cacheKeyMaker('id', entity1.getID()),
+    ]);
+    const cachedValueMiss = cachedResultMiss.get(cacheKeyMaker('id', entity1.getID()));
+    expect(cachedValueMiss).toMatchObject({ status: CacheStatus.MISS });
+  });
+
+  it('shares the cache between different requests', async () => {
+    const genericLocalMemoryCacherLoadManySpy = jest.spyOn(
+      GenericLocalMemoryCacher.prototype as unknown as any,
+      'loadManyAsync'
+    );
+    const viewerContext = new TestViewerContext(
+      createLocalMemoryIntegrationTestEntityCompanionProvider()
+    );
+
+    const date = new Date();
+    const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
+      .setField('name', 'blah')
+      .setField('dateField', date)
+      .enforceCreateAsync();
+
+    // loading an entity should put it in cache
+    await LocalMemoryTestEntity.loader(viewerContext)
+      .enforcing()
+      .loadByIDAsync(entity1Created.getID());
+
+    // load entity with a different request
+    const viewerContext2 = new TestViewerContext(
+      createLocalMemoryIntegrationTestEntityCompanionProvider()
+    );
+    const entity1WithVc2 = await LocalMemoryTestEntity.loader(viewerContext2)
+      .enforcing()
+      .loadByIDAsync(entity1Created.getID());
+
+    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
+      LocalMemoryTestEntity,
+      LocalMemoryTestEntity.getCompanionDefinition()
+    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
+    expect(entity1WithVc2.getAllFields()).toMatchObject({
+      id: entity1WithVc2.getID(),
+      name: 'blah',
+      dateField: date,
+    });
+    expect(genericLocalMemoryCacherLoadManySpy).toBeCalledWith([
+      cacheKeyMaker('id', entity1WithVc2.getID()),
+    ]);
+    expect(genericLocalMemoryCacherLoadManySpy).toBeCalledTimes(2);
+  });
+});

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-test.ts
@@ -1,0 +1,125 @@
+import { CacheStatus, UUIDField, EntityConfiguration } from '@expo/entity';
+
+import GenericLocalMemoryCacher, {
+  DOES_NOT_EXIST_LOCAL_MEMORY_CACHE,
+} from '../GenericLocalMemoryCacher';
+import LocalMemoryCacheAdapter from '../LocalMemoryCacheAdapter';
+
+type BlahFields = {
+  id: string;
+};
+
+const entityConfiguration = new EntityConfiguration<BlahFields>({
+  idField: 'id',
+  tableName: 'blah',
+  schema: {
+    id: new UUIDField({ columnName: 'id', cache: true }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'local-memory',
+});
+
+describe(LocalMemoryCacheAdapter, () => {
+  describe('loadManyAsync', () => {
+    it('returns appropriate cache results', async () => {
+      const cacheAdapter = new LocalMemoryCacheAdapter(
+        entityConfiguration,
+        GenericLocalMemoryCacher.createLRUCache({
+          maxSize: Number.MAX_SAFE_INTEGER,
+          ttlSeconds: Number.MAX_SAFE_INTEGER,
+        })
+      );
+
+      const cacheHits = new Map<string, Readonly<BlahFields>>([['test-id-1', { id: 'test-id-1' }]]);
+      await cacheAdapter.cacheManyAsync('id', cacheHits);
+      await cacheAdapter.cacheDBMissesAsync('id', ['test-id-2']);
+
+      const results = await cacheAdapter.loadManyAsync('id', [
+        'test-id-1',
+        'test-id-2',
+        'test-id-3',
+      ]);
+
+      expect(results.get('test-id-1')).toMatchObject({
+        status: CacheStatus.HIT,
+        item: { id: 'test-id-1' },
+      });
+      expect(results.get('test-id-2')).toMatchObject({ status: CacheStatus.NEGATIVE });
+      expect(results.get('test-id-3')).toMatchObject({ status: CacheStatus.MISS });
+      expect(results.size).toBe(3);
+    });
+
+    it('returns empty map when passed empty array of fieldValues', async () => {
+      const cacheAdapter = new LocalMemoryCacheAdapter(
+        entityConfiguration,
+        GenericLocalMemoryCacher.createLRUCache({
+          maxSize: Number.MAX_SAFE_INTEGER,
+          ttlSeconds: Number.MAX_SAFE_INTEGER,
+        })
+      );
+      const results = await cacheAdapter.loadManyAsync('id', []);
+      expect(results).toEqual(new Map());
+    });
+  });
+
+  describe('cacheManyAsync', () => {
+    it('correctly caches all objects', async () => {
+      const lruCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({
+        maxSize: Number.MAX_SAFE_INTEGER,
+        ttlSeconds: Number.MAX_SAFE_INTEGER,
+      });
+
+      const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, lruCache);
+      await cacheAdapter.cacheManyAsync('id', new Map([['test-id-1', { id: 'test-id-1' }]]));
+
+      const cacheKey = cacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(lruCache.get(cacheKey)).toMatchObject({
+        id: 'test-id-1',
+      });
+    });
+  });
+
+  describe('cacheDBMissesAsync', () => {
+    it('correctly caches misses', async () => {
+      const lruCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({
+        maxSize: Number.MAX_SAFE_INTEGER,
+        ttlSeconds: Number.MAX_SAFE_INTEGER,
+      });
+
+      const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, lruCache);
+      await cacheAdapter.cacheDBMissesAsync('id', ['test-id-1']);
+
+      const cacheKey = cacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(lruCache.get(cacheKey)).toEqual(DOES_NOT_EXIST_LOCAL_MEMORY_CACHE);
+    });
+  });
+
+  describe('invalidateManyAsync', () => {
+    it('invalidates correctly', async () => {
+      const lruCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({
+        maxSize: Number.MAX_SAFE_INTEGER,
+        ttlSeconds: Number.MAX_SAFE_INTEGER,
+      });
+
+      const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, lruCache);
+      await cacheAdapter.cacheManyAsync('id', new Map([['test-id-1', { id: 'test-id-1' }]]));
+      await cacheAdapter.cacheDBMissesAsync('id', ['test-id-2']);
+      await cacheAdapter.invalidateManyAsync('id', ['test-id-1', 'test-id-2']);
+
+      const results = await cacheAdapter.loadManyAsync('id', ['test-id-1', 'test-id-2']);
+      expect(results.get('test-id-1')).toMatchObject({ status: CacheStatus.MISS });
+      expect(results.get('test-id-2')).toMatchObject({ status: CacheStatus.MISS });
+    });
+
+    it('returns when passed empty array of fieldValues', async () => {
+      const cacheAdapter = new LocalMemoryCacheAdapter(
+        entityConfiguration,
+        GenericLocalMemoryCacher.createLRUCache<BlahFields>({
+          maxSize: Number.MAX_SAFE_INTEGER,
+          ttlSeconds: Number.MAX_SAFE_INTEGER,
+        })
+      );
+      await cacheAdapter.invalidateManyAsync('id', []);
+    });
+  });
+});

--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/LocalMemoryTestEntity.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/LocalMemoryTestEntity.ts
@@ -1,0 +1,100 @@
+import {
+  AlwaysAllowPrivacyPolicyRule,
+  EntityPrivacyPolicy,
+  ViewerContext,
+  UUIDField,
+  DateField,
+  StringField,
+  EntityConfiguration,
+  EntityCompanionDefinition,
+  Entity,
+} from '@expo/entity';
+
+export type LocalMemoryTestEntityFields = {
+  id: string;
+  name: string;
+  dateField: Date | null;
+};
+
+export default class LocalMemoryTestEntity extends Entity<
+  LocalMemoryTestEntityFields,
+  string,
+  ViewerContext
+> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    LocalMemoryTestEntityFields,
+    string,
+    ViewerContext,
+    LocalMemoryTestEntity,
+    LocalMemoryTestEntityPrivacyPolicy
+  > {
+    return localMemoryTestEntityCompanionDefinition;
+  }
+}
+
+export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  LocalMemoryTestEntityFields,
+  string,
+  ViewerContext,
+  LocalMemoryTestEntity
+> {
+  protected override readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+  protected override readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+  protected override readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+  protected override readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+}
+
+export const localMemoryTestEntityConfiguration =
+  new EntityConfiguration<LocalMemoryTestEntityFields>({
+    idField: 'id',
+    tableName: 'local_memory_test_entities',
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+        cache: true,
+      }),
+      name: new StringField({
+        columnName: 'name',
+        cache: true,
+      }),
+      dateField: new DateField({
+        columnName: 'date_field',
+      }),
+    },
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'local-memory',
+  });
+
+const localMemoryTestEntityCompanionDefinition = new EntityCompanionDefinition({
+  entityClass: LocalMemoryTestEntity,
+  entityConfiguration: localMemoryTestEntityConfiguration,
+  privacyPolicyClass: LocalMemoryTestEntityPrivacyPolicy,
+});

--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryIntegrationTestEntityCompanionProvider.ts
@@ -1,0 +1,35 @@
+import {
+  NoOpEntityMetricsAdapter,
+  IEntityMetricsAdapter,
+  EntityCompanionProvider,
+  StubQueryContextProvider,
+  StubDatabaseAdapterProvider,
+} from '@expo/entity';
+
+import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
+
+export const createLocalMemoryIntegrationTestEntityCompanionProvider = (
+  localMemoryOptions: { maxSize?: number; ttlSeconds?: number } = {},
+  metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
+): EntityCompanionProvider => {
+  return new EntityCompanionProvider(
+    metricsAdapter,
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new StubDatabaseAdapterProvider(),
+          queryContextProvider: StubQueryContextProvider,
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'local-memory',
+        {
+          cacheAdapterProvider: LocalMemoryCacheAdapterProvider.getProvider(localMemoryOptions),
+        },
+      ],
+    ])
+  );
+};

--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryIntegrationTestEntityCompanionProvider.ts
@@ -12,6 +12,10 @@ export const createLocalMemoryIntegrationTestEntityCompanionProvider = (
   localMemoryOptions: { maxSize?: number; ttlSeconds?: number } = {},
   metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
 ): EntityCompanionProvider => {
+  const localMemoryCacheAdapterProvider =
+    localMemoryOptions.maxSize === 0 && localMemoryOptions.ttlSeconds === 0
+      ? LocalMemoryCacheAdapterProvider.getNoOpProvider()
+      : LocalMemoryCacheAdapterProvider.getProvider(localMemoryOptions);
   return new EntityCompanionProvider(
     metricsAdapter,
     new Map([
@@ -27,9 +31,18 @@ export const createLocalMemoryIntegrationTestEntityCompanionProvider = (
       [
         'local-memory',
         {
-          cacheAdapterProvider: LocalMemoryCacheAdapterProvider.getProvider(localMemoryOptions),
+          cacheAdapterProvider: localMemoryCacheAdapterProvider,
         },
       ],
     ])
+  );
+};
+
+export const createNoopLocalMemoryIntegrationTestEntityCompanionProvider = (
+  metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
+): EntityCompanionProvider => {
+  return createLocalMemoryIntegrationTestEntityCompanionProvider(
+    { maxSize: 0, ttlSeconds: 0 },
+    metricsAdapter
   );
 };

--- a/packages/entity-cache-adapter-local-memory/tsconfig.json
+++ b/packages/entity-cache-adapter-local-memory/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,28 +507,33 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@expo/entity-cache-adapter-local-memory@file:packages/entity-cache-adapter-local-memory":
+  version "0.23.0"
+  dependencies:
+    lru-cache "^7.3.1"
+
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.21.0"
+  version "0.23.0"
   dependencies:
     ioredis "^4.27.3"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.21.0"
+  version "0.23.0"
   dependencies:
     knex "^1.0.2"
 
 "@expo/entity-ip-address-field@file:packages/entity-ip-address-field":
-  version "0.21.0"
+  version "0.23.0"
   dependencies:
     ip-address "^8.1.0"
 
 "@expo/entity-secondary-cache-redis@file:packages/entity-secondary-cache-redis":
-  version "0.21.0"
+  version "0.23.0"
   dependencies:
     ioredis "^4.17.3"
 
 "@expo/entity@file:packages/entity":
-  version "0.21.0"
+  version "0.23.0"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"
@@ -1994,6 +1999,11 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
+"@types/lru-cache@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
+  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
 
 "@types/mime@*":
   version "2.0.1"
@@ -6564,6 +6574,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.3.1.tgz#7702e80694ec2bf19865567a469f2b081fcf53f5"
+  integrity sha512-nX1x4qUrKqwbIAhv4s9et4FIUVzNOpeY07bsjGUy8gwJrXH/wScImSQqXErmo/b2jZY2r0mohbLA9zVj7u1cNw==
 
 lunr@^2.3.9:
   version "2.3.9"


### PR DESCRIPTION
# Why

Moved the local memory cacher into the entity repo from www with a couple differences:
- upgrade to the newest `lru-cache` major version. The types are behind -- i can submit an upstream change to definitely typed, but in the meantime, i've made a new 'options' type for the lru cache constructor.
- added extra tests to increase test coverage

# Test Plan

- [ ] current and new tests pass
- [ ] todo: add an extra test for the generic cacher
