### PR TITLE
fix: fix workflow branch specification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
# Why

The main branch was changed from `master` to `main`, but the CI wasn't updated. This is causing codecov and CI not to run on the main branch.

# How

Update the workflow.

# Test Plan

Wait for CI.
