### PR TITLE
feat: add ability to specify knex transaction config

### DIFF
--- a/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
@@ -30,16 +30,9 @@ export default class PostgresEntityQueryContextProvider extends EntityQueryConte
   }
 
   protected createNestedTransactionRunner<T>(
-    outerQueryInterface: any,
-    transactionConfig?: TransactionConfig
+    outerQueryInterface: any
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
-    return (transactionScope) =>
-      (outerQueryInterface as Knex).transaction(
-        transactionScope,
-        transactionConfig
-          ? PostgresEntityQueryContextProvider.convertTransactionConfig(transactionConfig)
-          : undefined
-      );
+    return (transactionScope) => (outerQueryInterface as Knex).transaction(transactionScope);
   }
 
   private static convertTransactionConfig(
@@ -49,12 +42,8 @@ export default class PostgresEntityQueryContextProvider extends EntityQueryConte
       isolationLevel: TransactionIsolationLevel
     ): Knex.IsolationLevels => {
       switch (isolationLevel) {
-        case TransactionIsolationLevel.READ_UNCOMMITTED:
-          return 'read uncommitted';
         case TransactionIsolationLevel.READ_COMMITTED:
           return 'read committed';
-        case TransactionIsolationLevel.SNAPSHOT:
-          return 'snapshot';
         case TransactionIsolationLevel.REPEATABLE_READ:
           return 'repeatable read';
         case TransactionIsolationLevel.SERIALIZABLE:

--- a/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityQueryContextProvider.ts
@@ -1,4 +1,8 @@
-import { EntityQueryContextProvider } from '@expo/entity';
+import {
+  EntityQueryContextProvider,
+  TransactionConfig,
+  TransactionIsolationLevel,
+} from '@expo/entity';
 import { Knex } from 'knex';
 
 /**
@@ -13,15 +17,55 @@ export default class PostgresEntityQueryContextProvider extends EntityQueryConte
     return this.knexInstance;
   }
 
-  protected createTransactionRunner<T>(): (
-    transactionScope: (trx: any) => Promise<T>
-  ) => Promise<T> {
-    return (transactionScope) => this.knexInstance.transaction(transactionScope);
+  protected createTransactionRunner<T>(
+    transactionConfig?: TransactionConfig
+  ): (transactionScope: (trx: any) => Promise<T>) => Promise<T> {
+    return (transactionScope) =>
+      this.knexInstance.transaction(
+        transactionScope,
+        transactionConfig
+          ? PostgresEntityQueryContextProvider.convertTransactionConfig(transactionConfig)
+          : undefined
+      );
   }
 
   protected createNestedTransactionRunner<T>(
-    outerQueryInterface: any
+    outerQueryInterface: any,
+    transactionConfig?: TransactionConfig
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
-    return (transactionScope) => (outerQueryInterface as Knex).transaction(transactionScope);
+    return (transactionScope) =>
+      (outerQueryInterface as Knex).transaction(
+        transactionScope,
+        transactionConfig
+          ? PostgresEntityQueryContextProvider.convertTransactionConfig(transactionConfig)
+          : undefined
+      );
+  }
+
+  private static convertTransactionConfig(
+    transactionConfig: TransactionConfig
+  ): Knex.TransactionConfig {
+    const convertIsolationLevel = (
+      isolationLevel: TransactionIsolationLevel
+    ): Knex.IsolationLevels => {
+      switch (isolationLevel) {
+        case TransactionIsolationLevel.READ_UNCOMMITTED:
+          return 'read uncommitted';
+        case TransactionIsolationLevel.READ_COMMITTED:
+          return 'read committed';
+        case TransactionIsolationLevel.SNAPSHOT:
+          return 'snapshot';
+        case TransactionIsolationLevel.REPEATABLE_READ:
+          return 'repeatable read';
+        case TransactionIsolationLevel.SERIALIZABLE:
+          return 'serializable';
+      }
+    };
+
+    return {
+      ...(transactionConfig.isolationLevel
+        ? { isolationLevel: convertIsolationLevel(transactionConfig.isolationLevel) }
+        : {}),
+    };
   }
 }

--- a/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
+++ b/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
@@ -12,8 +12,7 @@ export default class InMemoryQueryContextProvider extends EntityQueryContextProv
   }
 
   protected createNestedTransactionRunner<T>(
-    _outerQueryInterface: any,
-    _transactionConfig?: TransactionConfig
+    _outerQueryInterface: any
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }

--- a/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
+++ b/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
@@ -1,18 +1,19 @@
-import { EntityQueryContextProvider } from '@expo/entity';
+import { EntityQueryContextProvider, TransactionConfig } from '@expo/entity';
 
 export default class InMemoryQueryContextProvider extends EntityQueryContextProvider {
   protected getQueryInterface(): any {
     return {};
   }
 
-  protected createTransactionRunner<T>(): (
-    transactionScope: (queryInterface: any) => Promise<T>
-  ) => Promise<T> {
+  protected createTransactionRunner<T>(
+    _transactionConfig?: TransactionConfig
+  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }
 
   protected createNestedTransactionRunner<T>(
-    _outerQueryInterface: any
+    _outerQueryInterface: any,
+    _transactionConfig?: TransactionConfig
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -9,11 +9,9 @@ export type PreCommitCallback = (
 ) => Promise<any>;
 
 export enum TransactionIsolationLevel {
-  READ_UNCOMMITTED,
-  READ_COMMITTED,
-  SNAPSHOT,
-  REPEATABLE_READ,
-  SERIALIZABLE,
+  READ_COMMITTED = 'READ_COMMITTED',
+  REPEATABLE_READ = 'REPEATABLE_READ',
+  SERIALIZABLE = 'SERIALIZABLE',
 }
 
 export type TransactionConfig = {
@@ -154,7 +152,7 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
   ): Promise<T> {
     assert(
       transactionConfig === undefined,
-      'should not pass transactionConfig to an already created transaction'
+      'Should not pass transactionConfig to a nested transaction'
     );
     return await transactionScope(this);
   }

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -29,8 +29,7 @@ export default abstract class EntityQueryContextProvider {
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T>;
 
   protected abstract createNestedTransactionRunner<T>(
-    outerQueryInterface: any,
-    transactionConfig?: TransactionConfig
+    outerQueryInterface: any
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T>;
 
   /**
@@ -61,15 +60,11 @@ export default abstract class EntityQueryContextProvider {
    */
   async runInNestedTransactionAsync<T>(
     outerQueryContext: EntityTransactionalQueryContext,
-    transactionScope: (innerQueryContext: EntityNestedTransactionalQueryContext) => Promise<T>,
-    transactionConfig?: TransactionConfig
+    transactionScope: (innerQueryContext: EntityNestedTransactionalQueryContext) => Promise<T>
   ): Promise<T> {
     const [returnedValue, innerQueryContext] = await this.createNestedTransactionRunner<
       [T, EntityNestedTransactionalQueryContext]
-    >(
-      outerQueryContext.getQueryInterface(),
-      transactionConfig
-    )(async (innerQueryInterface) => {
+    >(outerQueryContext.getQueryInterface())(async (innerQueryInterface) => {
       const innerQueryContext = new EntityNestedTransactionalQueryContext(
         innerQueryInterface,
         outerQueryContext,

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -1,7 +1,11 @@
 import { IEntityClass } from './Entity';
 import EntityCompanionProvider, { DatabaseAdapterFlavor } from './EntityCompanionProvider';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
-import { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
+import {
+  EntityQueryContext,
+  EntityTransactionalQueryContext,
+  TransactionConfig,
+} from './EntityQueryContext';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerScopedEntityCompanion from './ViewerScopedEntityCompanion';
 import ViewerScopedEntityCompanionProvider from './ViewerScopedEntityCompanionProvider';
@@ -82,11 +86,12 @@ export default class ViewerContext {
    */
   async runInTransactionForDatabaseAdaptorFlavorAsync<TResult>(
     databaseAdaptorFlavor: DatabaseAdapterFlavor,
-    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>
+    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>,
+    transactionConfig?: TransactionConfig
   ): Promise<TResult> {
     return await this.entityCompanionProvider
       .getQueryContextProviderForDatabaseAdaptorFlavor(databaseAdaptorFlavor)
       .getQueryContext()
-      .runInTransactionIfNotInTransactionAsync(transactionScope);
+      .runInTransactionIfNotInTransactionAsync(transactionScope, transactionConfig);
   }
 }

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -385,7 +385,8 @@ describe(EntityDataManager, () => {
         return await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'customIdField', [
           '1',
         ]);
-      }
+      },
+      {}
     );
 
     expect(entityDatas.get('1')).toHaveLength(1);

--- a/packages/entity/src/utils/testing/StubQueryContextProvider.ts
+++ b/packages/entity/src/utils/testing/StubQueryContextProvider.ts
@@ -13,8 +13,7 @@ export class StubQueryContextProvider extends EntityQueryContextProvider {
   }
 
   protected createNestedTransactionRunner<T>(
-    _outerQueryInterface: any,
-    _transactionConfig?: TransactionConfig
+    _outerQueryInterface: any
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }

--- a/packages/entity/src/utils/testing/StubQueryContextProvider.ts
+++ b/packages/entity/src/utils/testing/StubQueryContextProvider.ts
@@ -1,3 +1,4 @@
+import { TransactionConfig } from '../../EntityQueryContext';
 import EntityQueryContextProvider from '../../EntityQueryContextProvider';
 
 export class StubQueryContextProvider extends EntityQueryContextProvider {
@@ -5,14 +6,15 @@ export class StubQueryContextProvider extends EntityQueryContextProvider {
     return {};
   }
 
-  protected createTransactionRunner<T>(): (
-    transactionScope: (queryInterface: any) => Promise<T>
-  ) => Promise<T> {
+  protected createTransactionRunner<T>(
+    _transactionConfig?: TransactionConfig
+  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }
 
   protected createNestedTransactionRunner<T>(
-    _outerQueryInterface: any
+    _outerQueryInterface: any,
+    _transactionConfig?: TransactionConfig
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {
     return (transactionScope) => Promise.resolve(transactionScope({}));
   }


### PR DESCRIPTION
# Why

Expo has a need for serializable transaction isolation level. This change allows specifying this configuration for knex.

# How

Add transaction config, pass through (with translation particular to the adaptor flavor).

# Test Plan

Run new tests.
