### PR TITLE
[www] Upgrade knex to 2.3.0

### DIFF
--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -30,7 +30,7 @@
     "@expo/entity": "*"
   },
   "dependencies": {
-    "knex": "^1.0.2"
+    "knex": "^2.3.0"
   },
   "devDependencies": {
     "@expo/entity": "^0.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,31 +373,31 @@
   integrity sha512-reebgVwjf8VfZxSXU7e+UjpXGwcUTIMpWR9FY54Oh70ulhXrQiZei62B4D9bH3SVYMwnDGzifHJ8INRrJ+0L1g==
 
 "@expo/entity-cache-adapter-local-memory@file:packages/entity-cache-adapter-local-memory":
-  version "0.28.0"
+  version "0.29.0"
   dependencies:
     lru-cache "^6.0.0"
 
 "@expo/entity-cache-adapter-redis@file:packages/entity-cache-adapter-redis":
-  version "0.28.0"
+  version "0.29.0"
 
 "@expo/entity-database-adapter-knex@file:packages/entity-database-adapter-knex":
-  version "0.28.0"
+  version "0.29.0"
   dependencies:
-    knex "^1.0.2"
+    knex "^2.3.0"
 
 "@expo/entity-ip-address-field@file:packages/entity-ip-address-field":
-  version "0.28.0"
+  version "0.29.0"
   dependencies:
     ip-address "^8.1.0"
 
 "@expo/entity-secondary-cache-local-memory@file:packages/entity-secondary-cache-local-memory":
-  version "0.28.0"
+  version "0.29.0"
 
 "@expo/entity-secondary-cache-redis@file:packages/entity-secondary-cache-redis":
-  version "0.28.0"
+  version "0.29.0"
 
 "@expo/entity@file:packages/entity":
-  version "0.28.0"
+  version "0.29.0"
   dependencies:
     "@expo/results" "^1.0.0"
     dataloader "^2.0.0"
@@ -3189,10 +3189,10 @@ color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-colorette@2.0.16:
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
-  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+colorette@2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
 columnify@^1.6.0:
   version "1.6.0"
@@ -6082,12 +6082,12 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knex@^1.0.2:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-1.0.7.tgz#965f4490efc451b140aac4c5c6efa39fd877597b"
-  integrity sha512-89jxuRATt4qJMb9ZyyaKBy0pQ4d5h7eOFRqiNFnUvsgU+9WZ2eIaZKrAPG1+F3mgu5UloPUnkVE5Yo2sKZUs6Q==
+knex@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-2.3.0.tgz#87fa2a9553d7cafb125d7a0645256fbe29ef5967"
+  integrity sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==
   dependencies:
-    colorette "2.0.16"
+    colorette "2.0.19"
     commander "^9.1.0"
     debug "4.3.4"
     escalade "^3.1.1"


### PR DESCRIPTION
# Why

Trying to upgrade this where we use it, but it is resulting in conflicting typescript types I believe. https://github.com/expo/universe/pull/11100

https://nvd.nist.gov/vuln/detail/CVE-2016-20018 says Knex has a SQL injection that can cause the WHERE clause to be ignored. It's unclear how this is triggered, and due to the usage pattern within entity it is doubtful that it affects us, but still good to stay upgraded.

How
---
Upgrade to Knex 2.3.0. This is a major semver upgrade. However, the breaking change in 2.3.0 was adding back support for sqlite3. That does not affect us. I read through the changelog and saw no other changes that would affect us, though there is better support for JSONB and Postgres now: https://github.com/knex/knex/pull/5201

# Test Plan

Run all tests.
