### PR TITLE
feat: add EntityEdgeDeletionBehavior.SET_NULL_INVALIDATE_CACHE_ONLY

### DIFF
--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -92,11 +92,8 @@ async function createOrTruncatePostgresTables(knex: Knex): Promise<void> {
 }
 
 async function dropPostgresTable(knex: Knex): Promise<void> {
-  if (await knex.schema.hasTable('children')) {
-    await knex.schema.dropTable('children');
-  }
-  if (await knex.schema.hasTable('parents')) {
-    await knex.schema.dropTable('parents');
+  if (await knex.schema.hasTable('testentities')) {
+    await knex.schema.dropTable('testentities');
   }
 }
 

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -56,7 +56,7 @@ const childEntityConfiguration = new EntityConfiguration<ChildFields>({
       cache: true,
       association: {
         getAssociatedEntityClass: () => ParentEntity,
-        edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE,
+        edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY,
       },
     }),
   },

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -69,7 +69,7 @@ export default abstract class Entity<
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forCreate(queryContext, { cascadingDeleteCause: null });
+      .forCreate(queryContext);
   }
 
   /**
@@ -111,7 +111,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forUpdate(existingEntity, queryContext, { cascadingDeleteCause: null });
+      .forUpdate(existingEntity, queryContext);
   }
 
   /**
@@ -152,7 +152,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forDelete(existingEntity, queryContext, { cascadingDeleteCause: null })
+      .forDelete(existingEntity, queryContext)
       .deleteAsync();
   }
 
@@ -194,7 +194,7 @@ export default abstract class Entity<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
-      .forDelete(existingEntity, queryContext, { cascadingDeleteCause: null })
+      .forDelete(existingEntity, queryContext)
       .enforceDeleteAsync();
   }
 

--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -15,8 +15,8 @@ export enum EntityEdgeDeletionBehavior {
 
   /**
    * Invalidate the cache for all entities that reference the entity
-   *  being deleted through this field. This is most useful when the database itself expresses
-   * foreign keys and cascading set nulls and the entity framework just needs to be
+   * being deleted through this field. This is most useful when the database itself expresses
+   * foreign keys and cascading "SET NULL"s and the entity framework just needs to be
    * kept consistent with the state of the database.
    */
   SET_NULL_INVALIDATE_CACHE_ONLY,

--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -5,13 +5,21 @@ import ViewerContext from './ViewerContext';
 
 export enum EntityEdgeDeletionBehavior {
   /**
-   * Default. Invalidate the cache for all entities that reference the entity
+   * Invalidate the cache for all entities that reference the entity
    * being deleted through this field, and transitively run deletions on those entities.
    * This is most useful when the database itself expresses foreign
-   * keys and cascading deletes or set nulls and the entity framework just needs to
+   * keys and cascading deletes and the entity framework just needs to
    * be kept consistent with the state of the database.
    */
-  CASCADE_DELETE_INVALIDATE_CACHE,
+  CASCADE_DELETE_INVALIDATE_CACHE_ONLY,
+
+  /**
+   * Invalidate the cache for all entities that reference the entity
+   *  being deleted through this field. This is most useful when the database itself expresses
+   * foreign keys and cascading set nulls and the entity framework just needs to be
+   * kept consistent with the state of the database.
+   */
+  SET_NULL_INVALIDATE_CACHE_ONLY,
 
   /**
    * Delete all entities that reference the entity being deleted through this field. This is very similar
@@ -74,16 +82,17 @@ export interface EntityAssociationDefinition<
    *
    * @remarks
    * The entity framework doesn't prescribe a one-size-fits-all solution for referential
-   * integrity; instead it exposes mechanisms that supports both database foreign key constraints
+   * integrity; instead it exposes mechanisms that support both database foreign key constraints
    * and implicit entity-specified foreign keys. Choosing which approach to use often depends on
    * application requirements, and sometimes even a mix-and-match is the right choice.
    *
    * - If referential integrity is critical to your application, database foreign key constraints
-   *   combined with {@link EntityEdgeDeletionBehavior.CASACDE_DELETE_INVALIDATE_CACHE} are recommended.
+   *   combined with {@link EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY} or
+   *   {@link EntityEdgeDeletionBehavior.SET_NULL_INVALIDATE_CACHE_ONLY} are recommended.
    * - If the database being used doesn't support foreign keys, then using the entity framework for referential
    *   integrity is recommended.
    */
-  edgeDeletionBehavior?: EntityEdgeDeletionBehavior;
+  edgeDeletionBehavior: EntityEdgeDeletionBehavior;
 }
 
 /**

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -20,6 +20,7 @@ export type EntityValidatorMutationInfo<
   | {
       type: EntityMutationType.UPDATE;
       previousValue: TEntity;
+      cascadingDeleteCause: EntityCascadingDeletionInfo | null;
     };
 
 /**
@@ -50,6 +51,7 @@ export type EntityTriggerMutationInfo<
   | {
       type: EntityMutationType.UPDATE;
       previousValue: TEntity;
+      cascadingDeleteCause: EntityCascadingDeletionInfo | null;
     }
   | {
       type: EntityMutationType.DELETE;

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -396,6 +396,14 @@ export class UpdateMutator<
   }
 
   private async updateInTransactionAsync(
+    skipDatabaseUpdate: true,
+    cascadingDeleteCause: EntityCascadingDeletionInfo
+  ): Promise<Result<TEntity>>;
+  private async updateInTransactionAsync(
+    skipDatabaseUpdate: false,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null
+  ): Promise<Result<TEntity>>;
+  private async updateInTransactionAsync(
     skipDatabaseUpdate: boolean,
     cascadingDeleteCause: EntityCascadingDeletionInfo | null
   ): Promise<Result<TEntity>> {

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -18,7 +18,7 @@ import EntityMutationTriggerConfiguration, {
   EntityNonTransactionalMutationTrigger,
 } from './EntityMutationTriggerConfiguration';
 import EntityMutationValidator from './EntityMutationValidator';
-import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -44,7 +44,6 @@ abstract class BaseMutator<
   constructor(
     protected readonly viewerContext: TViewerContext,
     protected readonly queryContext: EntityQueryContext,
-    protected readonly privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext,
     protected readonly entityConfiguration: EntityConfiguration<TFields>,
     protected readonly entityClass: IEntityClass<
       TFields,
@@ -221,7 +220,7 @@ export class CreateMutator<
       this.privacyPolicy.authorizeCreateAsync(
         this.viewerContext,
         queryContext,
-        this.privacyPolicyEvaluationContext,
+        { cascadingDeleteCause: null },
         temporaryEntityForPrivacyCheck,
         this.metricsAdapter
       )
@@ -251,11 +250,9 @@ export class CreateMutator<
 
     const insertResult = await this.databaseAdapter.insertAsync(queryContext, this.fieldsForEntity);
 
-    const entityLoader = this.entityLoaderFactory.forLoad(
-      this.viewerContext,
-      queryContext,
-      this.privacyPolicyEvaluationContext
-    );
+    const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, queryContext, {
+      cascadingDeleteCause: null,
+    });
     queryContext.appendPostCommitInvalidationCallback(
       entityLoader.invalidateFieldsAsync.bind(entityLoader, insertResult)
     );
@@ -315,7 +312,6 @@ export class UpdateMutator<
   constructor(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext,
     entityConfiguration: EntityConfiguration<TFields>,
     entityClass: IEntityClass<
       TFields,
@@ -355,7 +351,6 @@ export class UpdateMutator<
     super(
       viewerContext,
       queryContext,
-      privacyPolicyEvaluationContext,
       entityConfiguration,
       entityClass,
       privacyPolicy,
@@ -390,7 +385,7 @@ export class UpdateMutator<
       this.metricsAdapter,
       EntityMetricsMutationType.UPDATE,
       this.entityClass.name
-    )(this.updateInTransactionAsync());
+    )(this.updateInTransactionAsync(false, null));
   }
 
   /**
@@ -400,14 +395,19 @@ export class UpdateMutator<
     return await enforceAsyncResult(this.updateAsync());
   }
 
-  private async updateInTransactionAsync(): Promise<Result<TEntity>> {
+  private async updateInTransactionAsync(
+    skipDatabaseUpdate: boolean,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null
+  ): Promise<Result<TEntity>> {
     return await this.queryContext.runInTransactionIfNotInTransactionAsync((innerQueryContext) =>
-      this.updateInternalAsync(innerQueryContext)
+      this.updateInternalAsync(innerQueryContext, skipDatabaseUpdate, cascadingDeleteCause)
     );
   }
 
   private async updateInternalAsync(
-    queryContext: EntityTransactionalQueryContext
+    queryContext: EntityTransactionalQueryContext,
+    skipDatabaseUpdate: boolean,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null
   ): Promise<Result<TEntity>> {
     this.validateFields(this.updatedFields);
 
@@ -416,7 +416,7 @@ export class UpdateMutator<
       this.privacyPolicy.authorizeUpdateAsync(
         this.viewerContext,
         queryContext,
-        this.privacyPolicyEvaluationContext,
+        { cascadingDeleteCause },
         entityAboutToBeUpdated,
         this.metricsAdapter
       )
@@ -429,33 +429,34 @@ export class UpdateMutator<
       this.mutationValidators,
       queryContext,
       entityAboutToBeUpdated,
-      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
+      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity, cascadingDeleteCause }
     );
     await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeAll,
       queryContext,
       entityAboutToBeUpdated,
-      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
+      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity, cascadingDeleteCause }
     );
     await this.executeMutationTriggersAsync(
       this.mutationTriggers.beforeUpdate,
       queryContext,
       entityAboutToBeUpdated,
-      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
+      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity, cascadingDeleteCause }
     );
 
-    const updateResult = await this.databaseAdapter.updateAsync(
-      queryContext,
-      this.entityConfiguration.idField,
-      entityAboutToBeUpdated.getID(),
-      this.updatedFields
-    );
+    // skip the database update when specified
+    const updateResult = skipDatabaseUpdate
+      ? null
+      : await this.databaseAdapter.updateAsync(
+          queryContext,
+          this.entityConfiguration.idField,
+          entityAboutToBeUpdated.getID(),
+          this.updatedFields
+        );
 
-    const entityLoader = this.entityLoaderFactory.forLoad(
-      this.viewerContext,
-      queryContext,
-      this.privacyPolicyEvaluationContext
-    );
+    const entityLoader = this.entityLoaderFactory.forLoad(this.viewerContext, queryContext, {
+      cascadingDeleteCause,
+    });
 
     queryContext.appendPostCommitInvalidationCallback(
       entityLoader.invalidateFieldsAsync.bind(
@@ -467,22 +468,25 @@ export class UpdateMutator<
       entityLoader.invalidateFieldsAsync.bind(entityLoader, this.fieldsForEntity)
     );
 
-    const unauthorizedEntityAfterUpdate = new this.entityClass(this.viewerContext, updateResult);
-    const updatedEntity = await entityLoader
-      .enforcing()
-      .loadByIDAsync(unauthorizedEntityAfterUpdate.getID());
+    // when the database update was skipped, assume it succeeded and use the optimistic
+    // entity to execute triggers
+    const updatedEntity = updateResult
+      ? await entityLoader
+          .enforcing()
+          .loadByIDAsync(new this.entityClass(this.viewerContext, updateResult).getID())
+      : entityAboutToBeUpdated;
 
     await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterUpdate,
       queryContext,
       updatedEntity,
-      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
+      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity, cascadingDeleteCause }
     );
     await this.executeMutationTriggersAsync(
       this.mutationTriggers.afterAll,
       queryContext,
       updatedEntity,
-      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
+      { type: EntityMutationType.UPDATE, previousValue: this.originalEntity, cascadingDeleteCause }
     );
 
     queryContext.appendPostCommitCallback(
@@ -490,7 +494,11 @@ export class UpdateMutator<
         this,
         this.mutationTriggers.afterCommit,
         updatedEntity,
-        { type: EntityMutationType.UPDATE, previousValue: this.originalEntity }
+        {
+          type: EntityMutationType.UPDATE,
+          previousValue: this.originalEntity,
+          cascadingDeleteCause,
+        }
       )
     );
 
@@ -518,7 +526,6 @@ export class DeleteMutator<
   constructor(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext,
     entityConfiguration: EntityConfiguration<TFields>,
     entityClass: IEntityClass<
       TFields,
@@ -558,7 +565,6 @@ export class DeleteMutator<
     super(
       viewerContext,
       queryContext,
-      privacyPolicyEvaluationContext,
       entityConfiguration,
       entityClass,
       privacyPolicy,
@@ -771,19 +777,34 @@ export class DeleteMutator<
             }
 
             switch (association.edgeDeletionBehavior) {
-              case undefined:
-              case EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE: {
+              case EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY: {
                 await Promise.all(
                   inboundReferenceEntities.map((inboundReferenceEntity) =>
-                    mutatorFactory
-                      .forDelete(inboundReferenceEntity, queryContext, {
-                        cascadingDeleteCause: newCascadingDeleteCause,
-                      })
-                      .deleteInTransactionAsync(
-                        processedEntityIdentifiers,
-                        /* skipDatabaseDeletion */ true, // deletion is handled by DB
-                        newCascadingDeleteCause
-                      )
+                    enforceAsyncResult(
+                      mutatorFactory
+                        .forDelete(inboundReferenceEntity, queryContext)
+                        .deleteInTransactionAsync(
+                          processedEntityIdentifiers,
+                          /* skipDatabaseDeletion */ true, // deletion is handled by DB
+                          newCascadingDeleteCause
+                        )
+                    )
+                  )
+                );
+                break;
+              }
+              case EntityEdgeDeletionBehavior.SET_NULL_INVALIDATE_CACHE_ONLY: {
+                await Promise.all(
+                  inboundReferenceEntities.map((inboundReferenceEntity) =>
+                    enforceAsyncResult(
+                      mutatorFactory
+                        .forUpdate(inboundReferenceEntity, queryContext)
+                        .setField(fieldName, null)
+                        ['updateInTransactionAsync'](
+                          /* skipDatabaseUpdate */ true,
+                          newCascadingDeleteCause
+                        )
+                    )
                   )
                 );
                 break;
@@ -791,12 +812,15 @@ export class DeleteMutator<
               case EntityEdgeDeletionBehavior.SET_NULL: {
                 await Promise.all(
                   inboundReferenceEntities.map((inboundReferenceEntity) =>
-                    mutatorFactory
-                      .forUpdate(inboundReferenceEntity, queryContext, {
-                        cascadingDeleteCause: newCascadingDeleteCause,
-                      })
-                      .setField(fieldName, null)
-                      .enforceUpdateAsync()
+                    enforceAsyncResult(
+                      mutatorFactory
+                        .forUpdate(inboundReferenceEntity, queryContext)
+                        .setField(fieldName, null)
+                        ['updateInTransactionAsync'](
+                          /* skipDatabaseUpdate */ false,
+                          newCascadingDeleteCause
+                        )
+                    )
                   )
                 );
                 break;
@@ -804,15 +828,15 @@ export class DeleteMutator<
               case EntityEdgeDeletionBehavior.CASCADE_DELETE: {
                 await Promise.all(
                   inboundReferenceEntities.map((inboundReferenceEntity) =>
-                    mutatorFactory
-                      .forDelete(inboundReferenceEntity, queryContext, {
-                        cascadingDeleteCause: newCascadingDeleteCause,
-                      })
-                      .deleteInTransactionAsync(
-                        processedEntityIdentifiers,
-                        /* skipDatabaseDeletion */ false,
-                        newCascadingDeleteCause
-                      )
+                    enforceAsyncResult(
+                      mutatorFactory
+                        .forDelete(inboundReferenceEntity, queryContext)
+                        .deleteInTransactionAsync(
+                          processedEntityIdentifiers,
+                          /* skipDatabaseDeletion */ false,
+                          newCascadingDeleteCause
+                        )
+                    )
                   )
                 );
               }

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -73,12 +73,10 @@ export default class EntityMutatorFactory<
   forCreate(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext
-    // privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new CreateMutator(
       viewerContext,
       queryContext,
-      // privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -5,7 +5,7 @@ import EntityLoaderFactory from './EntityLoaderFactory';
 import EntityMutationTriggerConfiguration from './EntityMutationTriggerConfiguration';
 import EntityMutationValidator from './EntityMutationValidator';
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
-import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
 import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
@@ -72,13 +72,13 @@ export default class EntityMutatorFactory<
    */
   forCreate(
     viewerContext: TViewerContext,
-    queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
+    queryContext: EntityQueryContext
+    // privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new CreateMutator(
       viewerContext,
       queryContext,
-      privacyPolicyEvaluationContext,
+      // privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
@@ -98,13 +98,11 @@ export default class EntityMutatorFactory<
    */
   forUpdate(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
+    queryContext: EntityQueryContext
   ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new UpdateMutator(
       existingEntity.getViewerContext(),
       queryContext,
-      privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,
@@ -124,13 +122,11 @@ export default class EntityMutatorFactory<
    */
   forDelete(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
+    queryContext: EntityQueryContext
   ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new DeleteMutator(
       existingEntity.getViewerContext(),
       queryContext,
-      privacyPolicyEvaluationContext,
       this.entityConfiguration,
       this.entityClass,
       this.privacyPolicy,

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -36,13 +36,8 @@ export default class ViewerScopedEntityMutatorFactory<
 
   forCreate(
     queryContext: EntityQueryContext
-    // privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityMutatorFactory.forCreate(
-      this.viewerContext,
-      queryContext
-      // privacyPolicyEvaluationContext
-    );
+    return this.entityMutatorFactory.forCreate(this.viewerContext, queryContext);
   }
 
   forUpdate(

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -1,6 +1,6 @@
 import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
 import EntityMutatorFactory from './EntityMutatorFactory';
-import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -35,37 +35,27 @@ export default class ViewerScopedEntityMutatorFactory<
   ) {}
 
   forCreate(
-    queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
+    queryContext: EntityQueryContext
+    // privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return this.entityMutatorFactory.forCreate(
       this.viewerContext,
-      queryContext,
-      privacyPolicyEvaluationContext
+      queryContext
+      // privacyPolicyEvaluationContext
     );
   }
 
   forUpdate(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
+    queryContext: EntityQueryContext
   ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityMutatorFactory.forUpdate(
-      existingEntity,
-      queryContext,
-      privacyPolicyEvaluationContext
-    );
+    return this.entityMutatorFactory.forUpdate(existingEntity, queryContext);
   }
 
   forDelete(
     existingEntity: TEntity,
-    queryContext: EntityQueryContext,
-    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext
+    queryContext: EntityQueryContext
   ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return this.entityMutatorFactory.forDelete(
-      existingEntity,
-      queryContext,
-      privacyPolicyEvaluationContext
-    );
+    return this.entityMutatorFactory.forDelete(existingEntity, queryContext);
   }
 }

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -213,7 +213,7 @@ describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
 describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
   it('invalidates the cache', async () => {
     const { CategoryEntity } = makeEntityClass(
-      EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE
+      EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY
     );
 
     const companionProvider = createUnitTestEntityCompanionProvider();
@@ -283,7 +283,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
 
   it('handles cycles', async () => {
     const { CategoryEntity } = makeEntityClass(
-      EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE
+      EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY
     );
 
     const companionProvider = createUnitTestEntityCompanionProvider();

--- a/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
@@ -1,7 +1,6 @@
 import { mock, instance, verify } from 'ts-mockito';
 
 import EntityMutatorFactory from '../EntityMutatorFactory';
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import ViewerScopedEntityMutatorFactory from '../ViewerScopedEntityMutatorFactory';
@@ -10,7 +9,6 @@ import TestEntity, { TestFields, TestEntityPrivacyPolicy } from '../testfixtures
 describe(ViewerScopedEntityMutatorFactory, () => {
   it('correctly scopes viewer to entity mutations', async () => {
     const viewerContext = instance(mock(ViewerContext));
-    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
     const queryContext = instance(mock(EntityQueryContext));
     const baseMutatorFactory =
       mock<
@@ -27,10 +25,8 @@ describe(ViewerScopedEntityMutatorFactory, () => {
       keyof TestFields
     >(baseMutatorFactoryInstance, viewerContext);
 
-    viewerScopedEntityLoader.forCreate(queryContext, privacyPolicyEvaluationContext);
+    viewerScopedEntityLoader.forCreate(queryContext);
 
-    verify(
-      baseMutatorFactory.forCreate(viewerContext, queryContext, privacyPolicyEvaluationContext)
-    ).once();
+    verify(baseMutatorFactory.forCreate(viewerContext, queryContext)).once();
   });
 });


### PR DESCRIPTION
# Why

Previously it was recommended to use `EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE` when the database was set up to do `ON DELETE SET NULL`, but this had the bug where the deletion triggers would be run for the entity that was not actually being deleted by the DBMS (it was just being updated).

The correct solution before this PR was to use `EntityEdgeDeletionBehavior.SET_NULL` and rely upon entity to do the right thing.

This PR introduces a new `EntityEdgeDeletionBehavior` for the `ON DELETE SET NULL` case, `EntityEdgeDeletionBehavior.SET_NULL_INVALIDATE_CACHE_ONLY`, which runs the update triggers (and update cache invalidations) but rely upon the dbms for the actual underlying data update.

# How

Add new mode and tests.

Notes:
- This corrects the odd cascading info passing to the privacy policies, which now is controlled entirely internally to the mutator which is correct (no more control of it via the public API).

# Test Plan

Run tests.
