### PR TITLE
[fix/feat] recache values in higher layers for composed cache adapter

### DIFF
--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -60,7 +60,7 @@ export default class ComposedEntityCacheAdapter<TFields> extends EntityCacheAdap
     for (let i = this.cacheAdapters.length - 1; i >= 0; i--) {
       const cacheAdapter = nullthrows(this.cacheAdapters[i]);
       const hitsToCache = new Map<NonNullable<TFields[N]>, Readonly<TFields>>();
-      const missesToCache: NonNullable<TFields[N]>[] = [];
+      const negativesToCache: NonNullable<TFields[N]>[] = [];
 
       // Loop over all lower layer caches to collect hits and misses
       for (let j = i + 1; j < this.cacheAdapters.length; j++) {
@@ -70,7 +70,7 @@ export default class ComposedEntityCacheAdapter<TFields> extends EntityCacheAdap
           if (cacheResult.status === CacheStatus.HIT) {
             hitsToCache.set(fieldValue, cacheResult.item);
           } else if (cacheResult.status === CacheStatus.NEGATIVE) {
-            missesToCache.push(fieldValue);
+            negativesToCache.push(fieldValue);
           }
         });
       }
@@ -79,8 +79,8 @@ export default class ComposedEntityCacheAdapter<TFields> extends EntityCacheAdap
       if (hitsToCache.size > 0) {
         promises.push(cacheAdapter.cacheManyAsync(fieldName, hitsToCache));
       }
-      if (missesToCache.length > 0) {
-        promises.push(cacheAdapter.cacheDBMissesAsync(fieldName, missesToCache));
+      if (negativesToCache.length > 0) {
+        promises.push(cacheAdapter.cacheDBMissesAsync(fieldName, negativesToCache));
       }
       await Promise.all(promises);
     }

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -27,7 +27,8 @@ export default class ComposedEntityCacheAdapter<TFields> extends EntityCacheAdap
     fieldValues: readonly NonNullable<TFields[N]>[]
   ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
     const retMap = new Map<NonNullable<TFields[N]>, CacheLoadResult<TFields>>();
-    const fulfilledFieldValuesByCacheIndex: NonNullable<TFields[N]>[][] = this.cacheAdapters.map(
+    const fulfilledFieldValuesByCacheIndex: NonNullable<TFields[N]>[][] = Array.from(
+      { length: this.cacheAdapters.length },
       () => []
     );
 

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -44,8 +44,7 @@ export default class ComposedEntityCacheAdapter<TFields> extends EntityCacheAdap
           newUnfulfilledFieldValues.push(fieldValue);
         } else {
           retMap.set(fieldValue, cacheResult);
-          const fulfilledFieldValues = nullthrows(fulfilledFieldValuesByCacheIndex[i]);
-          fulfilledFieldValues.push(fieldValue);
+          nullthrows(fulfilledFieldValuesByCacheIndex[i]).push(fieldValue);
         }
       }
       unfulfilledFieldValues = newUnfulfilledFieldValues;

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -206,6 +206,20 @@ describe(ComposedEntityCacheAdapter, () => {
       expect(primaryResults.get('test-id-2')).toMatchObject({ status: CacheStatus.NEGATIVE });
       expect(primaryResults.get('test-id-3')).toMatchObject({ status: CacheStatus.MISS });
       expect(primaryResults.size).toBe(3);
+
+      // ensure that populating the primary cache doesn't change the output
+      const composedResults = await cacheAdapter.loadManyAsync('id', [
+        'test-id-1',
+        'test-id-2',
+        'test-id-3',
+      ]);
+      expect(composedResults.get('test-id-1')).toMatchObject({
+        status: CacheStatus.HIT,
+        item: { id: 'test-id-1' },
+      });
+      expect(composedResults.get('test-id-2')).toMatchObject({ status: CacheStatus.NEGATIVE });
+      expect(composedResults.get('test-id-3')).toMatchObject({ status: CacheStatus.MISS });
+      expect(composedResults.size).toBe(3);
     });
 
     it('returns empty map when passed empty array of fieldValues', async () => {


### PR DESCRIPTION
# Why
This PR recaches the values of lower cache layers missing from the higher layers of a ComposedCacheAdapter.

Consider a ComposedCacheAdapter with a local memory cache and a redis cache. In www, values typically stay in Redis much longer than they stay in Local Memory (capped to 5 seconds). In the scenario that a value is already cached in Redis but no longer cached in Local Memory (either it expired or was not the machine that originally cached to Redis), we will consider this a cache hit. Because the only time we cache values is when we fetch from DB, we will continually fetch from Redis until the value is evicted, at which point we will cache back into all the layers.

A better system would be to recache the higher layers with values found in the lower layers so we aren't loading from Redis most of the time. 

# How

recache higher layers in `loadManyAsync`

# Test Plan

- [ ] added new test
