### PR TITLE
feat: nested transactions

### DIFF
--- a/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
@@ -18,4 +18,10 @@ export default class PostgresEntityQueryContextProvider extends EntityQueryConte
   ) => Promise<T> {
     return (transactionScope) => this.knexInstance.transaction(transactionScope);
   }
+
+  protected createNestedTransactionRunner<T>(
+    outerQueryInterface: any
+  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
+    return (transactionScope) => (outerQueryInterface as Knex).transaction(transactionScope);
+  }
 }

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PosgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PosgresEntityQueryContextProvider-test.ts
@@ -1,0 +1,101 @@
+import { ViewerContext } from '@expo/entity';
+import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
+
+import PostgresEntityQueryContextProvider from '../PostgresEntityQueryContextProvider';
+import PostgresUniqueTestEntity from '../testfixtures/PostgresUniqueTestEntity';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../testfixtures/createKnexIntegrationTestEntityCompanionProvider';
+
+describe(PostgresEntityQueryContextProvider, () => {
+  let knexInstance: Knex;
+
+  beforeAll(() => {
+    knexInstance = knex({
+      client: 'pg',
+      connection: {
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
+        host: 'localhost',
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
+        database: nullthrows(process.env['PGDATABASE']),
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    await PostgresUniqueTestEntity.createOrTruncatePostgresTable(knexInstance);
+  });
+
+  afterAll(async () => {
+    await PostgresUniqueTestEntity.dropPostgresTable(knexInstance);
+    await knexInstance.destroy();
+  });
+
+  it('supports nested transactions', async () => {
+    const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+    await PostgresUniqueTestEntity.creator(vc1).setField('name', 'unique').enforceCreateAsync();
+
+    const id = (
+      await PostgresUniqueTestEntity.creator(vc1).setField('name', 'wat').enforceCreateAsync()
+    ).getID();
+
+    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+      const entity = await PostgresUniqueTestEntity.loader(vc1, queryContext)
+        .enforcing()
+        .loadByIDAsync(id);
+      await PostgresUniqueTestEntity.updater(entity, queryContext)
+        .setField('name', 'wat2')
+        .enforceUpdateAsync();
+
+      // ensure the outer transaction is not aborted due to postgres error in inner transaction,
+      // in this case the error triggered is a unique constraint violation
+      try {
+        await queryContext.runInNestedTransactionAsync(async (innerQueryContex) => {
+          const entity = await PostgresUniqueTestEntity.loader(vc1, innerQueryContex)
+            .enforcing()
+            .loadByIDAsync(id);
+          await PostgresUniqueTestEntity.updater(entity, innerQueryContex)
+            .setField('name', 'unique')
+            .enforceUpdateAsync();
+        });
+      } catch {}
+
+      const entity2 = await PostgresUniqueTestEntity.loader(vc1, queryContext)
+        .enforcing()
+        .loadByIDAsync(id);
+      await PostgresUniqueTestEntity.updater(entity2, queryContext)
+        .setField('name', 'wat3')
+        .enforceUpdateAsync();
+    });
+
+    const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).enforcing().loadByIDAsync(id);
+    expect(entityLoaded.getField('name')).toEqual('wat3');
+  });
+
+  it('supports multi-nested transactions', async () => {
+    const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+    const id = (
+      await PostgresUniqueTestEntity.creator(vc1).setField('name', 'wat').enforceCreateAsync()
+    ).getID();
+
+    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+      await queryContext.runInNestedTransactionAsync(async (innerQueryContex) => {
+        await innerQueryContex.runInNestedTransactionAsync(async (innerQueryContex2) => {
+          await innerQueryContex2.runInNestedTransactionAsync(async (innerQueryContex3) => {
+            const entity = await PostgresUniqueTestEntity.loader(vc1, innerQueryContex3)
+              .enforcing()
+              .loadByIDAsync(id);
+            await PostgresUniqueTestEntity.updater(entity, innerQueryContex3)
+              .setField('name', 'wat3')
+              .enforceUpdateAsync();
+          });
+        });
+      });
+    });
+
+    const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).enforcing().loadByIDAsync(id);
+    expect(entityLoaded.getField('name')).toEqual('wat3');
+  });
+});

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -51,11 +51,11 @@ describe(PostgresEntityQueryContextProvider, () => {
       // ensure the outer transaction is not aborted due to postgres error in inner transaction,
       // in this case the error triggered is a unique constraint violation
       try {
-        await queryContext.runInNestedTransactionAsync(async (innerQueryContex) => {
-          const entity = await PostgresUniqueTestEntity.loader(vc1, innerQueryContex)
+        await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+          const entity = await PostgresUniqueTestEntity.loader(vc1, innerQueryContext)
             .enforcing()
             .loadByIDAsync(id);
-          await PostgresUniqueTestEntity.updater(entity, innerQueryContex)
+          await PostgresUniqueTestEntity.updater(entity, innerQueryContext)
             .setField('name', 'unique')
             .enforceUpdateAsync();
         });
@@ -81,8 +81,8 @@ describe(PostgresEntityQueryContextProvider, () => {
     ).getID();
 
     await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
-      await queryContext.runInNestedTransactionAsync(async (innerQueryContex) => {
-        await innerQueryContex.runInNestedTransactionAsync(async (innerQueryContex2) => {
+      await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+        await innerQueryContext.runInNestedTransactionAsync(async (innerQueryContex2) => {
           await innerQueryContex2.runInNestedTransactionAsync(async (innerQueryContex3) => {
             const entity = await PostgresUniqueTestEntity.loader(vc1, innerQueryContex3)
               .enforcing()

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresUniqueTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresUniqueTestEntity.ts
@@ -1,0 +1,117 @@
+import {
+  AlwaysAllowPrivacyPolicyRule,
+  EntityPrivacyPolicy,
+  ViewerContext,
+  UUIDField,
+  StringField,
+  EntityConfiguration,
+  EntityCompanionDefinition,
+  Entity,
+} from '@expo/entity';
+import { Knex } from 'knex';
+
+type PostgresUniqueTestEntityFields = {
+  id: string;
+  name: string | null;
+};
+
+export default class PostgresUniqueTestEntity extends Entity<
+  PostgresUniqueTestEntityFields,
+  string,
+  ViewerContext
+> {
+  static getCompanionDefinition(): EntityCompanionDefinition<
+    PostgresUniqueTestEntityFields,
+    string,
+    ViewerContext,
+    PostgresUniqueTestEntity,
+    PostgresUniqueTestEntityPrivacyPolicy
+  > {
+    return postgresTestEntityCompanionDefinition;
+  }
+
+  public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'); // for uuid_generate_v4()
+
+    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (!hasTable) {
+      await knex.schema.createTable(tableName, (table) => {
+        table.uuid('id').defaultTo(knex.raw('uuid_generate_v4()')).primary();
+        table.string('name').unique();
+      });
+    }
+    await knex.into(tableName).truncate();
+  }
+
+  public static async dropPostgresTable(knex: Knex): Promise<void> {
+    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const hasTable = await knex.schema.hasTable(tableName);
+    if (hasTable) {
+      await knex.schema.dropTable(tableName);
+    }
+  }
+}
+
+class PostgresUniqueTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  PostgresUniqueTestEntityFields,
+  string,
+  ViewerContext,
+  PostgresUniqueTestEntity
+> {
+  protected override readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresUniqueTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresUniqueTestEntity
+    >(),
+  ];
+  protected override readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresUniqueTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresUniqueTestEntity
+    >(),
+  ];
+  protected override readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresUniqueTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresUniqueTestEntity
+    >(),
+  ];
+  protected override readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<
+      PostgresUniqueTestEntityFields,
+      string,
+      ViewerContext,
+      PostgresUniqueTestEntity
+    >(),
+  ];
+}
+
+export const postgresTestEntityConfiguration =
+  new EntityConfiguration<PostgresUniqueTestEntityFields>({
+    idField: 'id',
+    tableName: 'postgres_test_entities',
+    schema: {
+      id: new UUIDField({
+        columnName: 'id',
+        cache: true,
+      }),
+      name: new StringField({
+        columnName: 'name',
+      }),
+    },
+    databaseAdapterFlavor: 'postgres',
+    cacheAdapterFlavor: 'redis',
+  });
+
+const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
+  entityClass: PostgresUniqueTestEntity,
+  entityConfiguration: postgresTestEntityConfiguration,
+  privacyPolicyClass: PostgresUniqueTestEntityPrivacyPolicy,
+});

--- a/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
+++ b/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
@@ -10,4 +10,10 @@ export default class InMemoryQueryContextProvider extends EntityQueryContextProv
   ) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }
+
+  protected createNestedTransactionRunner<T>(
+    _outerQueryInterface: any
+  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
+    return (transactionScope) => Promise.resolve(transactionScope({}));
+  }
 }

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -60,7 +60,7 @@ export default abstract class EntityQueryContextProvider {
     outerQueryContext: EntityTransactionalQueryContext,
     transactionScope: (innerQueryContext: EntityNestedTransactionalQueryContext) => Promise<T>
   ): Promise<T> {
-    const [returnedValue, innerQueryContex] = await this.createNestedTransactionRunner<
+    const [returnedValue, innerQueryContext] = await this.createNestedTransactionRunner<
       [T, EntityNestedTransactionalQueryContext]
     >(outerQueryContext.getQueryInterface())(async (innerQueryInterface) => {
       const innerQueryContext = new EntityNestedTransactionalQueryContext(
@@ -73,7 +73,7 @@ export default abstract class EntityQueryContextProvider {
       return [result, innerQueryContext];
     });
     // post-commit callbacks are appended to parent transaction instead of run, but only after the transaction has succeeded
-    innerQueryContex.transferPostCommitCallbacksToParent();
+    innerQueryContext.transferPostCommitCallbacksToParent();
     return returnedValue;
   }
 }

--- a/packages/entity/src/utils/testing/StubQueryContextProvider.ts
+++ b/packages/entity/src/utils/testing/StubQueryContextProvider.ts
@@ -10,6 +10,12 @@ export class StubQueryContextProvider extends EntityQueryContextProvider {
   ) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }
+
+  protected createNestedTransactionRunner<T>(
+    _outerQueryInterface: any
+  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
+    return (transactionScope) => Promise.resolve(transactionScope({}));
+  }
 }
 
 export default new StubQueryContextProvider();


### PR DESCRIPTION
# Why

There's a bug in the Expo server of the following nature:
```typescript
await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
  'postgres',
  async (queryContext) => {
    const testEntity = await TestEntity.loader(viewerContext, queryContext)
      .enforcing()
      .loadByIDAsync(id);
    const testEntity2 = await TestEntity.loader(viewerContext, queryContext)
      .enforcing()
      .loadByIDAsync(id2);
    try {
      await TestEntity.updater(testEntity, queryContext)
        .setField('unique_field', 'non-unique-value')
        .enforceUpdateAsync();
    } catch {}

    // this never runs since the transaction was aborted, even though the catch caught the exception
    await TestEntity.updater(testEntity2).setField('blah', 'wat').enforceUpdateAsync();
  }
);
```

The exact text of the error is `current transaction is aborted` (for postgres database adapter).

To fix this, nested transactions are needed so that only the inner transaction rolls back on a postgres error and the outer transaction is allowed to continue.

# How

With this PR, the code becomes:

```typescript
await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
  'postgres',
  async (queryContext) => {
    const testEntity = await TestEntity.loader(viewerContext, queryContext)
      .enforcing()
      .loadByIDAsync(id);
    const testEntity2 = await TestEntity.loader(viewerContext, queryContext)
      .enforcing()
      .loadByIDAsync(id2);
    try {
      await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
        await TestEntity.updater(testEntity, innerQueryContext)
          .setField('unique_field', 'non-unique-value')
          .enforceUpdateAsync();
      });
    } catch {}

    // this succeeds now
    await TestEntity.updater(testEntity2).setField('blah', 'wat').enforceUpdateAsync();
  }
);
```

# Test Plan

Run the new tests.
