### PR TITLE
fix: lru-cache yarn workspace version resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "devDependencies": {
     "@expo/entity": "file:packages/entity",
     "@expo/results": "^1.0.0",
-    "@types/lru-cache": "^5.1.1",
     "@types/invariant": "^2.2.33",
     "@types/ioredis": "^4.26.4",
     "@types/jest": "^26.0.10",
     "@types/jsbn": "^1.2.29",
+    "@types/lru-cache": "^7.4.0",
     "@types/node": "^14.6.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
@@ -33,6 +33,7 @@
     "eslint-plugin-tsdoc": "^0.2.11",
     "jest": "^26.6.3",
     "lerna": "^4.0.0",
+    "lru-cache": "^7.3.1",
     "nullthrows": "^1.1.1",
     "pg": "^8.6.0",
     "prettier": "^2.3.2",
@@ -47,8 +48,8 @@
     "@expo/entity-cache-adapter-local-memory": "file:packages/entity-cache-adapter-local-memory",
     "@expo/entity-cache-adapter-redis": "file:packages/entity-cache-adapter-redis",
     "@expo/entity-database-adapter-knex": "file:packages/entity-database-adapter-knex",
-    "@expo/entity-secondary-cache-redis": "file:packages/entity-secondary-cache-redis",
+    "@expo/entity-ip-address-field": "file:packages/entity-ip-address-field",
     "@expo/entity-secondary-cache-local-memory": "file:packages/entity-secondary-cache-local-memory",
-    "@expo/entity-ip-address-field": "file:packages/entity-ip-address-field"
+    "@expo/entity-secondary-cache-redis": "file:packages/entity-secondary-cache-redis"
   }
 }

--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -88,6 +88,7 @@ export default class GenericLocalMemoryCacher<TFields> implements IEntityGeneric
     const maxAgeSeconds = options.ttlSeconds ?? DEFAULT_LRU_CACHE_MAX_AGE_SECONDS;
     const lruCacheOptions: LRUCacheOptionsV7<string, TFields> = {
       max: options.maxSize ?? DEFAULT_LRU_CACHE_SIZE,
+      maxSize: options.maxSize ?? DEFAULT_LRU_CACHE_SIZE,
       sizeCalculation: (value: LocalMemoryCacheValue<TFields>) =>
         value === DOES_NOT_EXIST_LOCAL_MEMORY_CACHE ? 0 : 1,
       ttl: maxAgeSeconds * 1000, // convert to ms
@@ -97,8 +98,9 @@ export default class GenericLocalMemoryCacher<TFields> implements IEntityGeneric
 
   static createNoOpCache<TFields>(): LocalMemoryCache<TFields> {
     return new LRUCache<string, LocalMemoryCacheValue<TFields>>({
-      max: 0,
-      maxAge: -1,
+      max: 1,
+      maxSize: 1,
+      sizeCalculation: () => 10, // make all things larger than max size
     });
   }
 
@@ -140,7 +142,7 @@ export default class GenericLocalMemoryCacher<TFields> implements IEntityGeneric
 
   public async invalidateManyAsync(keys: readonly string[]): Promise<void> {
     for (const key of keys) {
-      this.localMemoryCache.del(key);
+      this.localMemoryCache.delete(key);
     }
   }
 

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
@@ -1,0 +1,30 @@
+import GenericLocalMemoryCacher from '../GenericLocalMemoryCacher';
+
+describe(GenericLocalMemoryCacher, () => {
+  describe(GenericLocalMemoryCacher.createLRUCache, () => {
+    it('creates a cache with default options', () => {
+      const cache = GenericLocalMemoryCacher.createLRUCache();
+      expect(cache.max).toBe(10000);
+      expect(cache.maxSize).toBe(10000);
+      expect(cache.ttl).toBe(10000);
+    });
+
+    it('respects specified options', () => {
+      const cache = GenericLocalMemoryCacher.createLRUCache({
+        ttlSeconds: 3,
+        maxSize: 10,
+      });
+      expect(cache.max).toBe(10);
+      expect(cache.maxSize).toBe(10);
+      expect(cache.ttl).toBe(3000);
+    });
+  });
+
+  describe(GenericLocalMemoryCacher.createNoOpCache, () => {
+    it('creates a no-op cache', () => {
+      const cache = GenericLocalMemoryCacher.createNoOpCache<{ hello: 'world' }>();
+      cache.set('a', { hello: 'world' });
+      expect(cache.get('a')).toBeUndefined();
+    });
+  });
+});

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-test.ts
@@ -24,10 +24,7 @@ describe(LocalMemoryCacheAdapter, () => {
     it('returns appropriate cache results', async () => {
       const cacheAdapter = new LocalMemoryCacheAdapter(
         entityConfiguration,
-        GenericLocalMemoryCacher.createLRUCache({
-          maxSize: Number.MAX_SAFE_INTEGER,
-          ttlSeconds: Number.MAX_SAFE_INTEGER,
-        })
+        GenericLocalMemoryCacher.createLRUCache()
       );
 
       const cacheHits = new Map<string, Readonly<BlahFields>>([['test-id-1', { id: 'test-id-1' }]]);
@@ -52,10 +49,7 @@ describe(LocalMemoryCacheAdapter, () => {
     it('returns empty map when passed empty array of fieldValues', async () => {
       const cacheAdapter = new LocalMemoryCacheAdapter(
         entityConfiguration,
-        GenericLocalMemoryCacher.createLRUCache({
-          maxSize: Number.MAX_SAFE_INTEGER,
-          ttlSeconds: Number.MAX_SAFE_INTEGER,
-        })
+        GenericLocalMemoryCacher.createLRUCache()
       );
       const results = await cacheAdapter.loadManyAsync('id', []);
       expect(results).toEqual(new Map());
@@ -64,10 +58,7 @@ describe(LocalMemoryCacheAdapter, () => {
 
   describe('cacheManyAsync', () => {
     it('correctly caches all objects', async () => {
-      const localMemoryCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({
-        maxSize: Number.MAX_SAFE_INTEGER,
-        ttlSeconds: Number.MAX_SAFE_INTEGER,
-      });
+      const localMemoryCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({});
 
       const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, localMemoryCache);
       await cacheAdapter.cacheManyAsync('id', new Map([['test-id-1', { id: 'test-id-1' }]]));
@@ -81,10 +72,7 @@ describe(LocalMemoryCacheAdapter, () => {
 
   describe('cacheDBMissesAsync', () => {
     it('correctly caches misses', async () => {
-      const localMemoryCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({
-        maxSize: Number.MAX_SAFE_INTEGER,
-        ttlSeconds: Number.MAX_SAFE_INTEGER,
-      });
+      const localMemoryCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({});
 
       const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, localMemoryCache);
       await cacheAdapter.cacheDBMissesAsync('id', ['test-id-1']);
@@ -96,10 +84,7 @@ describe(LocalMemoryCacheAdapter, () => {
 
   describe('invalidateManyAsync', () => {
     it('invalidates correctly', async () => {
-      const localMemoryCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({
-        maxSize: Number.MAX_SAFE_INTEGER,
-        ttlSeconds: Number.MAX_SAFE_INTEGER,
-      });
+      const localMemoryCache = GenericLocalMemoryCacher.createLRUCache<BlahFields>({});
 
       const cacheAdapter = new LocalMemoryCacheAdapter(entityConfiguration, localMemoryCache);
       await cacheAdapter.cacheManyAsync('id', new Map([['test-id-1', { id: 'test-id-1' }]]));
@@ -114,10 +99,7 @@ describe(LocalMemoryCacheAdapter, () => {
     it('returns when passed empty array of fieldValues', async () => {
       const cacheAdapter = new LocalMemoryCacheAdapter(
         entityConfiguration,
-        GenericLocalMemoryCacher.createLRUCache<BlahFields>({
-          maxSize: Number.MAX_SAFE_INTEGER,
-          ttlSeconds: Number.MAX_SAFE_INTEGER,
-        })
+        GenericLocalMemoryCacher.createLRUCache<BlahFields>({})
       );
       await cacheAdapter.invalidateManyAsync('id', []);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,37 +508,35 @@
     minimist "^1.2.0"
 
 "@expo/entity-cache-adapter-local-memory@file:packages/entity-cache-adapter-local-memory":
-  version "0.24.0"
+  version "0.25.1"
   dependencies:
     lru-cache "^7.3.1"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.24.0"
+  version "0.25.1"
   dependencies:
     ioredis "^4.27.3"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.24.0"
+  version "0.25.1"
   dependencies:
     knex "^1.0.2"
 
 "@expo/entity-ip-address-field@file:packages/entity-ip-address-field":
-  version "0.24.0"
+  version "0.25.1"
   dependencies:
     ip-address "^8.1.0"
 
 "@expo/entity-secondary-cache-local-memory@file:packages/entity-secondary-cache-local-memory":
-  version "0.24.0"
-  dependencies:
-    ioredis "^4.17.3"
+  version "0.25.1"
 
 "@expo/entity-secondary-cache-redis@file:packages/entity-secondary-cache-redis":
-  version "0.24.0"
+  version "0.25.1"
   dependencies:
     ioredis "^4.17.3"
 
 "@expo/entity@file:packages/entity":
-  version "0.24.0"
+  version "0.25.1"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"
@@ -2005,10 +2003,10 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
-"@types/lru-cache@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
-  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
+"@types/lru-cache@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-7.4.0.tgz#74e50606962cb90448d928d6f0c7c872592fc84d"
+  integrity sha512-jZ/Tb2/3vXw4VYd9AImFC/n6XT3WywZNAxwY8Ox9eM87M9ta9G7KzCx4aKo2Zllvr02k40eY328cjOO3WuK5Kw==
 
 "@types/mime@*":
   version "2.0.1"
@@ -6581,9 +6579,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 lru-cache@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.3.1.tgz#7702e80694ec2bf19865567a469f2b081fcf53f5"
-  integrity sha512-nX1x4qUrKqwbIAhv4s9et4FIUVzNOpeY07bsjGUy8gwJrXH/wScImSQqXErmo/b2jZY2r0mohbLA9zVj7u1cNw==
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.4.4.tgz#a3dabc394ec07e2285af52fd24d0d74b3ac71c29"
+  integrity sha512-2XbUJmlpIbmc9JvNNmtLzHlF31srxoDxuiQiwBHic7RZyHyltbTdzoO6maRqpdEhOOG5GD80EXvzAU0wR15ccg==
 
 lunr@^2.3.9:
   version "2.3.9"


### PR DESCRIPTION
# Why

`lru-cache` was resolving to 6.0.0 in the workspace root, which is what the sub-package cache-adapter-local-memory was using even though it required 7.x. I'm not sure why workspaces behaves this way, but the only way I could figure out how to fix it was to require 7.x in the root package.json.

I also looked into `nohoist` but it didn't seem to work as I would have expected: https://classic.yarnpkg.com/blog/2018/02/15/nohoist/.

# How

Update base package.json.

# Test Plan

Run all tests with new version, see it was failing until new argument formats were included.
