### PR TITLE
ci: fix node version in docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 18.x
       - name: Cache Node.js modules
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
# Why

https://github.com/expo/entity/runs/7752849180?check_suite_focus=true

# How

Upgrade to same as `test` action.

# Test Plan

Wait for CI
