### PR TITLE
chore: clean up metrics API a bit and add docblocks

### DIFF
--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -19,9 +19,24 @@ export type EntityPrivacyPolicyEvaluationContext = {
   cascadingDeleteCause: EntityCascadingDeletionInfo | null;
 };
 
+/**
+ * Evaluation mode for a {@link EntityPrivacyPolicy}. Useful when transitioning to
+ * using Entity for privacy.
+ */
 export enum EntityPrivacyPolicyEvaluationMode {
+  /**
+   * Enforce this privacy policy. Throw upon denial.
+   */
   ENFORCE,
+
+  /**
+   * Do not enforce this privacy policy. Always allow but log when it would have denied.
+   */
   DRY_RUN,
+
+  /**
+   * Enforce this privacy policy. Throw and log upon denial.
+   */
   ENFORCE_AND_LOG,
 }
 

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -11,7 +11,10 @@ import {
   timeAndLogLoadEventAsync,
   timeAndLogLoadMapEventAsync,
 } from '../metrics/EntityMetricsUtils';
-import IEntityMetricsAdapter, { EntityMetricsLoadType } from '../metrics/IEntityMetricsAdapter';
+import IEntityMetricsAdapter, {
+  EntityMetricsLoadType,
+  IncrementLoadCountEventType,
+} from '../metrics/IEntityMetricsAdapter';
 import { computeIfAbsent, zipToMap } from '../utils/collections/maps';
 import ReadThroughEntityCache from './ReadThroughEntityCache';
 
@@ -57,7 +60,8 @@ export default class EntityDataManager<TFields> {
     fieldName: N,
     fieldValues: readonly NonNullable<TFields[N]>[]
   ): Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly Readonly<TFields>[]>> {
-    this.metricsAdapter.incrementDataManagerCacheLoadCount({
+    this.metricsAdapter.incrementDataManagerLoadCount({
+      type: IncrementLoadCountEventType.CACHE,
       fieldValueCount: fieldValues.length,
       entityClassName: this.entityClassName,
     });
@@ -65,7 +69,8 @@ export default class EntityDataManager<TFields> {
       fieldName,
       fieldValues,
       async (fetcherValues) => {
-        this.metricsAdapter.incrementDataManagerDatabaseLoadCount({
+        this.metricsAdapter.incrementDataManagerLoadCount({
+          type: IncrementLoadCountEventType.DATABASE,
           fieldValueCount: fieldValues.length,
           entityClassName: this.entityClassName,
         });
@@ -117,7 +122,8 @@ export default class EntityDataManager<TFields> {
       return await this.databaseAdapter.fetchManyWhereAsync(queryContext, fieldName, fieldValues);
     }
 
-    this.metricsAdapter.incrementDataManagerDataloaderLoadCount({
+    this.metricsAdapter.incrementDataManagerLoadCount({
+      type: IncrementLoadCountEventType.DATALOADER,
       fieldValueCount: fieldValues.length,
       entityClassName: this.entityClassName,
     });

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -4,7 +4,6 @@ import {
   when,
   anything,
   verify,
-  anyNumber,
   objectContaining,
   spy,
   anyString,
@@ -13,7 +12,10 @@ import {
 } from 'ts-mockito';
 
 import EntityDatabaseAdapter from '../../EntityDatabaseAdapter';
-import IEntityMetricsAdapter, { EntityMetricsLoadType } from '../../metrics/IEntityMetricsAdapter';
+import IEntityMetricsAdapter, {
+  EntityMetricsLoadType,
+  IncrementLoadCountEventType,
+} from '../../metrics/IEntityMetricsAdapter';
 import NoOpEntityMetricsAdapter from '../../metrics/NoOpEntityMetricsAdapter';
 import TestEntity, { testEntityConfiguration, TestFields } from '../../testfixtures/TestEntity';
 import {
@@ -519,24 +521,27 @@ describe(EntityDataManager, () => {
     ).once();
 
     verify(
-      metricsAdapterMock.incrementDataManagerDataloaderLoadCount(
+      metricsAdapterMock.incrementDataManagerLoadCount(
         deepEqual({
+          type: IncrementLoadCountEventType.DATALOADER,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
         })
       )
     ).once();
     verify(
-      metricsAdapterMock.incrementDataManagerCacheLoadCount(
+      metricsAdapterMock.incrementDataManagerLoadCount(
         deepEqual({
+          type: IncrementLoadCountEventType.CACHE,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
         })
       )
     ).once();
     verify(
-      metricsAdapterMock.incrementDataManagerDatabaseLoadCount(
+      metricsAdapterMock.incrementDataManagerLoadCount(
         deepEqual({
+          type: IncrementLoadCountEventType.DATABASE,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
         })
@@ -565,9 +570,7 @@ describe(EntityDataManager, () => {
       )
     ).once();
 
-    verify(metricsAdapterMock.incrementDataManagerDataloaderLoadCount(anyNumber())).never();
-    verify(metricsAdapterMock.incrementDataManagerCacheLoadCount(anyNumber())).never();
-    verify(metricsAdapterMock.incrementDataManagerDatabaseLoadCount(anyNumber())).never();
+    verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).never();
   });
 
   it('throws when a load-by value is null or undefined', async () => {

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -70,7 +70,7 @@ export enum IncrementLoadCountEventType {
   CACHE,
 
   /**
-   * Type for when a database load is initiated due to a dataloader and cache miss.
+   * Type for when a database load is initiated due to a dataloader and cache miss, when an entity query doesn't support caching, or during a transaction.
    */
   DATABASE,
 }

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -9,10 +9,28 @@ export enum EntityMetricsLoadType {
   LOAD_MANY_RAW,
 }
 
+/**
+ * Event about a single call to an {@link EntityLoader} method.
+ */
 export interface EntityMetricsLoadEvent {
+  /**
+   * {@link EntityMetricsLoadType} for this load.
+   */
   type: EntityMetricsLoadType;
+
+  /**
+   * Class name of the {@link Entity} being loaded.
+   */
   entityClassName: string;
+
+  /**
+   * Total duration of this load, including fetch and construction of entities.
+   */
   duration: number;
+
+  /**
+   * Number of entities returned for this load.
+   */
   count: number;
 }
 
@@ -23,13 +41,57 @@ export enum EntityMetricsMutationType {
 }
 
 export interface EntityMetricsMutationEvent {
+  /**
+   * {@link EntityMetricsMutationType} for this mutation.
+   */
   type: EntityMetricsMutationType;
+
+  /**
+   * Class name of the {@link Entity} being mutated.
+   */
   entityClassName: string;
+
+  /**
+   * Total duration of this mutation.
+   */
   duration: number;
 }
 
+export enum IncrementLoadCountEventType {
+  /**
+   * Type for when a dataloader load is initiated via the standard load methods
+   * since all loads go through a dataloader.
+   */
+  DATALOADER,
+
+  /**
+   * Type for when a cache load is initiated due to a dataloader miss.
+   */
+  CACHE,
+
+  /**
+   * Type for when a database load is initiated due to a dataloader and cache miss.
+   */
+  DATABASE,
+}
+
+/**
+ * Event used to record dataloader, cache, and database load counts in {@link EntityDataManager}.
+ */
 export interface IncrementLoadCountEvent {
+  /**
+   * Type of this event.
+   */
+  type: IncrementLoadCountEventType;
+
+  /**
+   * Number of field values being loaded for this call.
+   */
   fieldValueCount: number;
+
+  /**
+   * Class name of the {@link Entity} being loaded.
+   */
   entityClassName: string;
 }
 
@@ -38,7 +100,13 @@ export enum EntityMetricsAuthorizationResult {
   ALLOW,
 }
 
+/**
+ * Event used to record a singe {@link EntityPrivacyPolicy} authorization.
+ */
 export interface EntityMetricsAuthorizationEvent {
+  /**
+   * Class name of the {@link Entity} being authorized.
+   */
   entityClassName: string;
   action: EntityAuthorizationAction;
   evaluationResult: EntityMetricsAuthorizationResult;
@@ -69,25 +137,10 @@ export default interface IEntityMetricsAdapter {
   logMutatorMutationEvent(mutationEvent: EntityMetricsMutationEvent): void;
 
   /**
-   * Called when a dataloader load is initiated via the standard
-   * load methods (not equality conjunction or raw).
+   * Called when a dataloader, cache, or database load is initiated via the standard
+   * load methods (not equality conjunction or raw). Most commonly used for logging
+   * a waterfall to determine dataloader and cache hit rates and ratios.
    * @param fieldValueCount - count of field values being loaded for a field
    */
-  incrementDataManagerDataloaderLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
-
-  /**
-   * Called when a cache load is initiated via the standard
-   * load methods (not equality conjunction or raw). Occurs upon a dataloader
-   * miss.
-   * @param fieldValueCount - count of field values being loaded for a field
-   */
-  incrementDataManagerCacheLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
-
-  /**
-   * Called when a database load is initiated via the standard
-   * load methods (not equality conjunction or raw). Occurs upon a cache
-   * miss or when fetching an uncacheable field.
-   * @param fieldValueCount - count of field values being loaded for a field
-   */
-  incrementDataManagerDatabaseLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
+  incrementDataManagerLoadCount(incrementLoadCountEvent: IncrementLoadCountEvent): void;
 }

--- a/packages/entity/src/metrics/NoOpEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/NoOpEntityMetricsAdapter.ts
@@ -9,9 +9,5 @@ export default class NoOpEntityMetricsAdapter implements IEntityMetricsAdapter {
   logAuthorizationEvent(_authorizationEvent: EntityMetricsAuthorizationEvent): void {}
   logDataManagerLoadEvent(_loadEvent: EntityMetricsLoadEvent): void {}
   logMutatorMutationEvent(_mutationEvent: EntityMetricsMutationEvent): void {}
-  incrementDataManagerDataloaderLoadCount(
-    _incrementLoadCountEvent: IncrementLoadCountEvent
-  ): void {}
-  incrementDataManagerCacheLoadCount(_incrementLoadCountEvent: IncrementLoadCountEvent): void {}
-  incrementDataManagerDatabaseLoadCount(_incrementLoadCountEvent: IncrementLoadCountEvent): void {}
+  incrementDataManagerLoadCount(_incrementLoadCountEvent: IncrementLoadCountEvent): void {}
 }


### PR DESCRIPTION
# Why

We don't need three methods for dataloader load count metrics. Instead, just use a type. This way consumers don't need to repeat code.

Also add docblocks in various places.

Closes ENG-5233.

# How

Add type, use `tsc` to ensure it works.

# Test Plan

`yarn tsc`