### PR TITLE
feat: add BigIntField

### DIFF
--- a/packages/entity-database-adapter-knex/src/EntityFields.ts
+++ b/packages/entity-database-adapter-knex/src/EntityFields.ts
@@ -1,0 +1,29 @@
+import { EntityFieldDefinition } from '@expo/entity';
+
+/**
+ * EntityFieldDefinition for a Postres column with a JS JSON array type.
+ */
+export class JSONArrayField extends EntityFieldDefinition<any[]> {
+  protected validateInputValueInternal(value: any[]): boolean {
+    return Array.isArray(value);
+  }
+}
+
+/**
+ * EntityFieldDefinition for a Postgres column that may be a JS JSON array type.
+ * Does not do any validation.
+ */
+export class MaybeJSONArrayField extends EntityFieldDefinition<any | any[]> {
+  protected validateInputValueInternal(_value: any): boolean {
+    return true;
+  }
+}
+
+/**
+ * EntityFieldDefinition for a Postgres BIGINT column.
+ */
+export class BigIntField extends EntityFieldDefinition<string> {
+  protected validateInputValueInternal(value: string): boolean {
+    return typeof value === 'string';
+  }
+}

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -2,8 +2,6 @@ import {
   EntityDatabaseAdapter,
   FieldTransformerMap,
   FieldTransformer,
-  JSONArrayField,
-  MaybeJSONArrayField,
   TableQuerySelectionModifiers,
   TableFieldSingleValueEqualityCondition,
   TableFieldMultiValueEqualityCondition,
@@ -11,6 +9,7 @@ import {
 } from '@expo/entity';
 import { Knex } from 'knex';
 
+import { JSONArrayField, MaybeJSONArrayField } from './EntityFields';
 import wrapNativePostgresCallAsync from './errors/wrapNativePostgresCallAsync';
 
 export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDatabaseAdapter<TFields> {

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -161,21 +161,20 @@ describe('postgres entity integration', () => {
     it('supports BIGINT fields', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 
-      const entity = await enforceAsyncResult(
+      let entity = await enforceAsyncResult(
         PostgresTestEntity.creator(vc1).setField('bigintField', '72057594037928038').createAsync()
       );
-
       expect(entity.getField('bigintField')).toEqual('72057594037928038');
-    });
 
-    it('supports small ints in BIGINT field (still as string though)', async () => {
-      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
-
-      const entity = await enforceAsyncResult(
-        PostgresTestEntity.creator(vc1).setField('bigintField', '10').createAsync()
+      entity = await enforceAsyncResult(
+        PostgresTestEntity.updater(entity).setField('bigintField', '10').updateAsync()
       );
-
       expect(entity.getField('bigintField')).toEqual('10');
+
+      entity = await enforceAsyncResult(
+        PostgresTestEntity.updater(entity).setField('bigintField', '-10').updateAsync()
+      );
+      expect(entity.getField('bigintField')).toEqual('-10');
     });
   });
 

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -157,6 +157,28 @@ describe('postgres entity integration', () => {
     });
   });
 
+  describe('BIGINT fields', () => {
+    it('supports BIGINT fields', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      const entity = await enforceAsyncResult(
+        PostgresTestEntity.creator(vc1).setField('bigintField', '72057594037928038').createAsync()
+      );
+
+      expect(entity.getField('bigintField')).toEqual('72057594037928038');
+    });
+
+    it('supports small ints in BIGINT field (still as string though)', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      const entity = await enforceAsyncResult(
+        PostgresTestEntity.creator(vc1).setField('bigintField', '10').createAsync()
+      );
+
+      expect(entity.getField('bigintField')).toEqual('10');
+    });
+  });
+
   describe('conjunction field equality loading', () => {
     it('supports single fieldValue and multiple fieldValues', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));

--- a/packages/entity-database-adapter-knex/src/__tests__/EntityFields-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/EntityFields-test.ts
@@ -1,0 +1,14 @@
+import { describeFieldTestCase } from '@expo/entity';
+
+import { JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
+
+describeFieldTestCase(
+  new JSONArrayField({ columnName: 'wat' }),
+  [[[1, 2]] as any, [['hello']] as any], // jest test cases need extra wrapping array
+  [1, 'hello']
+);
+describeFieldTestCase(
+  new MaybeJSONArrayField({ columnName: 'wat' }),
+  [1, 'hello', [['hello']]], // jest test cases need extra wrapping array
+  []
+);

--- a/packages/entity-database-adapter-knex/src/__tests__/EntityFields-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/EntityFields-test.ts
@@ -1,14 +1,19 @@
 import { describeFieldTestCase } from '@expo/entity';
 
-import { JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
+import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
 
 describeFieldTestCase(
   new JSONArrayField({ columnName: 'wat' }),
-  [[[1, 2]] as any, [['hello']] as any], // jest test cases need extra wrapping array
+  [[[1, 2]] as any, [['hello']] as any],
   [1, 'hello']
 );
 describeFieldTestCase(
   new MaybeJSONArrayField({ columnName: 'wat' }),
-  [1, 'hello', [['hello']]], // jest test cases need extra wrapping array
+  [1, 'hello', [['hello']]],
   []
+);
+describeFieldTestCase(
+  new BigIntField({ columnName: 'wat' }),
+  ['123457682149816498126412896', '123', '-1', '-124147812641876482716841'],
+  [1, false, -1, 1e6, {}]
 );

--- a/packages/entity-database-adapter-knex/src/index.ts
+++ b/packages/entity-database-adapter-knex/src/index.ts
@@ -7,3 +7,4 @@
 export { default as PostgresEntityDatabaseAdapter } from './PostgresEntityDatabaseAdapter';
 export { default as PostgresEntityDatabaseAdapterProvider } from './PostgresEntityDatabaseAdapterProvider';
 export { default as PostgresEntityQueryContextProvider } from './PostgresEntityQueryContextProvider';
+export * from './EntityFields';

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -6,15 +6,15 @@ import {
   StringField,
   BooleanField,
   StringArrayField,
-  JSONArrayField,
   JSONObjectField,
   DateField,
-  MaybeJSONArrayField,
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
 } from '@expo/entity';
 import { Knex } from 'knex';
+
+import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
 
 type PostgresTestEntityFields = {
   id: string;
@@ -28,6 +28,7 @@ type PostgresTestEntityFields = {
   } | null;
   dateField: Date | null;
   maybeJsonArrayField: string[] | { hello: string } | null;
+  bigintField: string | null;
 };
 
 export default class PostgresTestEntity extends Entity<
@@ -61,6 +62,7 @@ export default class PostgresTestEntity extends Entity<
         table.jsonb('json_object_field');
         table.dateTime('date_field', { useTz: true });
         table.jsonb('maybe_json_array_field');
+        table.bigint('bigint_field');
       });
     }
     await knex.into(tableName).truncate();
@@ -146,6 +148,9 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresT
     }),
     maybeJsonArrayField: new MaybeJSONArrayField({
       columnName: 'maybe_json_array_field',
+    }),
+    bigintField: new BigIntField({
+      columnName: 'bigint_field',
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -86,22 +86,3 @@ export class EnumField extends EntityFieldDefinition<string | number> {
     return typeof value === 'number' || typeof value === 'string';
   }
 }
-
-/**
- * EntityFieldDefinition for a column with a JS JSON array type.
- */
-export class JSONArrayField extends EntityFieldDefinition<any[]> {
-  protected validateInputValueInternal(value: any[]): boolean {
-    return Array.isArray(value);
-  }
-}
-
-/**
- * EntityFieldDefinition for a column that may be a JS JSON array type.
- * Does not do any validation.
- */
-export class MaybeJSONArrayField extends EntityFieldDefinition<any | any[]> {
-  protected validateInputValueInternal(_value: any): boolean {
-    return true;
-  }
-}

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -11,8 +11,6 @@ import {
   StringArrayField,
   JSONObjectField,
   EnumField,
-  JSONArrayField,
-  MaybeJSONArrayField,
 } from '../EntityFields';
 import describeFieldTestCase from '../utils/testing/describeFieldTestCase';
 
@@ -71,13 +69,3 @@ describeFieldTestCase(
 );
 describeFieldTestCase(new JSONObjectField({ columnName: 'wat' }), [{}], [true, 'hello']);
 describeFieldTestCase(new EnumField({ columnName: 'wat' }), ['hello', 1], [true]);
-describeFieldTestCase(
-  new JSONArrayField({ columnName: 'wat' }),
-  [[[1, 2]] as any, [['hello']] as any], // jest test cases need extra wrapping array
-  [1, 'hello']
-);
-describeFieldTestCase(
-  new MaybeJSONArrayField({ columnName: 'wat' }),
-  [1, 'hello', [['hello']]], // jest test cases need extra wrapping array
-  []
-);


### PR DESCRIPTION
# Why

Noticed by @FiberJW in https://github.com/expo/universe/pull/10420#discussion_r953010810. Knex (node-postgres) represents the BIGINT type as a string, so using `IntField` is incorrect. 

# How

This fixes that by adding a `BigInt` field that is of string type.

# Test Plan

Run new test case.
