### PR TITLE
[PLS REVIEW] feat: composed cachers, try 2

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -143,12 +143,4 @@ export default class GenericLocalMemoryCacher<TFields> implements IEntityGeneric
       this.localMemoryCache.del(key);
     }
   }
-
-  public makeCacheKey(parts: string[]): string {
-    const delimiter = ':';
-    const escapedParts = parts.map((part) =>
-      part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
-    );
-    return escapedParts.join(delimiter);
-  }
 }

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapter.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapter.ts
@@ -1,80 +1,28 @@
-import { EntityCacheAdapter, CacheLoadResult, EntityConfiguration, mapKeys } from '@expo/entity';
+import { EntityConfiguration, PartsCacheAdapter, Parts } from '@expo/entity';
+import SimplePartsCacher from '@expo/entity/build/SimplePartsCacher';
 import invariant from 'invariant';
 
 import GenericLocalMemoryCacher, { LocalMemoryCache } from './GenericLocalMemoryCacher';
 
-export default class LocalMemoryCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
-  private readonly genericLocalMemoryCacher: GenericLocalMemoryCacher<TFields>;
-
+export default class LocalMemoryCacheAdapter<TFields> extends PartsCacheAdapter<TFields> {
   constructor(
     entityConfiguration: EntityConfiguration<TFields>,
     localMemoryCache: LocalMemoryCache<TFields>
   ) {
-    super(entityConfiguration);
-    this.genericLocalMemoryCacher = new GenericLocalMemoryCacher(localMemoryCache);
-  }
-
-  public async loadManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[]
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
-    const localMemoryCacheKeyToFieldValueMapping = new Map(
-      fieldValues.map((fieldValue) => [this.makeCacheKey(fieldName, fieldValue), fieldValue])
-    );
-    const cacheResults = await this.genericLocalMemoryCacher.loadManyAsync(
-      Array.from(localMemoryCacheKeyToFieldValueMapping.keys())
-    );
-
-    return mapKeys(cacheResults, (cacheKey) => {
-      const fieldValue = localMemoryCacheKeyToFieldValueMapping.get(cacheKey);
-      invariant(
-        fieldValue !== undefined,
-        'Unspecified cache key %s returned from generic local memory cacher',
-        cacheKey
-      );
-      return fieldValue;
-    });
-  }
-
-  public async cacheManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>
-  ): Promise<void> {
-    await this.genericLocalMemoryCacher.cacheManyAsync(
-      mapKeys(objectMap, (fieldValue) => this.makeCacheKey(fieldName, fieldValue))
+    super(
+      entityConfiguration,
+      new SimplePartsCacher(new GenericLocalMemoryCacher(localMemoryCache))
     );
   }
 
-  public async cacheDBMissesAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[]
-  ): Promise<void> {
-    await this.genericLocalMemoryCacher.cacheDBMissesAsync(
-      fieldValues.map((fieldValue) => this.makeCacheKey(fieldName, fieldValue))
-    );
-  }
-
-  public async invalidateManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[]
-  ): Promise<void> {
-    await this.genericLocalMemoryCacher.invalidateManyAsync(
-      fieldValues.map((fieldValue) => this.makeCacheKey(fieldName, fieldValue))
-    );
-  }
-
-  private makeCacheKey<N extends keyof TFields>(
-    fieldName: N,
-    fieldValue: NonNullable<TFields[N]>
-  ): string {
+  getParts<N extends keyof TFields>(fieldName: N, fieldValue: NonNullable<TFields[N]>): Parts {
     const columnName = this.entityConfiguration.entityToDBFieldsKeyMapping.get(fieldName);
     invariant(columnName, `database field mapping missing for ${fieldName}`);
-    const parts = [
+    return [
       this.entityConfiguration.tableName,
       `${this.entityConfiguration.cacheKeyVersion}`,
       columnName,
       String(fieldValue),
     ];
-    return this.genericLocalMemoryCacher.makeCacheKey(parts);
   }
 }

--- a/packages/entity-cache-adapter-local-memory/src/__integration-tests__/LocalMemoryCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__integration-tests__/LocalMemoryCacheAdapter-integration-test.ts
@@ -41,7 +41,7 @@ describe(LocalMemoryCacheAdapter, () => {
     const entitySpecificGenericCacher =
       LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap.get(
         LocalMemoryTestEntity.getCompanionDefinition().entityConfiguration.tableName
-      )!['genericLocalMemoryCacher'];
+      )!['partsCacher']['cacher'];
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),
     ]);
@@ -153,7 +153,7 @@ describe(LocalMemoryCacheAdapter, () => {
     const entitySpecificGenericCacher =
       LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap.get(
         LocalMemoryTestEntity.getCompanionDefinition().entityConfiguration.tableName
-      )!['genericLocalMemoryCacher'];
+      )!['partsCacher']['cacher'];
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),
     ]);

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-test.ts
@@ -72,7 +72,7 @@ describe(LocalMemoryCacheAdapter, () => {
       const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, localMemoryCache);
       await cacheAdapter.cacheManyAsync('id', new Map([['test-id-1', { id: 'test-id-1' }]]));
 
-      const cacheKey = cacheAdapter['makeCacheKey']('id', 'test-id-1');
+      const cacheKey = cacheAdapter['partsCacher']['makeCacheKey']('id', 'test-id-1');
       expect(localMemoryCache.get(cacheKey)).toMatchObject({
         id: 'test-id-1',
       });
@@ -89,7 +89,7 @@ describe(LocalMemoryCacheAdapter, () => {
       const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, localMemoryCache);
       await cacheAdapter.cacheDBMissesAsync('id', ['test-id-1']);
 
-      const cacheKey = cacheAdapter['makeCacheKey']('id', 'test-id-1');
+      const cacheKey = cacheAdapter['partsCacher']['makeCacheKey']('id', 'test-id-1');
       expect(localMemoryCache.get(cacheKey)).toEqual(DOES_NOT_EXIST_LOCAL_MEMORY_CACHE);
     });
   });

--- a/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/RedisCacheAdapter-test.ts
@@ -39,8 +39,11 @@ describe(RedisCacheAdapter, () => {
         ttlSecondsNegative: 2,
       });
 
-      redisResults.set(cacheAdapter['makeCacheKey']('id', 'wat'), JSON.stringify({ id: 'wat' }));
-      redisResults.set(cacheAdapter['makeCacheKey']('id', 'who'), '');
+      redisResults.set(
+        cacheAdapter['partsCacher']['makeCacheKey']('id', 'wat'),
+        JSON.stringify({ id: 'wat' })
+      );
+      redisResults.set(cacheAdapter['partsCacher']['makeCacheKey']('id', 'who'), '');
 
       const results = await cacheAdapter.loadManyAsync('id', ['wat', 'who', 'why']);
 
@@ -91,7 +94,7 @@ describe(RedisCacheAdapter, () => {
       });
       await cacheAdapter.cacheManyAsync('id', new Map([['wat', { id: 'wat' }]]));
 
-      const cacheKey = cacheAdapter['makeCacheKey']('id', 'wat');
+      const cacheKey = cacheAdapter['partsCacher']['makeCacheKey']('id', 'wat');
       expect(redisResults.get(cacheKey)).toMatchObject({
         value: JSON.stringify({ id: 'wat' }),
         code: 'EX',
@@ -126,7 +129,7 @@ describe(RedisCacheAdapter, () => {
       });
       await cacheAdapter.cacheDBMissesAsync('id', ['wat']);
 
-      const cacheKey = cacheAdapter['makeCacheKey']('id', 'wat');
+      const cacheKey = cacheAdapter['partsCacher']['makeCacheKey']('id', 'wat');
       expect(redisResults.get(cacheKey)).toMatchObject({
         value: '',
         code: 'EX',
@@ -150,7 +153,7 @@ describe(RedisCacheAdapter, () => {
       });
       await cacheAdapter.invalidateManyAsync('id', ['wat']);
 
-      const cacheKey = cacheAdapter['makeCacheKey']('id', 'wat');
+      const cacheKey = cacheAdapter['partsCacher']['makeCacheKey']('id', 'wat');
       verify(mockRedisClient.del(cacheKey)).once();
     });
 

--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -1,4 +1,9 @@
-import { EntityConfiguration, GenericSecondaryEntityCache } from '@expo/entity';
+import {
+  EntityConfiguration,
+  GenericSecondaryEntityCache,
+  Parts,
+  SimplePartsCacher,
+} from '@expo/entity';
 import { GenericRedisCacheContext, GenericRedisCacher } from '@expo/entity-cache-adapter-redis';
 
 /**
@@ -13,8 +18,15 @@ export default class RedisSecondaryEntityCache<
   constructor(
     entityConfiguration: EntityConfiguration<TFields>,
     genericRedisCacheContext: GenericRedisCacheContext,
-    constructRedisKey: (params: Readonly<TLoadParams>) => string
+    makeRedisSpecificKey: (...parts: Parts) => string,
+    getParts: (params: Readonly<TLoadParams>) => Parts
   ) {
-    super(new GenericRedisCacher(genericRedisCacheContext, entityConfiguration), constructRedisKey);
+    super(
+      new SimplePartsCacher(
+        new GenericRedisCacher(genericRedisCacheContext, entityConfiguration),
+        makeRedisSpecificKey
+      ),
+      getParts
+    );
   }
 }

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -87,7 +87,8 @@ describe(RedisSecondaryEntityCache, () => {
       new RedisSecondaryEntityCache(
         redisTestEntityConfiguration,
         redisCacheAdapterContext,
-        (loadParams) => `test-key-${loadParams.id}`
+        (...parts) => parts.join(':redis-specific-delimiter:'),
+        (loadParams) => [`test-key-${loadParams.id}`]
       ),
       RedisTestEntity.loader(viewerContext)
     );
@@ -126,7 +127,8 @@ describe(RedisSecondaryEntityCache, () => {
       new RedisSecondaryEntityCache(
         redisTestEntityConfiguration,
         redisCacheAdapterContext,
-        (loadParams) => `test-key-${loadParams.id}`
+        (...parts) => parts.join(':redis-specific-delimiter:'),
+        (loadParams) => [`test-key-${loadParams.id}`]
       ),
       RedisTestEntity.loader(viewerContext)
     );

--- a/packages/entity/src/ComposedPartsCacher.ts
+++ b/packages/entity/src/ComposedPartsCacher.ts
@@ -1,0 +1,82 @@
+import { CacheLoadResult } from '@expo/entity/src/internal/ReadThroughEntityCache';
+import invariant from 'invariant';
+
+import PartsCacher, { Parts, PartsKey } from './PartsCacher';
+import { CacheStatus } from './internal/ReadThroughEntityCache';
+
+/**
+ * A composed cacher by which objects are stored, fetched and removed in a series of caches
+ * */
+export default class ComposedPartsCacher<TFields> extends PartsCacher<TFields> {
+  constructor(
+    /**
+     * The series of cachers to use, in order of evaluation
+     * For example, [cacheAdapterEvaluatedFirst, cacheAdapterEvaluatedSecond, cacheAdapterEvaluatedThird]
+     */
+    private readonly partsCachers: PartsCacher<TFields>[]
+  ) {
+    super();
+  }
+
+  public async loadManyAsync(
+    partsList: readonly Parts[]
+  ): Promise<ReadonlyMap<PartsKey, CacheLoadResult<TFields>>> {
+    const resultsFromAllCachers = new Map<PartsKey, CacheLoadResult<TFields>>();
+    const partsKeysToParts = new Map(
+      partsList.map((parts) => [PartsCacher.getPartsKey(...parts), parts])
+    );
+    let partsKeysToLookup: PartsKey[] = partsList.map((parts) => PartsCacher.getPartsKey(...parts));
+    for (const partsCacher of this.partsCachers) {
+      const partsListToLookup = partsKeysToLookup.map((partsKey) => {
+        const parts = partsKeysToParts.get(partsKey);
+        invariant(parts, 'parts cannot be undefined');
+        return parts;
+      });
+      const cacheResults = await partsCacher.loadManyAsync(partsListToLookup);
+      const cacheMisses = [];
+      for (const [partsKey, cacheResult] of cacheResults) {
+        if (cacheResult.status === CacheStatus.MISS) {
+          cacheMisses.push(partsKey);
+        } else {
+          resultsFromAllCachers.set(partsKey, cacheResult);
+        }
+      }
+      partsKeysToLookup = cacheMisses;
+    }
+
+    // None of the cachers have these values, so they are misses
+    for (const partsKey of partsKeysToLookup) {
+      resultsFromAllCachers.set(partsKey, {
+        status: CacheStatus.MISS,
+      });
+    }
+    return resultsFromAllCachers;
+  }
+
+  public async cacheManyAsync(objectMap: ReadonlyMap<PartsKey, Readonly<TFields>>): Promise<void> {
+    // perform action on lower layers first
+    for (let i = this.partsCachers.length - 1; i >= 0; i--) {
+      const partsCacher = this.partsCachers[i];
+      invariant(partsCacher, 'parts cacher cannot be undefined');
+      await partsCacher.cacheManyAsync(objectMap);
+    }
+  }
+
+  public async cacheDBMissesAsync(partsList: readonly Parts[]): Promise<void> {
+    // perform action on lower layers first
+    for (let i = this.partsCachers.length - 1; i >= 0; i--) {
+      const partsCacher = this.partsCachers[i];
+      invariant(partsCacher, 'parts cacher cannot be undefined');
+      await partsCacher.cacheDBMissesAsync(partsList);
+    }
+  }
+
+  public async invalidateManyAsync(partsList: readonly Parts[]): Promise<void> {
+    // perform action on lower layers first
+    for (let i = this.partsCachers.length - 1; i >= 0; i--) {
+      const cacheAdapter = this.partsCachers[i];
+      invariant(cacheAdapter, 'parts cacher cannot be undefined');
+      await cacheAdapter.invalidateManyAsync(partsList);
+    }
+  }
+}

--- a/packages/entity/src/LocalMemoryAndRedisCacheAdapter.ts
+++ b/packages/entity/src/LocalMemoryAndRedisCacheAdapter.ts
@@ -1,0 +1,41 @@
+import { RedisCacheAdapterContext } from '@expo/entity-cache-adapter-redis';
+import invariant from 'invariant';
+
+import ComposedPartsCacher from './ComposedPartsCacher';
+import EntityConfiguration from './EntityConfiguration';
+import PartsCacheAdapter from './PartsCacheAdapter';
+import PartsCacher, { Parts } from './PartsCacher';
+
+/**
+ * TODO: put this in www
+ */
+export default class LocalMemoryAndRedisPartsCacheAdapter<
+  TFields
+> extends PartsCacheAdapter<TFields> {
+  constructor(
+    entityConfiguration: EntityConfiguration<TFields>,
+    localMemoryPartsCacher: PartsCacher<TFields>,
+    redisPartsCacher: PartsCacher<TFields>,
+    private readonly redisCacheAdapterContext: RedisCacheAdapterContext
+  ) {
+    super(
+      entityConfiguration,
+      new ComposedPartsCacher<TFields>([localMemoryPartsCacher, redisPartsCacher])
+    );
+  }
+
+  /**
+   * TODO: this seems wrong - look at moving the redis specific bits into the makeCacheSpecificKey of the SimplePartsCacher
+   */
+  getParts<N extends keyof TFields>(fieldName: N, fieldValue: NonNullable<TFields[N]>): Parts {
+    const columnName = this.entityConfiguration.entityToDBFieldsKeyMapping.get(fieldName);
+    invariant(columnName, `database field mapping missing for ${fieldName}`);
+    return [
+      this.redisCacheAdapterContext.cacheKeyPrefix,
+      this.entityConfiguration.tableName,
+      `v2.${this.entityConfiguration.cacheKeyVersion}`,
+      columnName,
+      String(fieldValue),
+    ];
+  }
+}

--- a/packages/entity/src/LocalMemoryAndRedisSecondaryEntityCache.ts
+++ b/packages/entity/src/LocalMemoryAndRedisSecondaryEntityCache.ts
@@ -1,0 +1,19 @@
+import ComposedPartsCacher from './ComposedPartsCacher';
+import GenericSecondaryEntityCache from './GenericSecondaryEntityCache';
+import PartsCacher, { Parts } from './PartsCacher';
+
+/**
+ * TODO: put this in www
+ */
+export default class LocalMemoryAndRedisSecondaryEntityCache<
+  TFields,
+  TLoadParams
+> extends GenericSecondaryEntityCache<TFields, TLoadParams> {
+  constructor(
+    localMemoryPartsCacher: PartsCacher<TFields>,
+    redisPartsCacher: PartsCacher<TFields>,
+    getParts: (params: Readonly<TLoadParams>) => Parts
+  ) {
+    super(new ComposedPartsCacher([localMemoryPartsCacher, redisPartsCacher]), getParts);
+  }
+}

--- a/packages/entity/src/PartsCacheAdapter.ts
+++ b/packages/entity/src/PartsCacheAdapter.ts
@@ -1,0 +1,74 @@
+import invariant from 'invariant';
+
+import EntityCacheAdapter from './EntityCacheAdapter';
+import EntityConfiguration from './EntityConfiguration';
+import PartsCacher, { Parts } from './PartsCacher';
+import { CacheLoadResult } from './internal/ReadThroughEntityCache';
+import { mapKeys } from './utils/collections/maps';
+
+export default abstract class PartsCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+  constructor(
+    entityConfiguration: EntityConfiguration<TFields>,
+    private readonly partsCacher: PartsCacher<TFields>
+  ) {
+    super(entityConfiguration);
+  }
+
+  public async loadManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
+    const partsList = fieldValues.map((fieldValue) => this.getParts(fieldName, fieldValue));
+    const partsKeysToFieldValueMapping = new Map(
+      fieldValues.map((fieldValue) => {
+        const parts = this.getParts(fieldName, fieldValue);
+        return [PartsCacher.getPartsKey(...parts), fieldValue];
+      })
+    );
+    const cacheResults = await this.partsCacher.loadManyAsync(partsList);
+
+    return mapKeys(cacheResults, (partsKey) => {
+      const fieldValue = partsKeysToFieldValueMapping.get(partsKey);
+      invariant(
+        fieldValue !== undefined,
+        'Unspecified cache key %s returned from Redis parts cacher',
+        partsKey
+      );
+      return fieldValue;
+    });
+  }
+
+  public async cacheManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>
+  ): Promise<void> {
+    const partsKeyToObject = mapKeys(objectMap, (fieldValue) => {
+      const parts = this.getParts(fieldName, fieldValue);
+      return PartsCacher.getPartsKey(...parts);
+    });
+    await this.partsCacher.cacheManyAsync(partsKeyToObject);
+  }
+
+  public async cacheDBMissesAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    await this.partsCacher.cacheDBMissesAsync(
+      fieldValues.map((fieldValue) => this.getParts(fieldName, fieldValue))
+    );
+  }
+
+  public async invalidateManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    await this.partsCacher.invalidateManyAsync(
+      fieldValues.map((fieldValue) => this.getParts(fieldName, fieldValue))
+    );
+  }
+
+  abstract getParts<N extends keyof TFields>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>
+  ): Parts;
+}

--- a/packages/entity/src/PartsCacher.ts
+++ b/packages/entity/src/PartsCacher.ts
@@ -1,0 +1,25 @@
+import { CacheLoadResult } from '@expo/entity/src/internal/ReadThroughEntityCache';
+
+export type Parts = string[];
+export type PartsKey = string;
+export default abstract class PartsCacher<TFields> {
+  public abstract loadManyAsync(
+    partsList: readonly Parts[]
+  ): Promise<ReadonlyMap<PartsKey, CacheLoadResult<TFields>>>;
+
+  public abstract cacheManyAsync(
+    objectMap: ReadonlyMap<PartsKey, Readonly<TFields>>
+  ): Promise<void>;
+
+  public abstract cacheDBMissesAsync(partsList: readonly Parts[]): Promise<void>;
+
+  public abstract invalidateManyAsync(partsList: readonly Parts[]): Promise<void>;
+
+  public static getPartsKey(...parts: Parts): PartsKey {
+    return JSON.stringify(parts);
+  }
+
+  public static getPartsFromKey(partKey: PartsKey): Parts {
+    return JSON.parse(partKey);
+  }
+}

--- a/packages/entity/src/SimplePartsCacher.ts
+++ b/packages/entity/src/SimplePartsCacher.ts
@@ -1,0 +1,59 @@
+import IEntityGenericCacher from '@expo/entity/src/IEntityGenericCacher';
+import { CacheLoadResult } from '@expo/entity/src/internal/ReadThroughEntityCache';
+import { mapKeys } from '@expo/entity/src/utils/collections/maps';
+import invariant from 'invariant';
+
+import PartsCacher, { Parts, PartsKey } from './PartsCacher';
+
+export default class SimplePartsCacher<TFields> extends PartsCacher<TFields> {
+  constructor(
+    private readonly cacher: IEntityGenericCacher<TFields>,
+    private readonly makeCacheSpecificKey: (...parts: Parts) => string = PartsCacher.getPartsKey
+  ) {
+    super();
+  }
+
+  public async loadManyAsync(
+    partsList: readonly Parts[]
+  ): Promise<ReadonlyMap<PartsKey, CacheLoadResult<TFields>>> {
+    const cacheSpecificKeyToPartKeyMapping = new Map(
+      partsList.map((parts) => [
+        this.makeCacheSpecificKey(...parts),
+        PartsCacher.getPartsKey(...parts),
+      ])
+    );
+    const cacheResults = await this.cacher.loadManyAsync(
+      Array.from(cacheSpecificKeyToPartKeyMapping.keys())
+    );
+
+    return mapKeys(cacheResults, (cacheKey) => {
+      const partKey = cacheSpecificKeyToPartKeyMapping.get(cacheKey);
+      invariant(
+        partKey !== undefined,
+        'Unspecified cache key %s returned from generic local memory cacher',
+        cacheKey
+      );
+      return partKey;
+    });
+  }
+
+  public async cacheManyAsync(objectMap: ReadonlyMap<PartsKey, Readonly<TFields>>): Promise<void> {
+    await this.cacher.cacheManyAsync(
+      mapKeys(objectMap, (partKey) =>
+        this.makeCacheSpecificKey(...PartsCacher.getPartsFromKey(partKey))
+      )
+    );
+  }
+
+  public async cacheDBMissesAsync(partsList: readonly Parts[]): Promise<void> {
+    await this.cacher.cacheDBMissesAsync(
+      partsList.map((parts) => this.makeCacheSpecificKey(...parts))
+    );
+  }
+
+  public async invalidateManyAsync(partsList: readonly Parts[]): Promise<void> {
+    await this.cacher.invalidateManyAsync(
+      partsList.map((parts) => this.makeCacheSpecificKey(...parts))
+    );
+  }
+}

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -45,6 +45,11 @@ export { default as IEntityCacheAdapterProvider } from './IEntityCacheAdapterPro
 export { default as IEntityDatabaseAdapterProvider } from './IEntityDatabaseAdapterProvider';
 export { default as EntityQueryContextProvider } from './EntityQueryContextProvider';
 export { default as IEntityGenericCacher } from './IEntityGenericCacher';
+export { default as SimplePartsCacher } from './SimplePartsCacher';
+export { default as PartsCacher } from './PartsCacher';
+export * from './PartsCacher';
+export { default as PartsCacheAdapter } from './PartsCacheAdapter';
+export { default as ComposedPartsCacher } from './ComposedPartsCacher';
 export { default as ReadonlyEntity } from './ReadonlyEntity';
 export { default as ViewerContext } from './ViewerContext';
 export { default as ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion';


### PR DESCRIPTION
# Why

This PR implements a LocalMemory + Redis SecondaryCache and CacheAdapter by introducing the concept of a PartsCacher. 

# How

![cachers](https://user-images.githubusercontent.com/6380927/154647012-e9e979ce-f133-402d-ae7f-dcd1fd99a5e0.png)

It was difficult to make a hybrid SecondaryCache because each cache has different cacheKey functions. Because the underlying Redis and LocalMemory Cachers have different cache key functions, it is hard to resolve them with the keys returned by the fetcher. 

A cleaner way is to introduce a `PartsCacher` abstraction, where the cacheKey functions and parts are standardized across the different cachers, making it easier to write a ComposedCacher. 

# Test Plan

- [ ] TODO
