### PR TITLE
chore: upgrade ioredis to 5.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^7.7.0",
     "eslint-config-universe": "^7.0.0",
     "eslint-plugin-tsdoc": "^0.2.16",
-    "ioredis": "^5.0.4",
+    "ioredis": "^5.2.5",
     "jest": "^26.6.3",
     "lerna": "^5.4.0",
     "lru-cache": "^6.0.0",

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@expo/entity": "^0.30.0",
-    "ioredis": "^5.0.4"
+    "ioredis": "^5.2.5"
   }
 }

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@expo/entity": "^0.30.0",
     "@expo/entity-cache-adapter-redis": "^0.30.0",
-    "ioredis": "^5.0.4",
+    "ioredis": "^5.2.5",
     "nullthrows": "^1.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5116,10 +5116,10 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ioredis@^5.0.4:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.0.6.tgz#e50b8cc945f1f3ac932b0b8aab4bd8073d1402a9"
-  integrity sha512-KUm7wPzIet9QrFMoMm09/4bkfVKBUD9KXwBitP3hrNkZ+A6NBndweXGwYIB/7szHcTZgfo7Kvx88SxljJV4D9A==
+ioredis@^5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.5.tgz#c62dc3945ad2a8f0323fbb2765b934a84a68cde0"
+  integrity sha512-7HKo/ClM2DGLRXdFq8ruS3Uuadensz4A76wPOU0adqlOqd1qkhoLPDaBhmVhUhNGpB+J65/bhLmNB8DDY99HJQ==
   dependencies:
     "@ioredis/commands" "^1.1.1"
     cluster-key-slot "^1.1.0"


### PR DESCRIPTION
# Why

Similar upgrade in the Expo server: https://github.com/expo/universe/pull/11246

Changelog: https://github.com/luin/ioredis/blob/main/CHANGELOG.md

# How

Upgrade

# Test Plan

Run all unit and integration tests in redis cache adapter pakage(s).
