### PR TITLE
[cache-adapter-local-memory] export classes

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -8,7 +8,7 @@ import {
 import GenericLocalMemoryCacher, { LocalMemoryCache } from './GenericLocalMemoryCacher';
 import LocalMemoryCacheAdapter from './LocalMemoryCacheAdapter';
 
-export class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvider {
+export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvider {
   // local memory cache adapters should be shared/reused across requests
   static localMemoryCacheAdapterMap = new Map<string, LocalMemoryCacheAdapter<any>>();
 

--- a/packages/entity-cache-adapter-local-memory/src/index.ts
+++ b/packages/entity-cache-adapter-local-memory/src/index.ts
@@ -1,0 +1,10 @@
+/* eslint-disable tsdoc/syntax */
+/**
+ * @packageDocumentation
+ * @module @expo/entity-cache-adapter-local-memory
+ */
+
+export { default as LocalMemoryCacheAdapter } from './LocalMemoryCacheAdapter';
+export { default as LocalMemoryCacheAdapterProvider } from './LocalMemoryCacheAdapterProvider';
+export { default as GenericLocalMemoryCacher } from './GenericLocalMemoryCacher';
+export * from './GenericLocalMemoryCacher';


### PR DESCRIPTION
# Why

Actually export classes for use in the package

