### PR TITLE
feat: privacy policy evaluation context

### DIFF
--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -3,6 +3,7 @@ import {
   ReadonlyEntity,
   EntityQueryContext,
   RuleEvaluationResult,
+  EntityPrivacyPolicyEvaluationContext,
 } from '@expo/entity';
 
 import { ExampleViewerContext } from '../viewerContexts';
@@ -34,6 +35,7 @@ export default class AllowIfUserOwnerPrivacyRule<
   async evaluateAsync(
     viewerContext: ExampleViewerContext,
     _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     entity: TEntity
   ): Promise<RuleEvaluationResult> {
     if (viewerContext.isUserViewerContext()) {

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -69,7 +69,7 @@ export default abstract class Entity<
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forCreate(queryContext);
+      .forCreate(queryContext, { cascadingDeleteCause: null });
   }
 
   /**
@@ -111,7 +111,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forUpdate(existingEntity, queryContext);
+      .forUpdate(existingEntity, queryContext, { cascadingDeleteCause: null });
   }
 
   /**
@@ -152,7 +152,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forDelete(existingEntity, queryContext)
+      .forDelete(existingEntity, queryContext, { cascadingDeleteCause: null })
       .deleteAsync();
   }
 
@@ -194,7 +194,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forDelete(existingEntity, queryContext)
+      .forDelete(existingEntity, queryContext, { cascadingDeleteCause: null })
       .enforceDeleteAsync();
   }
 
@@ -251,6 +251,7 @@ export default abstract class Entity<
       privacyPolicy.authorizeUpdateAsync(
         existingEntity.getViewerContext(),
         queryContext,
+        { cascadingDeleteCause: null },
         existingEntity,
         companion.getMetricsAdapter()
       )
@@ -304,6 +305,7 @@ export default abstract class Entity<
       privacyPolicy.authorizeDeleteAsync(
         existingEntity.getViewerContext(),
         queryContext,
+        { cascadingDeleteCause: null },
         existingEntity,
         companion.getMetricsAdapter()
       )

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -69,7 +69,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
-      .forLoad(queryContext);
+      .forLoad(queryContext, { cascadingDeleteCause: null });
 
     return (await loader.loadByIDAsync(associatedEntityID as unknown as TAssociatedID)) as Result<
       null extends TFields[TIdentifyingField] ? TAssociatedEntity | null : TAssociatedEntity
@@ -123,7 +123,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
-      .forLoad(queryContext);
+      .forLoad(queryContext, { cascadingDeleteCause: null });
     return await loader.loadManyByFieldEqualingAsync(
       associatedEntityFieldContainingThisID,
       thisID as any
@@ -180,7 +180,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
-      .forLoad(queryContext);
+      .forLoad(queryContext, { cascadingDeleteCause: null });
     return await loader.loadByFieldEqualingAsync(
       associatedEntityLookupByField,
       associatedFieldValue as any
@@ -238,7 +238,7 @@ export default class EntityAssociationLoader<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
-      .forLoad(queryContext);
+      .forLoad(queryContext, { cascadingDeleteCause: null });
     return await loader.loadManyByFieldEqualingAsync(
       associatedEntityLookupByField,
       associatedFieldValue as any

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -9,7 +9,7 @@ import {
   QuerySelectionModifiers,
   isSingleValueFieldEqualityCondition,
 } from './EntityDatabaseAdapter';
-import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -40,6 +40,7 @@ export default class EntityLoader<
   constructor(
     private readonly viewerContext: TViewerContext,
     private readonly queryContext: EntityQueryContext,
+    private readonly privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext,
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly entityClass: IEntityClass<
       TFields,
@@ -218,6 +219,7 @@ export default class EntityLoader<
           this.privacyPolicy.authorizeReadAsync(
             this.viewerContext,
             this.queryContext,
+            this.privacyPolicyEvaluationContext,
             uncheckedEntityResult.value,
             this.metricsAdapter
           )
@@ -272,6 +274,7 @@ export default class EntityLoader<
           this.privacyPolicy.authorizeReadAsync(
             this.viewerContext,
             this.queryContext,
+            this.privacyPolicyEvaluationContext,
             uncheckedEntityResult.value,
             this.metricsAdapter
           )
@@ -332,6 +335,7 @@ export default class EntityLoader<
             this.privacyPolicy.authorizeReadAsync(
               this.viewerContext,
               this.queryContext,
+              this.privacyPolicyEvaluationContext,
               uncheckedEntityResult.value,
               this.metricsAdapter
             )

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -1,7 +1,7 @@
 import { IEntityClass } from './Entity';
 import EntityConfiguration from './EntityConfiguration';
 import EntityLoader from './EntityLoader';
-import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -47,11 +47,13 @@ export default class EntityLoaderFactory<
    */
   forLoad(
     viewerContext: TViewerContext,
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): EntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicyClass,

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -22,9 +22,19 @@ export type EntityValidatorMutationInfo<
       previousValue: TEntity;
     };
 
-export type EntityMutationTriggerDeleteCascadeInfo<> = {
+/**
+ * Information about a cascading deletion.
+ */
+export type EntityCascadingDeletionInfo = {
+  /**
+   * The entity that is being mutated at this step in the cascaded deletion.
+   */
   entity: Entity<any, any, any, any>;
-  cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null;
+
+  /**
+   * The cascade deletion that caused this mutation.
+   */
+  cascadingDeleteCause: EntityCascadingDeletionInfo | null;
 };
 
 export type EntityTriggerMutationInfo<
@@ -43,5 +53,5 @@ export type EntityTriggerMutationInfo<
     }
   | {
       type: EntityMutationType.DELETE;
-      cascadingDeleteCause: EntityMutationTriggerDeleteCascadeInfo | null;
+      cascadingDeleteCause: EntityCascadingDeletionInfo | null;
     };

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -5,7 +5,7 @@ import EntityLoaderFactory from './EntityLoaderFactory';
 import EntityMutationTriggerConfiguration from './EntityMutationTriggerConfiguration';
 import EntityMutationValidator from './EntityMutationValidator';
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
-import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
 import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
@@ -72,11 +72,13 @@ export default class EntityMutatorFactory<
    */
   forCreate(
     viewerContext: TViewerContext,
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new CreateMutator(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
@@ -96,11 +98,13 @@ export default class EntityMutatorFactory<
    */
   forUpdate(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new UpdateMutator(
       existingEntity.getViewerContext(),
       queryContext,
+      privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
@@ -120,11 +124,13 @@ export default class EntityMutatorFactory<
    */
   forDelete(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new DeleteMutator(
       existingEntity.getViewerContext(),
       queryContext,
+      privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -156,6 +156,6 @@ export default abstract class ReadonlyEntity<
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getLoaderFactory()
-      .forLoad(queryContext);
+      .forLoad(queryContext, { cascadingDeleteCause: null });
   }
 }

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -1,6 +1,6 @@
 import EntityLoader from './EntityLoader';
 import EntityLoaderFactory from './EntityLoaderFactory';
-import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -35,8 +35,13 @@ export default class ViewerScopedEntityLoaderFactory<
   ) {}
 
   forLoad(
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): EntityLoader<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityLoaderFactory.forLoad(this.viewerContext, queryContext);
+    return this.entityLoaderFactory.forLoad(
+      this.viewerContext,
+      queryContext,
+      privacyPolicyEvaluationContext
+    );
   }
 }

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -1,6 +1,6 @@
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
 import EntityMutatorFactory from './EntityMutatorFactory';
-import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -35,22 +35,37 @@ export default class ViewerScopedEntityMutatorFactory<
   ) {}
 
   forCreate(
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityMutatorFactory.forCreate(this.viewerContext, queryContext);
+    return this.entityMutatorFactory.forCreate(
+      this.viewerContext,
+      queryContext,
+      privacyPolicyEvaluationContext
+    );
   }
 
   forUpdate(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityMutatorFactory.forUpdate(existingEntity, queryContext);
+    return this.entityMutatorFactory.forUpdate(
+      existingEntity,
+      queryContext,
+      privacyPolicyEvaluationContext
+    );
   }
 
   forDelete(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityMutatorFactory.forDelete(existingEntity, queryContext);
+    return this.entityMutatorFactory.forDelete(
+      existingEntity,
+      queryContext,
+      privacyPolicyEvaluationContext
+    );
   }
 }

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -5,7 +5,7 @@ import Entity from '../Entity';
 import EntityCompanionProvider, { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
-import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import { enforceResultsAsync } from '../entityUtils';
@@ -51,6 +51,7 @@ class DenyIfNotOwnerPrivacyPolicyRule extends PrivacyPolicyRule<
   async evaluateAsync(
     viewerContext: TestUserViewerContext,
     _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     entity: BlahEntity
   ): Promise<RuleEvaluationResult> {
     if (viewerContext.getUserID() === entity.getField('ownerID')) {

--- a/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
@@ -5,7 +5,7 @@ import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { StringField } from '../EntityFields';
 import EntityLoader from '../EntityLoader';
-import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import ViewerContext from '../ViewerContext';
 import EntityDataManager from '../internal/EntityDataManager';
 import ReadThroughEntityCache from '../internal/ReadThroughEntityCache';
@@ -118,6 +118,7 @@ export const testEntityCompanion = new EntityCompanionDefinition({
 describe(EntityLoader, () => {
   it('handles thrown errors and literals from constructor', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
 
@@ -154,6 +155,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -3,6 +3,7 @@ import { mock, instance, verify, spy, deepEqual, anyOfClass, anything, when } fr
 import { v4 as uuidv4 } from 'uuid';
 
 import EntityLoader from '../EntityLoader';
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import ViewerContext from '../ViewerContext';
 import { enforceResultsAsync } from '../entityUtils';
 import EntityDataManager from '../internal/EntityDataManager';
@@ -21,6 +22,7 @@ describe(EntityLoader, () => {
   it('loads entities', async () => {
     const dateToInsert = new Date();
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
 
@@ -69,6 +71,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -113,6 +116,7 @@ describe(EntityLoader, () => {
     const privacyPolicy = new TestEntityPrivacyPolicy();
     const spiedPrivacyPolicy = spy(privacyPolicy);
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
 
@@ -169,6 +173,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -192,6 +197,7 @@ describe(EntityLoader, () => {
       spiedPrivacyPolicy.authorizeReadAsync(
         viewerContext,
         queryContext,
+        privacyPolicyEvaluationContext,
         anyOfClass(TestEntity),
         anything()
       )
@@ -209,6 +215,7 @@ describe(EntityLoader, () => {
     const spiedPrivacyPolicy = spy(privacyPolicy);
 
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
 
@@ -247,6 +254,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -255,12 +263,19 @@ describe(EntityLoader, () => {
     );
     const entity = await enforceAsyncResult(entityLoader.loadByIDAsync(id1));
     verify(
-      spiedPrivacyPolicy.authorizeReadAsync(viewerContext, queryContext, entity, anything())
+      spiedPrivacyPolicy.authorizeReadAsync(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        entity,
+        anything()
+      )
     ).once();
   });
 
   it('invalidates upon invalidate one', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
@@ -271,6 +286,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -286,6 +302,7 @@ describe(EntityLoader, () => {
 
   it('invalidates upon invalidate by field', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
@@ -296,6 +313,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -310,6 +328,7 @@ describe(EntityLoader, () => {
 
   it('invalidates upon invalidate by entity', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
@@ -324,6 +343,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -338,6 +358,7 @@ describe(EntityLoader, () => {
 
   it('returns error result when not allowed', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicyMock = mock(TestEntityPrivacyPolicy);
@@ -354,6 +375,7 @@ describe(EntityLoader, () => {
       privacyPolicyMock.authorizeReadAsync(
         viewerContext,
         queryContext,
+        privacyPolicyEvaluationContext,
         anyOfClass(TestEntity),
         anything()
       )
@@ -365,6 +387,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,
@@ -380,6 +403,7 @@ describe(EntityLoader, () => {
 
   it('throws upon database adapter error', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
@@ -396,6 +420,7 @@ describe(EntityLoader, () => {
     const entityLoader = new EntityLoader(
       viewerContext,
       queryContext,
+      privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
       privacyPolicy,

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -25,6 +25,7 @@ import EntityMutationTriggerConfiguration, {
 } from '../EntityMutationTriggerConfiguration';
 import EntityMutationValidator from '../EntityMutationValidator';
 import EntityMutatorFactory from '../EntityMutatorFactory';
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityTransactionalQueryContext, EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import { enforceResultsAsync } from '../entityUtils';
@@ -340,6 +341,7 @@ describe(EntityMutatorFactory, () => {
   describe('forCreate', () => {
     it('creates entities', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -363,7 +365,7 @@ describe(EntityMutatorFactory, () => {
         },
       ]);
       const newEntity = await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh')
         .enforceCreateAsync();
       expect(newEntity).toBeTruthy();
@@ -371,6 +373,7 @@ describe(EntityMutatorFactory, () => {
 
     it('checks privacy', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -397,7 +400,7 @@ describe(EntityMutatorFactory, () => {
       const spiedPrivacyPolicy = spy(privacyPolicy);
 
       await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh')
         .enforceCreateAsync();
 
@@ -405,6 +408,7 @@ describe(EntityMutatorFactory, () => {
         spiedPrivacyPolicy.authorizeCreateAsync(
           viewerContext,
           anyOfClass(EntityTransactionalQueryContext),
+          privacyPolicyEvaluationContext,
           anyOfClass(TestEntity),
           anything()
         )
@@ -413,6 +417,7 @@ describe(EntityMutatorFactory, () => {
 
     it('executes triggers', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -439,7 +444,7 @@ describe(EntityMutatorFactory, () => {
       const triggerSpies = setUpMutationTriggerSpies(mutationTriggers);
 
       await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh')
         .enforceCreateAsync();
 
@@ -460,6 +465,7 @@ describe(EntityMutatorFactory, () => {
 
     it('executes validators', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -486,7 +492,7 @@ describe(EntityMutatorFactory, () => {
       const validatorSpies = setUpMutationValidatorSpies(mutationValidators);
 
       await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh')
         .enforceCreateAsync();
 
@@ -497,6 +503,7 @@ describe(EntityMutatorFactory, () => {
   describe('forUpdate', () => {
     it('updates entities', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -521,11 +528,13 @@ describe(EntityMutatorFactory, () => {
       ]);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id2)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2)
       );
 
       const updatedEntity = await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
+        .forUpdate(existingEntity, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh2')
         .enforceUpdateAsync();
 
@@ -534,13 +543,16 @@ describe(EntityMutatorFactory, () => {
       expect(updatedEntity.getField('stringField')).toEqual('huh2');
 
       const reloadedEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id2)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2)
       );
       expect(reloadedEntity.getAllFields()).toMatchObject(updatedEntity.getAllFields());
     });
 
     it('checks privacy', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -568,11 +580,13 @@ describe(EntityMutatorFactory, () => {
       const spiedPrivacyPolicy = spy(privacyPolicy);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id2)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2)
       );
 
       await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
+        .forUpdate(existingEntity, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh2')
         .enforceUpdateAsync();
 
@@ -580,6 +594,7 @@ describe(EntityMutatorFactory, () => {
         spiedPrivacyPolicy.authorizeUpdateAsync(
           viewerContext,
           anyOfClass(EntityTransactionalQueryContext),
+          privacyPolicyEvaluationContext,
           anyOfClass(TestEntity),
           anything()
         )
@@ -588,6 +603,7 @@ describe(EntityMutatorFactory, () => {
 
     it('executes triggers', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -615,11 +631,13 @@ describe(EntityMutatorFactory, () => {
       const triggerSpies = setUpMutationTriggerSpies(mutationTriggers);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id2)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2)
       );
 
       await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
+        .forUpdate(existingEntity, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh2')
         .enforceUpdateAsync();
 
@@ -639,6 +657,7 @@ describe(EntityMutatorFactory, () => {
     });
     it('executes validators', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -666,11 +685,13 @@ describe(EntityMutatorFactory, () => {
       const validatorSpies = setUpMutationValidatorSpies(mutationValidators);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id2)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2)
       );
 
       await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
+        .forUpdate(existingEntity, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh2')
         .enforceUpdateAsync();
 
@@ -684,6 +705,7 @@ describe(EntityMutatorFactory, () => {
   describe('forDelete', () => {
     it('deletes entities', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -699,21 +721,28 @@ describe(EntityMutatorFactory, () => {
       ]);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id1)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1)
       );
       expect(existingEntity).toBeTruthy();
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory
+        .forDelete(existingEntity, queryContext, privacyPolicyEvaluationContext)
+        .enforceDeleteAsync();
 
       await expect(
         enforceAsyncResult(
-          entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id1)
+          entityLoaderFactory
+            .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+            .loadByIDAsync(id1)
         )
       ).rejects.toBeInstanceOf(Error);
     });
 
     it('checks privacy', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -732,15 +761,20 @@ describe(EntityMutatorFactory, () => {
       const spiedPrivacyPolicy = spy(privacyPolicy);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id1)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1)
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory
+        .forDelete(existingEntity, queryContext, privacyPolicyEvaluationContext)
+        .enforceDeleteAsync();
 
       verify(
         spiedPrivacyPolicy.authorizeDeleteAsync(
           viewerContext,
           anyOfClass(EntityTransactionalQueryContext),
+          anything(),
           anyOfClass(TestEntity),
           anything()
         )
@@ -749,6 +783,7 @@ describe(EntityMutatorFactory, () => {
 
     it('executes triggers', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -767,10 +802,14 @@ describe(EntityMutatorFactory, () => {
       const triggerSpies = setUpMutationTriggerSpies(mutationTriggers);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id1)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1)
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory
+        .forDelete(existingEntity, queryContext, privacyPolicyEvaluationContext)
+        .enforceDeleteAsync();
 
       verifyTriggerCounts(
         viewerContext,
@@ -789,6 +828,7 @@ describe(EntityMutatorFactory, () => {
 
     it('does not execute validators', async () => {
       const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const queryContext = StubQueryContextProvider.getQueryContext();
 
       const id1 = uuidv4();
@@ -807,10 +847,14 @@ describe(EntityMutatorFactory, () => {
       const validatorSpies = setUpMutationValidatorSpies(mutationValidators);
 
       const existingEntity = await enforceAsyncResult(
-        entityLoaderFactory.forLoad(viewerContext, queryContext).loadByIDAsync(id1)
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1)
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory
+        .forDelete(existingEntity, queryContext, privacyPolicyEvaluationContext)
+        .enforceDeleteAsync();
 
       verifyValidatorCounts(viewerContext, validatorSpies, 0, {
         type: EntityMutationType.DELETE as any,
@@ -820,6 +864,7 @@ describe(EntityMutatorFactory, () => {
 
   it('invalidates cache for fields upon create', async () => {
     const viewerContext = mock<ViewerContext>();
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = StubQueryContextProvider.getQueryContext();
 
     const id1 = uuidv4();
@@ -836,21 +881,21 @@ describe(EntityMutatorFactory, () => {
 
     const entites1 = await enforceResultsAsync(
       entityLoaderFactory
-        .forLoad(viewerContext, queryContext)
+        .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .loadManyByFieldEqualingAsync('stringField', 'huh')
     );
     expect(entites1).toHaveLength(1);
 
     await enforceAsyncResult(
       entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh')
         .createAsync()
     );
 
     const entities2 = await enforceResultsAsync(
       entityLoaderFactory
-        .forLoad(viewerContext, queryContext)
+        .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .loadManyByFieldEqualingAsync('stringField', 'huh')
     );
     expect(entities2).toHaveLength(2);
@@ -858,6 +903,7 @@ describe(EntityMutatorFactory, () => {
 
   it('throws error when field not valid', async () => {
     const viewerContext = mock<ViewerContext>();
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const id1 = uuidv4();
     const { entityMutatorFactory } = createEntityMutatorFactory([
@@ -873,19 +919,19 @@ describe(EntityMutatorFactory, () => {
 
     await expect(
       entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 10 as any)
         .createAsync()
     ).rejects.toThrowError('Entity field not valid: TestEntity (stringField = 10)');
 
     const createdEntity = await entityMutatorFactory
-      .forCreate(viewerContext, queryContext)
+      .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
       .setField('stringField', 'hello')
       .enforceCreateAsync();
 
     await expect(
       entityMutatorFactory
-        .forUpdate(createdEntity, queryContext)
+        .forUpdate(createdEntity, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 10 as any)
         .updateAsync()
     ).rejects.toThrowError('Entity field not valid: TestEntity (stringField = 10)');
@@ -893,6 +939,7 @@ describe(EntityMutatorFactory, () => {
 
   it('returns error result when not authorized to create', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicyMock = mock(SimpleTestEntityPrivacyPolicy);
     const databaseAdapter = instance(mock<EntityDatabaseAdapter<SimpleTestFields>>());
@@ -916,6 +963,7 @@ describe(EntityMutatorFactory, () => {
       privacyPolicyMock.authorizeCreateAsync(
         viewerContext,
         anyOfClass(EntityTransactionalQueryContext),
+        anything(),
         anyOfClass(SimpleTestEntity),
         anything()
       )
@@ -924,6 +972,7 @@ describe(EntityMutatorFactory, () => {
       privacyPolicyMock.authorizeUpdateAsync(
         viewerContext,
         anyOfClass(EntityTransactionalQueryContext),
+        anything(),
         anyOfClass(SimpleTestEntity),
         anything()
       )
@@ -932,6 +981,7 @@ describe(EntityMutatorFactory, () => {
       privacyPolicyMock.authorizeDeleteAsync(
         viewerContext,
         anyOfClass(EntityTransactionalQueryContext),
+        anything(),
         anyOfClass(SimpleTestEntity),
         anything()
       )
@@ -949,7 +999,7 @@ describe(EntityMutatorFactory, () => {
     );
 
     const entityCreateResult = await entityMutatorFactory
-      .forCreate(viewerContext, queryContext)
+      .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
       .createAsync();
     expect(entityCreateResult.ok).toBe(false);
     expect(entityCreateResult.reason).toEqual(rejectionError);
@@ -961,14 +1011,14 @@ describe(EntityMutatorFactory, () => {
     });
 
     const entityUpdateResult = await entityMutatorFactory
-      .forUpdate(fakeEntity, queryContext)
+      .forUpdate(fakeEntity, queryContext, privacyPolicyEvaluationContext)
       .updateAsync();
     expect(entityUpdateResult.ok).toBe(false);
     expect(entityUpdateResult.reason).toEqual(rejectionError);
     expect(entityUpdateResult.value).toBe(undefined);
 
     const entityDeleteResult = await entityMutatorFactory
-      .forDelete(fakeEntity, queryContext)
+      .forDelete(fakeEntity, queryContext, privacyPolicyEvaluationContext)
       .deleteAsync();
     expect(entityDeleteResult.ok).toBe(false);
     expect(entityDeleteResult.reason).toEqual(rejectionError);
@@ -977,6 +1027,7 @@ describe(EntityMutatorFactory, () => {
 
   it('throws error when db adapter throws', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const privacyPolicy = instance(mock(SimpleTestEntityPrivacyPolicy));
     const databaseAdapterMock = mock<EntityDatabaseAdapter<SimpleTestFields>>();
@@ -1032,37 +1083,48 @@ describe(EntityMutatorFactory, () => {
     });
 
     await expect(
-      entityMutatorFactory.forCreate(viewerContext, queryContext).createAsync()
+      entityMutatorFactory
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
+        .createAsync()
     ).rejects.toEqual(rejectionError);
     await expect(
-      entityMutatorFactory.forUpdate(fakeEntity, queryContext).updateAsync()
+      entityMutatorFactory
+        .forUpdate(fakeEntity, queryContext, privacyPolicyEvaluationContext)
+        .updateAsync()
     ).rejects.toEqual(rejectionError);
     await expect(
-      entityMutatorFactory.forDelete(fakeEntity, queryContext).deleteAsync()
+      entityMutatorFactory
+        .forDelete(fakeEntity, queryContext, privacyPolicyEvaluationContext)
+        .deleteAsync()
     ).rejects.toEqual(rejectionError);
   });
 
   it('records metrics appropriately', async () => {
     const viewerContext = mock<ViewerContext>();
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = StubQueryContextProvider.getQueryContext();
     const { entityMutatorFactory, metricsAdapter } = createEntityMutatorFactory([]);
     const spiedMetricsAdapter = spy(metricsAdapter);
 
     const newEntity = await enforceAsyncResult(
       entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
+        .forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'huh')
         .createAsync()
     );
 
     await enforceAsyncResult(
       entityMutatorFactory
-        .forUpdate(newEntity, queryContext)
+        .forUpdate(newEntity, queryContext, privacyPolicyEvaluationContext)
         .setField('stringField', 'wat')
         .updateAsync()
     );
 
-    await enforceAsyncResult(entityMutatorFactory.forDelete(newEntity, queryContext).deleteAsync());
+    await enforceAsyncResult(
+      entityMutatorFactory
+        .forDelete(newEntity, queryContext, privacyPolicyEvaluationContext)
+        .deleteAsync()
+    );
 
     verify(
       spiedMetricsAdapter.logMutatorMutationEvent(

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -8,6 +8,7 @@ import EntityPrivacyPolicy, {
   EntityPrivacyPolicyEvaluator,
   EntityAuthorizationAction,
   EntityPrivacyPolicyEvaluationMode,
+  EntityPrivacyPolicyEvaluationContext,
 } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
@@ -166,6 +167,7 @@ class AlwaysThrowPrivacyPolicyRule extends PrivacyPolicyRule<
   evaluateAsync(
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: BlahEntity
   ): Promise<RuleEvaluationResult> {
     throw new Error('WooHoo!');
@@ -245,12 +247,19 @@ describe(EntityPrivacyPolicy, () => {
     it('throws EntityNotAuthorizedError when deny', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
       const policy = new AlwaysDenyPolicy();
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
       verify(
         metricsAdapterMock.logAuthorizationEvent(
@@ -267,6 +276,7 @@ describe(EntityPrivacyPolicy, () => {
     it('returns entity when allowed', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -274,6 +284,7 @@ describe(EntityPrivacyPolicy, () => {
       const approvedEntity = await policy.authorizeCreateAsync(
         viewerContext,
         queryContext,
+        privacyPolicyEvaluationContext,
         entity,
         metricsAdapter
       );
@@ -293,12 +304,19 @@ describe(EntityPrivacyPolicy, () => {
     it('throws EntityNotAuthorizedError when all skipped', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
       const policy = new SkipAllPolicy();
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
       verify(
         metricsAdapterMock.logAuthorizationEvent(
@@ -315,12 +333,19 @@ describe(EntityPrivacyPolicy, () => {
     it('throws EntityNotAuthorizedError when empty policy', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
       const policy = new EmptyPolicy();
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
       verify(
         metricsAdapterMock.logAuthorizationEvent(
@@ -337,12 +362,19 @@ describe(EntityPrivacyPolicy, () => {
     it('throws when rule throws', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
       const policy = new ThrowAllPolicy();
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toThrowError('WooHoo!');
       verify(metricsAdapterMock.logAuthorizationEvent(anything())).never();
     });
@@ -352,6 +384,7 @@ describe(EntityPrivacyPolicy, () => {
     it('returns entity when denied but calls denialHandler', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -362,6 +395,7 @@ describe(EntityPrivacyPolicy, () => {
       const approvedEntity = await policy.authorizeCreateAsync(
         viewerContext,
         queryContext,
+        privacyPolicyEvaluationContext,
         entity,
         metricsAdapter
       );
@@ -384,6 +418,7 @@ describe(EntityPrivacyPolicy, () => {
     it('does not log when not denied', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -394,6 +429,7 @@ describe(EntityPrivacyPolicy, () => {
       const approvedEntity = await policy.authorizeCreateAsync(
         viewerContext,
         queryContext,
+        privacyPolicyEvaluationContext,
         entity,
         metricsAdapter
       );
@@ -416,6 +452,7 @@ describe(EntityPrivacyPolicy, () => {
     it('passes through other errors', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -424,7 +461,13 @@ describe(EntityPrivacyPolicy, () => {
       const policySpy = spy(policy);
 
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toThrowError('WooHoo!');
 
       verify(policySpy.denyHandler(anyOfClass(EntityNotAuthorizedError))).never();
@@ -437,6 +480,7 @@ describe(EntityPrivacyPolicy, () => {
     it('denies when denied but calls denialHandler', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -445,7 +489,13 @@ describe(EntityPrivacyPolicy, () => {
       const policySpy = spy(policy);
 
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
       verify(policySpy.denyHandler(anyOfClass(EntityNotAuthorizedError))).once();
@@ -465,6 +515,7 @@ describe(EntityPrivacyPolicy, () => {
     it('does not log when not denied', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -475,6 +526,7 @@ describe(EntityPrivacyPolicy, () => {
       const approvedEntity = await policy.authorizeCreateAsync(
         viewerContext,
         queryContext,
+        privacyPolicyEvaluationContext,
         entity,
         metricsAdapter
       );
@@ -497,6 +549,7 @@ describe(EntityPrivacyPolicy, () => {
     it('passes through other errors', async () => {
       const viewerContext = instance(mock(ViewerContext));
       const queryContext = instance(mock(EntityQueryContext));
+      const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
       const entity = new BlahEntity(viewerContext, { id: '1' });
@@ -505,7 +558,13 @@ describe(EntityPrivacyPolicy, () => {
       const policySpy = spy(policy);
 
       await expect(
-        policy.authorizeCreateAsync(viewerContext, queryContext, entity, metricsAdapter)
+        policy.authorizeCreateAsync(
+          viewerContext,
+          queryContext,
+          privacyPolicyEvaluationContext,
+          entity,
+          metricsAdapter
+        )
       ).rejects.toThrowError('WooHoo!');
 
       verify(policySpy.denyHandler(anyOfClass(EntityNotAuthorizedError))).never();

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -79,6 +79,7 @@ describe(EntitySecondaryCacheLoader, () => {
           vc1,
           anyOfClass(EntityNonTransactionalQueryContext),
           anything(),
+          anything(),
           anything()
         )
       ).once();

--- a/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
@@ -1,6 +1,7 @@
 import { mock, verify, instance } from 'ts-mockito';
 
 import EntityLoaderFactory from '../EntityLoaderFactory';
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import ViewerScopedEntityLoaderFactory from '../ViewerScopedEntityLoaderFactory';
@@ -8,6 +9,7 @@ import ViewerScopedEntityLoaderFactory from '../ViewerScopedEntityLoaderFactory'
 describe(ViewerScopedEntityLoaderFactory, () => {
   it('correctly scopes viewer to entity loads', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = instance(mock(EntityQueryContext));
     const baseLoader = mock<EntityLoaderFactory<any, any, any, any, any, any>>(EntityLoaderFactory);
     const baseLoaderInstance = instance(baseLoader);
@@ -21,8 +23,8 @@ describe(ViewerScopedEntityLoaderFactory, () => {
       any
     >(baseLoaderInstance, viewerContext);
 
-    viewerScopedEntityLoader.forLoad(queryContext);
+    viewerScopedEntityLoader.forLoad(queryContext, privacyPolicyEvaluationContext);
 
-    verify(baseLoader.forLoad(viewerContext, queryContext)).once();
+    verify(baseLoader.forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)).once();
   });
 });

--- a/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
@@ -1,6 +1,7 @@
 import { mock, instance, verify } from 'ts-mockito';
 
 import EntityMutatorFactory from '../EntityMutatorFactory';
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import ViewerScopedEntityMutatorFactory from '../ViewerScopedEntityMutatorFactory';
@@ -9,6 +10,7 @@ import TestEntity, { TestFields, TestEntityPrivacyPolicy } from '../testfixtures
 describe(ViewerScopedEntityMutatorFactory, () => {
   it('correctly scopes viewer to entity mutations', async () => {
     const viewerContext = instance(mock(ViewerContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = instance(mock(EntityQueryContext));
     const baseMutatorFactory =
       mock<
@@ -25,8 +27,10 @@ describe(ViewerScopedEntityMutatorFactory, () => {
       keyof TestFields
     >(baseMutatorFactoryInstance, viewerContext);
 
-    viewerScopedEntityLoader.forCreate(queryContext);
+    viewerScopedEntityLoader.forCreate(queryContext, privacyPolicyEvaluationContext);
 
-    verify(baseMutatorFactory.forCreate(viewerContext, queryContext)).once();
+    verify(
+      baseMutatorFactory.forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
+    ).once();
   });
 });

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -1,3 +1,4 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
@@ -16,6 +17,7 @@ export default class AlwaysAllowPrivacyPolicyRule<
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: TEntity
   ): Promise<RuleEvaluationResult> {
     return RuleEvaluationResult.ALLOW;

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -1,3 +1,4 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
@@ -16,6 +17,7 @@ export default class AlwaysDenyPrivacyPolicyRule<
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: TEntity
   ): Promise<RuleEvaluationResult> {
     return RuleEvaluationResult.DENY;

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -1,3 +1,4 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
@@ -16,6 +17,7 @@ export default class AlwaysSkipPrivacyPolicyRule<
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: TEntity
   ): Promise<RuleEvaluationResult> {
     return RuleEvaluationResult.SKIP;

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -1,3 +1,4 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
@@ -45,6 +46,7 @@ export default abstract class PrivacyPolicyRule<
   abstract evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext,
     entity: TEntity
   ): Promise<RuleEvaluationResult>;
 }

--- a/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
@@ -1,5 +1,6 @@
 import { mock, instance, anything } from 'ts-mockito';
 
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/testing/PrivacyPolicyRuleTestUtils';
@@ -10,6 +11,7 @@ describePrivacyPolicyRule(new AlwaysAllowPrivacyPolicyRule(), {
     {
       viewerContext: instance(mock(ViewerContext)),
       queryContext: instance(mock(EntityQueryContext)),
+      evaluationContext: instance(mock<EntityPrivacyPolicyEvaluationContext>()),
       entity: anything(),
     },
   ],

--- a/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
@@ -1,5 +1,6 @@
 import { mock, instance, anything } from 'ts-mockito';
 
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/testing/PrivacyPolicyRuleTestUtils';
@@ -10,6 +11,7 @@ describePrivacyPolicyRule(new AlwaysDenyPrivacyPolicyRule(), {
     {
       viewerContext: instance(mock(ViewerContext)),
       queryContext: instance(mock(EntityQueryContext)),
+      evaluationContext: instance(mock<EntityPrivacyPolicyEvaluationContext>()),
       entity: anything(),
     },
   ],

--- a/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
@@ -1,5 +1,6 @@
 import { mock, instance, anything } from 'ts-mockito';
 
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/testing/PrivacyPolicyRuleTestUtils';
@@ -10,6 +11,7 @@ describePrivacyPolicyRule(new AlwaysSkipPrivacyPolicyRule(), {
     {
       viewerContext: instance(mock(ViewerContext)),
       queryContext: instance(mock(EntityQueryContext)),
+      evaluationContext: instance(mock<EntityPrivacyPolicyEvaluationContext>()),
       entity: anything(),
     },
   ],

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -1,3 +1,4 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ReadonlyEntity from '../../ReadonlyEntity';
 import ViewerContext from '../../ViewerContext';
@@ -12,6 +13,7 @@ export interface Case<
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
+  evaluationContext: EntityPrivacyPolicyEvaluationContext;
   entity: TEntity;
 }
 
@@ -48,9 +50,11 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (allowCases && allowCases.size > 0) {
       describe('allow cases', () => {
         test.each(Array.from(allowCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, entity } = await allowCases.get(caseKey)!();
+          const { viewerContext, queryContext, evaluationContext, entity } = await allowCases.get(
+            caseKey
+          )!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, entity)
+            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity)
           ).resolves.toEqual(RuleEvaluationResult.ALLOW);
         });
       });
@@ -59,9 +63,11 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (skipCases && skipCases.size > 0) {
       describe('skip cases', () => {
         test.each(Array.from(skipCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, entity } = await skipCases.get(caseKey)!();
+          const { viewerContext, queryContext, evaluationContext, entity } = await skipCases.get(
+            caseKey
+          )!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, entity)
+            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity)
           ).resolves.toEqual(RuleEvaluationResult.SKIP);
         });
       });
@@ -70,9 +76,11 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (denyCases && denyCases.size > 0) {
       describe('deny cases', () => {
         test.each(Array.from(denyCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, entity } = await denyCases.get(caseKey)!();
+          const { viewerContext, queryContext, evaluationContext, entity } = await denyCases.get(
+            caseKey
+          )!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, entity)
+            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity)
           ).resolves.toEqual(RuleEvaluationResult.DENY);
         });
       });


### PR DESCRIPTION
# Why

Just like cascading info was added into triggers in https://github.com/expo/entity/pull/145, this information may be useful when evaluating a privacy policy.

Concretely we have the following use case:
- User has permission to create an object owned by a parent object (user has permission on parent object, privacy policy of child object is derived from permission on parent object). On this object the user's ID is recorded for audit purposes with SET_NULL behavior on the column.
- User creates that object
- User's permission is revoked on parent object but child object is still there (since revoking permission doesn't mean that the data should no longer exist) and therefore still references user.
- User deletes their account, and therefore the SET_NULL deletion behavior is executed. Unfortunately, during this update the user no longer has permission to update the child object and the privacy policy evaluation fails.

# How

This PR adds another piece of information available to privacy policy evaluation, the cascadingDeleteCause. 

This will fix the situation above since we can now check if the update (to SET_NULL) is being executed via a cascade to delete a user, and if so allow in the privacy policy.

# Test Plan

Run all tests.
