### PR TITLE
feat: composed cache adapter, composed secondary cache, local memory secondary cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@expo/entity-cache-adapter-redis": "file:packages/entity-cache-adapter-redis",
     "@expo/entity-database-adapter-knex": "file:packages/entity-database-adapter-knex",
     "@expo/entity-secondary-cache-redis": "file:packages/entity-secondary-cache-redis",
+    "@expo/entity-secondary-cache-local-memory": "file:packages/entity-secondary-cache-local-memory",
     "@expo/entity-ip-address-field": "file:packages/entity-ip-address-field"
   }
 }

--- a/packages/entity-cache-adapter-local-memory/README.md
+++ b/packages/entity-cache-adapter-local-memory/README.md
@@ -3,6 +3,8 @@
 Cross-request [LRU](https://github.com/isaacs/node-lru-cache) cache adapter for `@expo/entity`. Use
 this cache with caution - it is nonstandard. The cache is shared between requests in the node process.
 
+[Documentation](https://expo.github.io/entity/modules/_expo_cache_adapter_local_memory.html)
+
 ## Why NOT use this cache
 
 Because this is an in-memory cache, cross-box invalidation is not possible. Do not use this cache

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -8,7 +8,7 @@ import {
 import GenericLocalMemoryCacher, { LocalMemoryCache } from './GenericLocalMemoryCacher';
 import LocalMemoryCacheAdapter from './LocalMemoryCacheAdapter';
 
-export class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvider {
+export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvider {
   // local memory cache adapters should be shared/reused across requests
   static localMemoryCacheAdapterMap = new Map<string, LocalMemoryCacheAdapter<any>>();
 

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-full-test.ts
@@ -3,12 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import GenericLocalMemoryCacher from '../GenericLocalMemoryCacher';
 import LocalMemoryCacheAdapter from '../LocalMemoryCacheAdapter';
-import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
+import LocalMemoryCacheAdapterProvider from '../LocalMemoryCacheAdapterProvider';
 import LocalMemoryTestEntity from '../testfixtures/LocalMemoryTestEntity';
 import {
-  createLocalMemoryIntegrationTestEntityCompanionProvider,
+  createLocalMemoryTestEntityCompanionProvider,
   createNoopLocalMemoryIntegrationTestEntityCompanionProvider,
-} from '../testfixtures/createLocalMemoryIntegrationTestEntityCompanionProvider';
+} from '../testfixtures/createLocalMemoryTestEntityCompanionProvider';
 
 class TestViewerContext extends ViewerContext {}
 
@@ -18,9 +18,7 @@ describe(LocalMemoryCacheAdapter, () => {
   });
 
   it('has correct caching behavior', async () => {
-    const viewerContext = new TestViewerContext(
-      createLocalMemoryIntegrationTestEntityCompanionProvider()
-    );
+    const viewerContext = new TestViewerContext(createLocalMemoryTestEntityCompanionProvider());
     const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
       LocalMemoryTestEntity,
       LocalMemoryTestEntity.getCompanionDefinition()
@@ -90,9 +88,7 @@ describe(LocalMemoryCacheAdapter, () => {
       GenericLocalMemoryCacher.prototype as unknown as any,
       'loadManyAsync'
     );
-    const viewerContext = new TestViewerContext(
-      createLocalMemoryIntegrationTestEntityCompanionProvider()
-    );
+    const viewerContext = new TestViewerContext(createLocalMemoryTestEntityCompanionProvider());
 
     const date = new Date();
     const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
@@ -106,9 +102,7 @@ describe(LocalMemoryCacheAdapter, () => {
       .loadByIDAsync(entity1Created.getID());
 
     // load entity with a different request
-    const viewerContext2 = new TestViewerContext(
-      createLocalMemoryIntegrationTestEntityCompanionProvider()
-    );
+    const viewerContext2 = new TestViewerContext(createLocalMemoryTestEntityCompanionProvider());
     const entity1WithVc2 = await LocalMemoryTestEntity.loader(viewerContext2)
       .enforcing()
       .loadByIDAsync(entity1Created.getID());

--- a/packages/entity-cache-adapter-local-memory/src/index.ts
+++ b/packages/entity-cache-adapter-local-memory/src/index.ts
@@ -1,0 +1,10 @@
+/* eslint-disable tsdoc/syntax */
+/**
+ * @packageDocumentation
+ * @module @expo/entity-cache-adapter-local-memory
+ */
+
+export { default as GenericLocalMemoryCacher } from './GenericLocalMemoryCacher';
+export * from './GenericLocalMemoryCacher';
+export { default as LocalMemoryCacheAdapter } from './LocalMemoryCacheAdapter';
+export { default as LocalMemoryCacheAdapterProvider } from './LocalMemoryCacheAdapterProvider';

--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryTestEntityCompanionProvider.ts
@@ -6,9 +6,9 @@ import {
   StubDatabaseAdapterProvider,
 } from '@expo/entity';
 
-import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
+import LocalMemoryCacheAdapterProvider from '../LocalMemoryCacheAdapterProvider';
 
-export const createLocalMemoryIntegrationTestEntityCompanionProvider = (
+export const createLocalMemoryTestEntityCompanionProvider = (
   localMemoryOptions: { maxSize?: number; ttlSeconds?: number } = {},
   metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
 ): EntityCompanionProvider => {
@@ -41,7 +41,7 @@ export const createLocalMemoryIntegrationTestEntityCompanionProvider = (
 export const createNoopLocalMemoryIntegrationTestEntityCompanionProvider = (
   metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
 ): EntityCompanionProvider => {
-  return createLocalMemoryIntegrationTestEntityCompanionProvider(
+  return createLocalMemoryTestEntityCompanionProvider(
     { maxSize: 0, ttlSeconds: 0 },
     metricsAdapter
   );

--- a/packages/entity-secondary-cache-local-memory/CHANGELOG.md
+++ b/packages/entity-secondary-cache-local-memory/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+

--- a/packages/entity-secondary-cache-local-memory/README.md
+++ b/packages/entity-secondary-cache-local-memory/README.md
@@ -1,0 +1,24 @@
+# `@expo/entity-secondary-cache-local-memory`
+
+Cross-request [LRU](https://github.com/isaacs/node-lru-cache) secondary cache for `@expo/entity`. Use
+this cache with caution - it is nonstandard. The cache is shared between requests in the node process.
+
+[Documentation](https://expo.github.io/entity/modules/_expo_secondary_cache_local_memory.html)
+
+## Usage
+
+1. Create a concrete implementation of abstract class `EntitySecondaryCacheLoader`, in this example `TestEntitySecondaryCacheLoader`. The underlying data can come from anywhere, but an entity is constructed from the data and then authorized for the viewer.
+2. Create an instance of your `EntitySecondaryCacheLoader`, passing in a `LocalMemorySecondaryEntityCache`.
+    ```typescript
+    const secondaryCacheLoader = new TestSecondaryLocalMemoryCacheLoader(
+      new LocalMemorySecondaryEntityCache(
+        GenericLocalMemoryCacher.createLRUCache<LocalMemoryTestEntityFields>({})
+      ),
+      LocalMemoryTestEntity.loader(viewerContext)
+    );
+    ```
+3. Load entities through it:
+    ```typescript
+    const loadParams = { id: createdEntity.getID() };
+    const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    ```

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@expo/entity-secondary-cache-local-memory",
+  "version": "0.24.0",
+  "description": "Local memory secondary cache for @expo/entity",
+  "files": [
+    "build",
+    "src"
+  ],
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "tsc": "tsc",
+    "clean": "rm -rf build coverage coverage-integration",
+    "lint": "eslint src",
+    "lint-fix": "eslint src --fix",
+    "test": "jest --rootDir . --config ../../resources/jest.config.js --passWithNoTests",
+    "integration": "../../resources/run-with-docker yarn integration-no-setup",
+    "integration-no-setup": "jest --config ../../resources/jest-integration.config.js --rootDir . --runInBand --passWithNoTests",
+    "barrelsby": "barrelsby --directory src --location top --exclude tests__ --singleQuotes --exportDefault --delete"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "keywords": [
+    "entity"
+  ],
+  "author": "Expo",
+  "license": "MIT",
+  "peerDependencies": {
+    "@expo/entity": "*",
+    "@expo/entity-cache-adapter-local-memory": "*"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@expo/entity": "^0.24.0",
+    "@expo/entity-cache-adapter-local-memory": "^0.24.0",
+    "nullthrows": "^1.1.1"
+  }
+}

--- a/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
@@ -1,0 +1,17 @@
+import { GenericSecondaryEntityCache } from '@expo/entity';
+import {
+  GenericLocalMemoryCacher,
+  LocalMemoryCache,
+} from '@expo/entity-cache-adapter-local-memory';
+
+/**
+ * A local memory {@link GenericSecondaryEntityCache}.
+ */
+export default class LocalMemorySecondaryEntityCache<
+  TFields,
+  TLoadParams
+> extends GenericSecondaryEntityCache<TFields, TLoadParams> {
+  constructor(localMemoryCache: LocalMemoryCache<TFields>) {
+    super(new GenericLocalMemoryCacher(localMemoryCache), (params) => JSON.stringify(params));
+  }
+}

--- a/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
@@ -6,6 +6,10 @@ import {
 
 /**
  * A local memory {@link GenericSecondaryEntityCache}.
+ *
+ * @remarks
+ *
+ * TLoadParams must be JSON stringifyable.
  */
 export default class LocalMemorySecondaryEntityCache<
   TFields,

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -1,0 +1,228 @@
+import {
+  EntitySecondaryCacheLoader,
+  mapMapAsync,
+  ViewerContext,
+  NoOpEntityMetricsAdapter,
+  IEntityMetricsAdapter,
+  EntityCompanionProvider,
+  StubQueryContextProvider,
+  StubDatabaseAdapterProvider,
+  AlwaysAllowPrivacyPolicyRule,
+  EntityPrivacyPolicy,
+  UUIDField,
+  StringField,
+  EntityConfiguration,
+  EntityCompanionDefinition,
+  Entity,
+} from '@expo/entity';
+import {
+  GenericLocalMemoryCacher,
+  LocalMemoryCacheAdapterProvider,
+} from '@expo/entity-cache-adapter-local-memory';
+import nullthrows from 'nullthrows';
+
+import LocalMemorySecondaryEntityCache from '../LocalMemorySecondaryEntityCache';
+
+export type LocalMemoryTestEntityFields = {
+  id: string;
+  name: string;
+};
+
+export default class LocalMemoryTestEntity extends Entity<
+  LocalMemoryTestEntityFields,
+  string,
+  ViewerContext
+> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    LocalMemoryTestEntityFields,
+    string,
+    ViewerContext,
+    LocalMemoryTestEntity,
+    LocalMemoryTestEntityPrivacyPolicy
+  > {
+    return localMemoryTestEntityCompanionDefinition;
+  }
+}
+
+export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  LocalMemoryTestEntityFields,
+  string,
+  ViewerContext,
+  LocalMemoryTestEntity
+> {
+  protected override readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+  protected override readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+  protected override readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+  protected override readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      LocalMemoryTestEntityFields,
+      string,
+      ViewerContext,
+      LocalMemoryTestEntity
+    >(),
+  ];
+}
+
+export const localMemoryTestEntityConfiguration =
+  new EntityConfiguration<LocalMemoryTestEntityFields>({
+    idField: 'id',
+    tableName: 'local_memory_test_entities',
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+      }),
+      name: new StringField({
+        columnName: 'name',
+      }),
+    },
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'local-memory',
+  });
+
+const localMemoryTestEntityCompanionDefinition = new EntityCompanionDefinition({
+  entityClass: LocalMemoryTestEntity,
+  entityConfiguration: localMemoryTestEntityConfiguration,
+  privacyPolicyClass: LocalMemoryTestEntityPrivacyPolicy,
+});
+
+export const createTestEntityCompanionProvider = (
+  metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
+): EntityCompanionProvider => {
+  return new EntityCompanionProvider(
+    metricsAdapter,
+    new Map([
+      [
+        'postgres',
+        {
+          adapterProvider: new StubDatabaseAdapterProvider(),
+          queryContextProvider: StubQueryContextProvider,
+        },
+      ],
+    ]),
+    new Map([
+      [
+        'local-memory',
+        {
+          cacheAdapterProvider: LocalMemoryCacheAdapterProvider.getProvider(),
+        },
+      ],
+    ])
+  );
+};
+
+class TestViewerContext extends ViewerContext {}
+
+type TestLoadParams = { id: string };
+
+const FAKE_ID = 'fake';
+
+class TestSecondaryLocalMemoryCacheLoader extends EntitySecondaryCacheLoader<
+  TestLoadParams,
+  LocalMemoryTestEntityFields,
+  string,
+  TestViewerContext,
+  LocalMemoryTestEntity,
+  LocalMemoryTestEntityPrivacyPolicy
+> {
+  public databaseLoadCount = 0;
+
+  protected async fetchObjectsFromDatabaseAsync(
+    loadParamsArray: readonly Readonly<TestLoadParams>[]
+  ): Promise<ReadonlyMap<Readonly<TestLoadParams>, Readonly<LocalMemoryTestEntityFields> | null>> {
+    this.databaseLoadCount += loadParamsArray.length;
+
+    const emptyMap = new Map(loadParamsArray.map((p) => [p, null]));
+    return await mapMapAsync(emptyMap, async (_value, loadParams) => {
+      if (loadParams.id === FAKE_ID) {
+        return null;
+      }
+      return nullthrows(
+        (
+          await this.entityLoader
+            .enforcing()
+            .loadManyByFieldEqualityConjunctionAsync([
+              { fieldName: 'id', fieldValue: loadParams.id },
+            ])
+        )[0]
+      ).getAllFields();
+    });
+  }
+}
+
+describe(LocalMemorySecondaryEntityCache, () => {
+  it('Loads through secondary loader, caches, and invalidates', async () => {
+    const viewerContext = new TestViewerContext(createTestEntityCompanionProvider());
+
+    const createdEntity = await LocalMemoryTestEntity.creator(viewerContext)
+      .setField('name', 'wat')
+      .enforceCreateAsync();
+
+    const secondaryCacheLoader = new TestSecondaryLocalMemoryCacheLoader(
+      new LocalMemorySecondaryEntityCache(
+        GenericLocalMemoryCacher.createLRUCache<LocalMemoryTestEntityFields>({})
+      ),
+      LocalMemoryTestEntity.loader(viewerContext)
+    );
+
+    const loadParams = { id: createdEntity.getID() };
+    const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(nullthrows(results.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID()
+    );
+
+    expect(secondaryCacheLoader.databaseLoadCount).toEqual(1);
+
+    const results2 = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(nullthrows(results2.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID()
+    );
+
+    expect(secondaryCacheLoader.databaseLoadCount).toEqual(1);
+
+    await secondaryCacheLoader.invalidateManyAsync([loadParams]);
+
+    const results3 = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(nullthrows(results3.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID()
+    );
+
+    expect(secondaryCacheLoader.databaseLoadCount).toEqual(2);
+  });
+
+  it('correctly handles uncached and unfetchable load params', async () => {
+    const viewerContext = new TestViewerContext(createTestEntityCompanionProvider());
+
+    const secondaryCacheLoader = new TestSecondaryLocalMemoryCacheLoader(
+      new LocalMemorySecondaryEntityCache(
+        GenericLocalMemoryCacher.createLRUCache<LocalMemoryTestEntityFields>({})
+      ),
+      LocalMemoryTestEntity.loader(viewerContext)
+    );
+
+    const loadParams = { id: FAKE_ID };
+    const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(results.size).toBe(1);
+    expect(results.get(loadParams)).toBe(null);
+  });
+});

--- a/packages/entity-secondary-cache-local-memory/src/index.ts
+++ b/packages/entity-secondary-cache-local-memory/src/index.ts
@@ -1,0 +1,7 @@
+/* eslint-disable tsdoc/syntax */
+/**
+ * @packageDocumentation
+ * @module @expo/entity-secondary-cache-local-memory
+ */
+
+export { default as LocalMemorySecondaryEntityCache } from './LocalMemorySecondaryEntityCache';

--- a/packages/entity-secondary-cache-local-memory/tsconfig.json
+++ b/packages/entity-secondary-cache-local-memory/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+  },
+  "include": ["src"]
+}

--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -2,9 +2,7 @@ import { EntityConfiguration, GenericSecondaryEntityCache } from '@expo/entity';
 import { GenericRedisCacheContext, GenericRedisCacher } from '@expo/entity-cache-adapter-redis';
 
 /**
- * A custom secondary read-through entity cache is a way to add a custom second layer of caching for a particular
- * single entity load. One common way this may be used is to add a second layer of caching in a hot path that makes
- * a call to {@link EntityLoader.loadManyByFieldEqualityConjunctionAsync} is guaranteed to return at most one entity.
+ * A redis {@link GenericSecondaryEntityCache}.
  */
 export default class RedisSecondaryEntityCache<
   TFields,

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -1,0 +1,86 @@
+import nullthrows from 'nullthrows';
+
+import EntityCacheAdapter from './EntityCacheAdapter';
+import EntityConfiguration from './EntityConfiguration';
+import { CacheStatus, CacheLoadResult } from './internal/ReadThroughEntityCache';
+
+export default class ComposedEntityCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+  /**
+   * A {@link EntityCacheAdapter} that composes other {@link EntityCacheAdapter} instances.
+   *
+   * @param entityConfiguration - configuration for entity being loaded
+   * @param cacheAdapters - list of cache adapters to compose in order of precedence.
+   *                        Earlier cache adapters are read from first and written to (including invalidations) last.
+   *                        Typically, caches closer to the application should be ordered before caches closer to the database.
+   */
+  constructor(
+    entityConfiguration: EntityConfiguration<TFields>,
+    private readonly cacheAdapters: EntityCacheAdapter<TFields>[]
+  ) {
+    super(entityConfiguration);
+  }
+
+  public async loadManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
+    const retMap = new Map<NonNullable<TFields[N]>, CacheLoadResult<TFields>>();
+
+    let unfulfilledFieldValues = fieldValues;
+    for (const cacheAdapter of this.cacheAdapters) {
+      const cacheResultsFromAdapter = await cacheAdapter.loadManyAsync(
+        fieldName,
+        unfulfilledFieldValues
+      );
+
+      const newUnfulfilledFieldValues = [];
+      for (const [fieldValue, cacheResult] of cacheResultsFromAdapter) {
+        if (cacheResult.status === CacheStatus.MISS) {
+          newUnfulfilledFieldValues.push(fieldValue);
+        } else {
+          retMap.set(fieldValue, cacheResult);
+        }
+      }
+      unfulfilledFieldValues = newUnfulfilledFieldValues;
+    }
+
+    for (const fieldValue of unfulfilledFieldValues) {
+      retMap.set(fieldValue, { status: CacheStatus.MISS });
+    }
+
+    return retMap;
+  }
+
+  public async cacheManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>
+  ): Promise<void> {
+    // write to lower layers first
+    for (let i = this.cacheAdapters.length - 1; i >= 0; i--) {
+      const cacheAdapter = nullthrows(this.cacheAdapters[i]);
+      await cacheAdapter.cacheManyAsync(fieldName, objectMap);
+    }
+  }
+
+  public async cacheDBMissesAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    // write to lower layers first
+    for (let i = this.cacheAdapters.length - 1; i >= 0; i--) {
+      const cacheAdapter = nullthrows(this.cacheAdapters[i]);
+      await cacheAdapter.cacheDBMissesAsync(fieldName, fieldValues);
+    }
+  }
+
+  public async invalidateManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    // delete from lower layers first
+    for (let i = this.cacheAdapters.length - 1; i >= 0; i--) {
+      const cacheAdapter = nullthrows(this.cacheAdapters[i]);
+      await cacheAdapter.invalidateManyAsync(fieldName, fieldValues);
+    }
+  }
+}

--- a/packages/entity/src/ComposedSecondaryEntityCache.ts
+++ b/packages/entity/src/ComposedSecondaryEntityCache.ts
@@ -1,0 +1,63 @@
+import nullthrows from 'nullthrows';
+
+import { ISecondaryEntityCache } from './EntitySecondaryCacheLoader';
+
+export default class ComposedSecondaryEntityCache<TLoadParams, TFields>
+  implements ISecondaryEntityCache<TFields, TLoadParams>
+{
+  /**
+   * A {@link ISecondaryEntityCache} that composes other {@link ISecondaryEntityCache} instances.
+   *
+   * @param secondaryEntityCaches - list of caches to compose in order of precedence.
+   *                                Earlier caches are read from first and written to (including invalidations) last.
+   *                                Typically, caches closer to the application should be ordered before caches closer to the database.
+   */
+  constructor(
+    private readonly secondaryEntityCaches: ISecondaryEntityCache<TFields, TLoadParams>[]
+  ) {}
+
+  async loadManyThroughAsync(
+    loadParamsArray: readonly Readonly<TLoadParams>[],
+    fetcher: (
+      fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
+    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>>
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>> {
+    return await ComposedSecondaryEntityCache.loadManyThroughRecursivelyAsync(
+      this.secondaryEntityCaches,
+      loadParamsArray,
+      fetcher
+    );
+  }
+
+  private static async loadManyThroughRecursivelyAsync<TLoadParams, TFields>(
+    secondaryEntityCaches: ISecondaryEntityCache<TFields, TLoadParams>[],
+    loadParamsArray: readonly Readonly<TLoadParams>[],
+    fetcher: (
+      fetcherLoadParamsArray: readonly Readonly<TLoadParams>[]
+    ) => Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>>
+  ): Promise<ReadonlyMap<Readonly<TLoadParams>, Readonly<TFields> | null>> {
+    if (secondaryEntityCaches.length === 0) {
+      return await fetcher(loadParamsArray);
+    }
+
+    const [firstCache, ...restCaches] = secondaryEntityCaches;
+
+    return await nullthrows(firstCache).loadManyThroughAsync(
+      loadParamsArray,
+      (fetcherLoadParamsArray) =>
+        ComposedSecondaryEntityCache.loadManyThroughRecursivelyAsync(
+          restCaches,
+          fetcherLoadParamsArray,
+          fetcher
+        )
+    );
+  }
+
+  async invalidateManyAsync(loadParamsArray: readonly Readonly<TLoadParams>[]): Promise<void> {
+    // invalidate lower layers first
+    for (let i = this.secondaryEntityCaches.length - 1; i >= 0; i--) {
+      const secondaryEntityCache = nullthrows(this.secondaryEntityCaches[i]);
+      await secondaryEntityCache.invalidateManyAsync(loadParamsArray);
+    }
+  }
+}

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -1,0 +1,280 @@
+import invariant from 'invariant';
+
+import ComposedEntityCacheAdapter from '../ComposedEntityCacheAdapter';
+import EntityCacheAdapter from '../EntityCacheAdapter';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField } from '../EntityFields';
+import { CacheLoadResult, CacheStatus } from '../internal/ReadThroughEntityCache';
+
+type BlahFields = {
+  id: string;
+};
+
+const entityConfiguration = new EntityConfiguration<BlahFields>({
+  idField: 'id',
+  tableName: 'blah',
+  schema: {
+    id: new UUIDField({ columnName: 'id', cache: true }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'local-memory-and-redis',
+});
+
+export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
+type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
+
+class TestLocalCacheAdapter<TFields> extends EntityCacheAdapter<TFields> {
+  constructor(
+    entityConfiguration: EntityConfiguration<TFields>,
+    private readonly cache: Map<string, LocalMemoryCacheValue<TFields>>
+  ) {
+    super(entityConfiguration);
+  }
+
+  public async loadManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
+    const localMemoryCacheKeyToFieldValueMapping = new Map(
+      fieldValues.map((fieldValue) => [this.makeCacheKey(fieldName, fieldValue), fieldValue])
+    );
+    const cacheResults = new Map<NonNullable<TFields[N]>, CacheLoadResult<TFields>>();
+    for (const [cacheKey, fieldValue] of localMemoryCacheKeyToFieldValueMapping) {
+      const cacheResult = this.cache.get(cacheKey);
+      if (cacheResult === DOES_NOT_EXIST_LOCAL_MEMORY_CACHE) {
+        cacheResults.set(fieldValue, {
+          status: CacheStatus.NEGATIVE,
+        });
+      } else if (cacheResult) {
+        cacheResults.set(fieldValue, {
+          status: CacheStatus.HIT,
+          item: cacheResult,
+        });
+      } else {
+        cacheResults.set(fieldValue, {
+          status: CacheStatus.MISS,
+        });
+      }
+    }
+
+    return cacheResults;
+  }
+
+  public async cacheManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>
+  ): Promise<void> {
+    for (const [fieldValue, item] of objectMap) {
+      const cacheKey = this.makeCacheKey(fieldName, fieldValue);
+      this.cache.set(cacheKey, item);
+    }
+  }
+
+  public async cacheDBMissesAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    for (const fieldValue of fieldValues) {
+      const cacheKey = this.makeCacheKey(fieldName, fieldValue);
+      this.cache.set(cacheKey, DOES_NOT_EXIST_LOCAL_MEMORY_CACHE);
+    }
+  }
+
+  public async invalidateManyAsync<N extends keyof TFields>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[]
+  ): Promise<void> {
+    for (const fieldValue of fieldValues) {
+      const cacheKey = this.makeCacheKey(fieldName, fieldValue);
+      this.cache.delete(cacheKey);
+    }
+  }
+
+  private makeCacheKey<N extends keyof TFields>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>
+  ): string {
+    const columnName = this.entityConfiguration.entityToDBFieldsKeyMapping.get(fieldName);
+    invariant(columnName, `database field mapping missing for ${fieldName}`);
+    const parts = [
+      this.entityConfiguration.tableName,
+      `${this.entityConfiguration.cacheKeyVersion}`,
+      columnName,
+      String(fieldValue),
+    ];
+    const delimiter = ':';
+    const escapedParts = parts.map((part) =>
+      part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
+    );
+    return escapedParts.join(delimiter);
+  }
+}
+
+function makeTestCacheAdapters(): {
+  primaryCache: Map<string, LocalMemoryCacheValue<BlahFields>>;
+  primaryCacheAdapter: TestLocalCacheAdapter<BlahFields>;
+  fallbackCache: Map<string, LocalMemoryCacheValue<BlahFields>>;
+  fallbackCacheAdapter: TestLocalCacheAdapter<BlahFields>;
+  cacheAdapter: ComposedEntityCacheAdapter<BlahFields>;
+} {
+  const primaryCache = new Map();
+  const primaryCacheAdapter = new TestLocalCacheAdapter(entityConfiguration, primaryCache);
+
+  const fallbackCache = new Map();
+  const fallbackCacheAdapter = new TestLocalCacheAdapter(entityConfiguration, fallbackCache);
+
+  const cacheAdapter = new ComposedEntityCacheAdapter(entityConfiguration, [
+    primaryCacheAdapter,
+    fallbackCacheAdapter,
+  ]);
+
+  return {
+    primaryCache,
+    primaryCacheAdapter,
+    fallbackCache,
+    fallbackCacheAdapter,
+    cacheAdapter,
+  };
+}
+
+describe(ComposedEntityCacheAdapter, () => {
+  describe('loadManyAsync', () => {
+    it('returns primary results when populated', async () => {
+      const { primaryCacheAdapter, cacheAdapter } = makeTestCacheAdapters();
+
+      const cacheHits = new Map<string, Readonly<BlahFields>>([['test-id-1', { id: 'test-id-1' }]]);
+      await primaryCacheAdapter.cacheManyAsync('id', cacheHits);
+      await primaryCacheAdapter.cacheDBMissesAsync('id', ['test-id-2']);
+
+      const results = await cacheAdapter.loadManyAsync('id', [
+        'test-id-1',
+        'test-id-2',
+        'test-id-3',
+      ]);
+
+      expect(results.get('test-id-1')).toMatchObject({
+        status: CacheStatus.HIT,
+        item: { id: 'test-id-1' },
+      });
+      expect(results.get('test-id-2')).toMatchObject({ status: CacheStatus.NEGATIVE });
+      expect(results.get('test-id-3')).toMatchObject({ status: CacheStatus.MISS });
+      expect(results.size).toBe(3);
+    });
+
+    it('returns fallback adapter results primary is empty', async () => {
+      const { primaryCacheAdapter, cacheAdapter } = makeTestCacheAdapters();
+
+      const cacheHits = new Map<string, Readonly<BlahFields>>([['test-id-1', { id: 'test-id-1' }]]);
+      await primaryCacheAdapter.cacheManyAsync('id', cacheHits);
+      await primaryCacheAdapter.cacheDBMissesAsync('id', ['test-id-2']);
+
+      const results = await cacheAdapter.loadManyAsync('id', [
+        'test-id-1',
+        'test-id-2',
+        'test-id-3',
+      ]);
+
+      expect(results.get('test-id-1')).toMatchObject({
+        status: CacheStatus.HIT,
+        item: { id: 'test-id-1' },
+      });
+      expect(results.get('test-id-2')).toMatchObject({ status: CacheStatus.NEGATIVE });
+      expect(results.get('test-id-3')).toMatchObject({ status: CacheStatus.MISS });
+      expect(results.size).toBe(3);
+    });
+
+    it('returns empty map when passed empty array of fieldValues', async () => {
+      const { cacheAdapter } = makeTestCacheAdapters();
+      const results = await cacheAdapter.loadManyAsync('id', []);
+      expect(results).toEqual(new Map());
+    });
+
+    it('handles 0 cache adapter compose case', async () => {
+      const cacheAdapter = new ComposedEntityCacheAdapter(entityConfiguration, []);
+      const results = await cacheAdapter.loadManyAsync('id', []);
+      expect(results).toEqual(new Map());
+    });
+  });
+
+  describe('cacheManyAsync', () => {
+    it('correctly caches all objects', async () => {
+      const {
+        primaryCache,
+        primaryCacheAdapter,
+        fallbackCache,
+        fallbackCacheAdapter,
+        cacheAdapter,
+      } = makeTestCacheAdapters();
+
+      await cacheAdapter.cacheManyAsync('id', new Map([['test-id-1', { id: 'test-id-1' }]]));
+
+      const primaryLocalMemoryCacheKey = primaryCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(primaryCache.get(primaryLocalMemoryCacheKey)).toMatchObject({
+        id: 'test-id-1',
+      });
+
+      const fallbackLocalMemoryCacheKey = fallbackCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(fallbackCache.get(fallbackLocalMemoryCacheKey)).toMatchObject({
+        id: 'test-id-1',
+      });
+    });
+  });
+
+  describe('cacheDBMissesAsync', () => {
+    it('correctly caches misses', async () => {
+      const {
+        primaryCache,
+        primaryCacheAdapter,
+        fallbackCache,
+        fallbackCacheAdapter,
+        cacheAdapter,
+      } = makeTestCacheAdapters();
+
+      await cacheAdapter.cacheDBMissesAsync('id', ['test-id-1']);
+
+      const primaryLocalMemoryCacheKey = primaryCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(primaryCache.get(primaryLocalMemoryCacheKey)).toBe(DOES_NOT_EXIST_LOCAL_MEMORY_CACHE);
+
+      const fallbackLocalMemoryCacheKey = fallbackCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(fallbackCache.get(fallbackLocalMemoryCacheKey)).toBe(
+        DOES_NOT_EXIST_LOCAL_MEMORY_CACHE
+      );
+    });
+  });
+
+  describe('invalidateManyAsync', () => {
+    it('invalidates correctly', async () => {
+      const {
+        primaryCache,
+        primaryCacheAdapter,
+        fallbackCache,
+        fallbackCacheAdapter,
+        cacheAdapter,
+      } = makeTestCacheAdapters();
+
+      const cacheHits = new Map<string, Readonly<BlahFields>>([['test-id-1', { id: 'test-id-1' }]]);
+      await primaryCacheAdapter.cacheManyAsync('id', cacheHits);
+      await primaryCacheAdapter.cacheDBMissesAsync('id', ['test-id-2']);
+      await fallbackCacheAdapter.cacheManyAsync('id', cacheHits);
+      await fallbackCacheAdapter.cacheDBMissesAsync('id', ['test-id-2']);
+
+      await cacheAdapter.invalidateManyAsync('id', ['test-id-1', 'test-id-2']);
+
+      const primaryLocalMemoryCacheKey1 = primaryCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(primaryCache.get(primaryLocalMemoryCacheKey1)).toBe(undefined);
+      const primaryLocalMemoryCacheKey2 = primaryCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(primaryCache.get(primaryLocalMemoryCacheKey2)).toBe(undefined);
+
+      const fallbackLocalMemoryCacheKey1 = fallbackCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(fallbackCache.get(fallbackLocalMemoryCacheKey1)).toBe(undefined);
+      const fallbackLocalMemoryCacheKey2 = fallbackCacheAdapter['makeCacheKey']('id', 'test-id-1');
+      expect(fallbackCache.get(fallbackLocalMemoryCacheKey2)).toBe(undefined);
+    });
+
+    it('returns when passed empty array of fieldValues', async () => {
+      const { cacheAdapter } = makeTestCacheAdapters();
+
+      await cacheAdapter.invalidateManyAsync('id', []);
+    });
+  });
+});

--- a/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
@@ -1,0 +1,101 @@
+import invariant from 'invariant';
+import nullthrows from 'nullthrows';
+
+import ComposedSecondaryEntityCache from '../ComposedSecondaryEntityCache';
+import { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader';
+
+type TestFields = { id: string };
+type TestLoadParams = { lp: string };
+
+class TestEntitySecondaryCache implements ISecondaryEntityCache<TestFields, TestLoadParams> {
+  constructor(
+    private readonly prefilledResults: Map<Readonly<TestLoadParams>, Readonly<TestFields>>
+  ) {}
+
+  async loadManyThroughAsync(
+    loadParamsArray: readonly Readonly<TestLoadParams>[],
+    fetcher: (
+      fetcherLoadParamsArray: readonly Readonly<TestLoadParams>[]
+    ) => Promise<ReadonlyMap<Readonly<TestLoadParams>, Readonly<TestFields> | null>>
+  ): Promise<ReadonlyMap<Readonly<TestLoadParams>, Readonly<TestFields> | null>> {
+    // this does an unusual method of calling fetcher, but there's no constraint that says fetcher can only be called once
+    // so this tests that
+
+    const retMap = new Map<Readonly<TestLoadParams>, Readonly<TestFields> | null>();
+    for (const loadParams of loadParamsArray) {
+      if (this.prefilledResults.has(loadParams)) {
+        retMap.set(loadParams, nullthrows(this.prefilledResults.get(loadParams)));
+      } else {
+        const fetcherResult = await fetcher([loadParams]);
+        const toSet = fetcherResult.get(loadParams);
+        invariant(toSet !== undefined, 'should be set');
+        retMap.set(loadParams, toSet);
+      }
+    }
+    return retMap;
+  }
+
+  async invalidateManyAsync(loadParamsArray: readonly Readonly<TestLoadParams>[]): Promise<void> {
+    for (const loadParams of loadParamsArray) {
+      this.prefilledResults.delete(loadParams);
+    }
+  }
+}
+
+describe(ComposedSecondaryEntityCache, () => {
+  it('composes correctly', async () => {
+    // TODO(wschurman): investigate whether we can use immutable or something to do better object equality for the map keys
+    const lp1 = { lp: '1' };
+    const lp2 = { lp: '2' };
+    const lp3 = { lp: '3' };
+
+    const primarySecondaryEntityCache = new TestEntitySecondaryCache(
+      new Map([[lp1, { id: 'primary-1' }]])
+    );
+    const fallbackSecondaryEntityCache = new TestEntitySecondaryCache(
+      new Map([[lp2, { id: 'fallback-2' }]])
+    );
+
+    const composedSecondaryEntityCache = new ComposedSecondaryEntityCache([
+      primarySecondaryEntityCache,
+      fallbackSecondaryEntityCache,
+    ]);
+
+    const results = await composedSecondaryEntityCache.loadManyThroughAsync(
+      [lp1, lp2, lp3],
+      async (fetcherLoadParamsArray) =>
+        new Map(fetcherLoadParamsArray.map((flp) => [flp, { id: `db-fetched-${flp.lp}` }]))
+    );
+
+    expect(results.get(lp1)).toEqual({ id: 'primary-1' });
+    expect(results.get(lp2)).toEqual({ id: 'fallback-2' });
+    expect(results.get(lp3)).toEqual({ id: 'db-fetched-3' });
+
+    await composedSecondaryEntityCache.invalidateManyAsync([lp1, lp2, lp3]);
+
+    const resultsAfterInvalidate = await composedSecondaryEntityCache.loadManyThroughAsync(
+      [lp1, lp2, lp3],
+      async (fetcherLoadParamsArray) =>
+        new Map(fetcherLoadParamsArray.map((flp) => [flp, { id: `db-fetched-${flp.lp}` }]))
+    );
+
+    expect(resultsAfterInvalidate.get(lp1)).toEqual({ id: 'db-fetched-1' });
+    expect(resultsAfterInvalidate.get(lp2)).toEqual({ id: 'db-fetched-2' });
+    expect(resultsAfterInvalidate.get(lp3)).toEqual({ id: 'db-fetched-3' });
+  });
+
+  it('handles n=0 compose case', async () => {
+    const lp1 = { lp: '1' };
+    const composedSecondaryEntityCache = new ComposedSecondaryEntityCache<
+      TestLoadParams,
+      TestFields
+    >([]);
+    const results = await composedSecondaryEntityCache.loadManyThroughAsync(
+      [lp1],
+      async (fetcherLoadParamsArray) =>
+        new Map(fetcherLoadParamsArray.map((flp) => [flp, { id: `db-fetched-${flp.lp}` }]))
+    );
+
+    expect(results.get(lp1)).toEqual({ id: 'db-fetched-1' });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,32 +508,37 @@
     minimist "^1.2.0"
 
 "@expo/entity-cache-adapter-local-memory@file:packages/entity-cache-adapter-local-memory":
-  version "0.23.0"
+  version "0.24.0"
   dependencies:
     lru-cache "^7.3.1"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.23.0"
+  version "0.24.0"
   dependencies:
     ioredis "^4.27.3"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.23.0"
+  version "0.24.0"
   dependencies:
     knex "^1.0.2"
 
 "@expo/entity-ip-address-field@file:packages/entity-ip-address-field":
-  version "0.23.0"
+  version "0.24.0"
   dependencies:
     ip-address "^8.1.0"
 
+"@expo/entity-secondary-cache-local-memory@file:packages/entity-secondary-cache-local-memory":
+  version "0.24.0"
+  dependencies:
+    ioredis "^4.17.3"
+
 "@expo/entity-secondary-cache-redis@file:packages/entity-secondary-cache-redis":
-  version "0.23.0"
+  version "0.24.0"
   dependencies:
     ioredis "^4.17.3"
 
 "@expo/entity@file:packages/entity":
-  version "0.23.0"
+  version "0.24.0"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"


### PR DESCRIPTION
# Why

This PR imports some features from Expo's internal testing ground:
- ComposedCacheAdapter - a cache adapter that composes other cache adapters
- ComposedSecondaryCache - a secondary cache that composes other secondary caches
- LocalMemorySecondaryCache - a LRUCache secondary cache (uses local memory stuff from https://github.com/expo/entity/pull/158)

# How

Add features and tests.

# Test Plan

Wait for CI.