### PR TITLE
[rfc] loadFirstByFieldEqualityConjunction, a convenience method

### DIFF
--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -118,6 +118,22 @@ export default class EnforcingEntityLoader<
    * Enforcing version of entity loader method by the same name.
    * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
    */
+  async loadFirstByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
+    querySelectionModifiers: Omit<QuerySelectionModifiers<TFields>, 'limit'> &
+      Required<Pick<QuerySelectionModifiers<TFields>, 'orderBy'>>
+  ): Promise<TEntity | null> {
+    const entityResult = await this.entityLoader.loadFirstByFieldEqualityConjunctionAsync(
+      fieldEqualityOperands,
+      querySelectionModifiers
+    );
+    return entityResult ? entityResult.enforceValue() : null;
+  }
+
+  /**
+   * Enforcing version of entity loader method by the same name.
+   * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
+   */
   async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
     querySelectionModifiers: QuerySelectionModifiers<TFields> = {}

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -183,6 +183,32 @@ export default class EntityLoader<
   }
 
   /**
+   * Loads the first entity matching the selection constructed from the conjunction of specified
+   * operands, or null if no matching entity exists. Entities loaded using this method are not
+   * batched or cached.
+   *
+   * This is a convenience method for {@link loadManyByFieldEqualityConjunctionAsync}. However, the
+   * `orderBy` option must be specified to define what "first" means. If ordering doesn't matter,
+   * explicitly pass in an empty array.
+   *
+   * @param fieldEqualityOperands - list of field equality selection operand specifications
+   * @param querySelectionModifiers - orderBy and optional offset for the query
+   * @returns the first entity results that matches the query, where result error can be
+   *  UnauthorizedError
+   */
+  async loadFirstByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
+    querySelectionModifiers: Omit<QuerySelectionModifiers<TFields>, 'limit'> &
+      Required<Pick<QuerySelectionModifiers<TFields>, 'orderBy'>>
+  ): Promise<Result<TEntity> | null> {
+    const results = await this.loadManyByFieldEqualityConjunctionAsync(fieldEqualityOperands, {
+      ...querySelectionModifiers,
+      limit: 1,
+    });
+    return results[0] ?? null;
+  }
+
+  /**
    * Loads many entities matching the selection constructed from the conjunction of specified operands.
    * Entities loaded using this method are not batched or cached.
    *

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -222,6 +222,46 @@ describe(EnforcingEntityLoader, () => {
     });
   });
 
+  describe('loadFirstByFieldEqualityConjunction', () => {
+    it('throws when result is unsuccessful', async () => {
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const rejection = new Error();
+      when(
+        entityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(anything(), anything())
+      ).thenResolve(result(rejection));
+      const entityLoader = instance(entityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      await expect(
+        enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything())
+      ).rejects.toThrow(rejection);
+    });
+
+    it('returns value when result is successful', async () => {
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const resolved = {};
+      when(
+        entityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(anything(), anything())
+      ).thenResolve(result(resolved));
+      const entityLoader = instance(entityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      await expect(
+        enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything())
+      ).resolves.toEqual(resolved);
+    });
+
+    it('returns null when the query is successful but no rows match', async () => {
+      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      when(
+        entityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(anything(), anything())
+      ).thenResolve(null);
+      const entityLoader = instance(entityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      await expect(
+        enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything())
+      ).resolves.toBeNull();
+    });
+  });
+
   describe('loadManyByFieldEqualityConjunction', () => {
     it('throws when result is unsuccessful', async () => {
       const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);


### PR DESCRIPTION
# Why

Several places (about five) in our codebase call `loadFirstByFieldEqualityConjunction` with `{ limit: 1 }` either to get just the first row or to test for the existence of any matching row. The intent of the callers is often to get the latest row (limit 1, order by a descending timestamp). This PR adds a convenience method for that use case, primarily to help the callers convey their intent better, rather than saving one line of code by removing the need to specify `limit: 1`.

# How

Added `loadFirstByFieldEqualityConjunction` to EntityLoader and EnforcingEntityLoader. This new method calls into `loadManyByFieldEqualityConjunction` and passes in `limit: 1`. It uses TS to prevent `limit` from being specified from the outside, which indicates a programming error. It also requires `orderBy` to be specified. We have a caller that doesn't care about order, just existence -- in this case, the caller should pass in `orderBy: []` to explicitly show that it doesn't care about order. The more common pattern was to get the first row of an ordered set, though.

# Test Plan

Added unit tests for both EntityLoader and EnforcingEntityLoader. Notably, the EntityLoader test ensures the privacy policy was evaluated only once even though two rows match, and also checks that the `orderBy` clause was honored.
