### PR TITLE
chore: update readme for easier release

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,10 @@ Note: The entity framework instance should not be shared across multiple request
 
 ## Releasing
 
-To release a new version, let's say `v1.0.0` for example:
-1. `git checkout -b bump-v1.0.0`
-1. `yarn lerna version [patch|minor|major] -- --no-push --conventional-commits`
-1. `git push -u origin bump-v1.0.0`
-1. Create a PR from the `bump-v1.0.0` branch, wait for tests, and commit the PR using GitHub interface.
-1. `git checkout main && git pull`
-1. `git tag -d v1.0.0`
-1. `git tag v1.0.0`
-1. `git push origin v1.0.0`
+To release a new version:
+1. `git checkout main`
+1. `yarn lerna publish [patch|minor|major] -- --conventional-commits`
 1. In GitHub release interface, create a new release from the tag, copy changelog changes to release description.
-1. `yarn clean && yarn tsc`
-1. In each public subpackage, run `npm publish` and enter 2FA token.
 
 ## License
 


### PR DESCRIPTION
# Why

Found a better way to release. The only downside is that it doesn't run tests but I think that's ok.

# How

Update readme.

# Test Plan

Just followed these steps for the 0.27.0 release.
