### PR TITLE
feat: entity companion definition static thunk

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/LocalMemoryCacheAdapter-full-test.ts
@@ -19,10 +19,10 @@ describe(LocalMemoryCacheAdapter, () => {
 
   it('has correct caching behavior', async () => {
     const viewerContext = new TestViewerContext(createLocalMemoryTestEntityCompanionProvider());
-    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
-      LocalMemoryTestEntity,
-      LocalMemoryTestEntity.getCompanionDefinition()
-    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheAdapter =
+      viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)[
+        'tableDataCoordinator'
+      ]['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
     const date = new Date();
@@ -38,7 +38,8 @@ describe(LocalMemoryCacheAdapter, () => {
 
     const entitySpecificGenericCacher =
       LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap.get(
-        LocalMemoryTestEntity.getCompanionDefinition().entityConfiguration.tableName
+        viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)
+          .entityCompanionDefinition.entityConfiguration.tableName
       )!['genericLocalMemoryCacher'];
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),
@@ -107,10 +108,10 @@ describe(LocalMemoryCacheAdapter, () => {
       .enforcing()
       .loadByIDAsync(entity1Created.getID());
 
-    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
-      LocalMemoryTestEntity,
-      LocalMemoryTestEntity.getCompanionDefinition()
-    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheAdapter =
+      viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)[
+        'tableDataCoordinator'
+      ]['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
     expect(entity1WithVc2.getAllFields()).toMatchObject({
       id: entity1WithVc2.getID(),
@@ -127,10 +128,10 @@ describe(LocalMemoryCacheAdapter, () => {
     const viewerContext = new TestViewerContext(
       createNoopLocalMemoryIntegrationTestEntityCompanionProvider()
     );
-    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
-      LocalMemoryTestEntity,
-      LocalMemoryTestEntity.getCompanionDefinition()
-    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheAdapter =
+      viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)[
+        'tableDataCoordinator'
+      ]['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
     const date = new Date();
@@ -146,7 +147,8 @@ describe(LocalMemoryCacheAdapter, () => {
 
     const entitySpecificGenericCacher =
       LocalMemoryCacheAdapterProvider.localMemoryCacheAdapterMap.get(
-        LocalMemoryTestEntity.getCompanionDefinition().entityConfiguration.tableName
+        viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)
+          .entityCompanionDefinition.entityConfiguration.tableName
       )!['genericLocalMemoryCacher'];
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),

--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/LocalMemoryTestEntity.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/LocalMemoryTestEntity.ts
@@ -21,14 +21,18 @@ export default class LocalMemoryTestEntity extends Entity<
   string,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     LocalMemoryTestEntityFields,
     string,
     ViewerContext,
     LocalMemoryTestEntity,
     LocalMemoryTestEntityPrivacyPolicy
   > {
-    return localMemoryTestEntityCompanionDefinition;
+    return {
+      entityClass: LocalMemoryTestEntity,
+      entityConfiguration: localMemoryTestEntityConfiguration,
+      privacyPolicyClass: LocalMemoryTestEntityPrivacyPolicy,
+    };
   }
 }
 
@@ -92,9 +96,3 @@ export const localMemoryTestEntityConfiguration =
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'local-memory',
   });
-
-const localMemoryTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: LocalMemoryTestEntity,
-  entityConfiguration: localMemoryTestEntityConfiguration,
-  privacyPolicyClass: LocalMemoryTestEntityPrivacyPolicy,
-});

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -93,10 +93,10 @@ describe(RedisCacheAdapter, () => {
 
     const mgetSpy = jest.spyOn(redis, 'mget');
 
-    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
-      RedisTestEntity,
-      RedisTestEntity.getCompanionDefinition()
-    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheAdapter =
+      viewerContext.entityCompanionProvider.getCompanionForEntity(RedisTestEntity)[
+        'tableDataCoordinator'
+      ]['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/RedisCacheAdapter-integration-test.ts
@@ -42,10 +42,10 @@ describe(RedisCacheAdapter, () => {
     const viewerContext = new TestViewerContext(
       createRedisIntegrationTestEntityCompanionProvider(redisCacheAdapterContext)
     );
-    const cacheAdapter = viewerContext.entityCompanionProvider.getCompanionForEntity(
-      RedisTestEntity,
-      RedisTestEntity.getCompanionDefinition()
-    )['tableDataCoordinator']['cacheAdapter'];
+    const cacheAdapter =
+      viewerContext.entityCompanionProvider.getCompanionForEntity(RedisTestEntity)[
+        'tableDataCoordinator'
+      ]['cacheAdapter'];
     const cacheKeyMaker = cacheAdapter['makeCacheKey'].bind(cacheAdapter);
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -17,14 +17,18 @@ export type RedisTestEntityFields = {
 };
 
 export default class RedisTestEntity extends Entity<RedisTestEntityFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     RedisTestEntityFields,
     string,
     ViewerContext,
     RedisTestEntity,
     RedisTestEntityPrivacyPolicy
   > {
-    return redisTestEntityCompanionDefinition;
+    return {
+      entityClass: RedisTestEntity,
+      entityConfiguration: redisTestEntityConfiguration,
+      privacyPolicyClass: RedisTestEntityPrivacyPolicy,
+    };
   }
 }
 
@@ -86,10 +90,4 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-});
-
-const redisTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: RedisTestEntity,
-  entityConfiguration: redisTestEntityConfiguration,
-  privacyPolicyClass: RedisTestEntityPrivacyPolicy,
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
@@ -27,21 +27,24 @@ export default class ErrorsTestEntity extends Entity<
   number,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     ErrorsTestEntityFields,
     number,
     ViewerContext,
     ErrorsTestEntity,
     ErrorsTestEntityPrivacyPolicy
   > {
-    return errorsTestEntityCompanionDefinition;
+    return {
+      entityClass: ErrorsTestEntity,
+      entityConfiguration: ErrorsTestEntityConfiguration,
+      privacyPolicyClass: ErrorsTestEntityPrivacyPolicy,
+    };
   }
 
   public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
     await knex.raw('CREATE EXTENSION IF NOT EXISTS "btree_gist"'); // for gist exclusion on varchar
 
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
-
+    const tableName = 'postgres_test_entities';
     const hasForeignTable = await knex.schema.hasTable(foreignTableName);
     if (!hasForeignTable) {
       await knex.schema.createTable(foreignTableName, (table) => {
@@ -87,7 +90,7 @@ export default class ErrorsTestEntity extends Entity<
   }
 
   public static async dropPostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (hasTable) {
       await knex.schema.dropTable(tableName);
@@ -168,10 +171,4 @@ export const ErrorsTestEntityConfiguration = new EntityConfiguration<ErrorsTestE
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-});
-
-const errorsTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: ErrorsTestEntity,
-  entityConfiguration: ErrorsTestEntityConfiguration,
-  privacyPolicyClass: ErrorsTestEntityPrivacyPolicy,
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -20,18 +20,22 @@ export default class InvalidTestEntity extends Entity<
   number,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     InvalidTestEntityFields,
     number,
     ViewerContext,
     InvalidTestEntity,
     InvalidTestEntityPrivacyPolicy
   > {
-    return invalidTestEntityCompanionDefinition;
+    return {
+      entityClass: InvalidTestEntity,
+      entityConfiguration: invalidTestEntityConfiguration,
+      privacyPolicyClass: InvalidTestEntityPrivacyPolicy,
+    };
   }
 
   public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (!hasTable) {
       await knex.schema.createTable(tableName, (table) => {
@@ -43,7 +47,7 @@ export default class InvalidTestEntity extends Entity<
   }
 
   public static async dropPostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (hasTable) {
       await knex.schema.dropTable(tableName);
@@ -104,10 +108,4 @@ export const invalidTestEntityConfiguration = new EntityConfiguration<InvalidTes
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-});
-
-const invalidTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: InvalidTestEntity,
-  entityConfiguration: invalidTestEntityConfiguration,
-  privacyPolicyClass: InvalidTestEntityPrivacyPolicy,
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -36,18 +36,22 @@ export default class PostgresTestEntity extends Entity<
   string,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresTestEntityFields,
     string,
     ViewerContext,
     PostgresTestEntity,
     PostgresTestEntityPrivacyPolicy
   > {
-    return postgresTestEntityCompanionDefinition;
+    return {
+      entityClass: PostgresTestEntity,
+      entityConfiguration: postgresTestEntityConfiguration,
+      privacyPolicyClass: PostgresTestEntityPrivacyPolicy,
+    };
   }
 
   public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (!hasTable) {
       await knex.schema.createTable(tableName, (table) => {
@@ -67,7 +71,7 @@ export default class PostgresTestEntity extends Entity<
   }
 
   public static async dropPostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (hasTable) {
       await knex.schema.dropTable(tableName);
@@ -153,10 +157,4 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresT
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-});
-
-const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: PostgresTestEntity,
-  entityConfiguration: postgresTestEntityConfiguration,
-  privacyPolicyClass: PostgresTestEntityPrivacyPolicy,
 });

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -24,18 +24,33 @@ export default class PostgresTriggerTestEntity extends Entity<
   string,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresTriggerTestEntityFields,
     string,
     ViewerContext,
     PostgresTriggerTestEntity,
     PostgresTriggerTestEntityPrivacyPolicy
   > {
-    return postgresTestEntityCompanionDefinition;
+    return {
+      entityClass: PostgresTriggerTestEntity,
+      entityConfiguration: postgresTestEntityConfiguration,
+      privacyPolicyClass: PostgresTriggerTestEntityPrivacyPolicy,
+      mutationTriggers: {
+        beforeCreate: [new ThrowConditionallyTrigger('name', 'beforeCreate')],
+        afterCreate: [new ThrowConditionallyTrigger('name', 'afterCreate')],
+        beforeUpdate: [new ThrowConditionallyTrigger('name', 'beforeUpdate')],
+        afterUpdate: [new ThrowConditionallyTrigger('name', 'afterUpdate')],
+        beforeDelete: [new ThrowConditionallyTrigger('name', 'beforeDelete')],
+        afterDelete: [new ThrowConditionallyTrigger('name', 'afterDelete')],
+        beforeAll: [new ThrowConditionallyTrigger('name', 'beforeAll')],
+        afterAll: [new ThrowConditionallyTrigger('name', 'afterAll')],
+        afterCommit: [new ThrowConditionallyNonTransactionalTrigger('name', 'afterCommit')],
+      },
+    };
   }
 
   public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (!hasTable) {
       await knex.schema.createTable(tableName, (table) => {
@@ -47,7 +62,7 @@ export default class PostgresTriggerTestEntity extends Entity<
   }
 
   public static async dropPostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (hasTable) {
       await knex.schema.dropTable(tableName);
@@ -158,20 +173,3 @@ export const postgresTestEntityConfiguration =
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'redis',
   });
-
-const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: PostgresTriggerTestEntity,
-  entityConfiguration: postgresTestEntityConfiguration,
-  privacyPolicyClass: PostgresTriggerTestEntityPrivacyPolicy,
-  mutationTriggers: () => ({
-    beforeCreate: [new ThrowConditionallyTrigger('name', 'beforeCreate')],
-    afterCreate: [new ThrowConditionallyTrigger('name', 'afterCreate')],
-    beforeUpdate: [new ThrowConditionallyTrigger('name', 'beforeUpdate')],
-    afterUpdate: [new ThrowConditionallyTrigger('name', 'afterUpdate')],
-    beforeDelete: [new ThrowConditionallyTrigger('name', 'beforeDelete')],
-    afterDelete: [new ThrowConditionallyTrigger('name', 'afterDelete')],
-    beforeAll: [new ThrowConditionallyTrigger('name', 'beforeAll')],
-    afterAll: [new ThrowConditionallyTrigger('name', 'afterAll')],
-    afterCommit: [new ThrowConditionallyNonTransactionalTrigger('name', 'afterCommit')],
-  }),
-});

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresUniqueTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresUniqueTestEntity.ts
@@ -20,18 +20,22 @@ export default class PostgresUniqueTestEntity extends Entity<
   string,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresUniqueTestEntityFields,
     string,
     ViewerContext,
     PostgresUniqueTestEntity,
     PostgresUniqueTestEntityPrivacyPolicy
   > {
-    return postgresTestEntityCompanionDefinition;
+    return {
+      entityClass: PostgresUniqueTestEntity,
+      entityConfiguration: postgresTestEntityConfiguration,
+      privacyPolicyClass: PostgresUniqueTestEntityPrivacyPolicy,
+    };
   }
 
   public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (!hasTable) {
       await knex.schema.createTable(tableName, (table) => {
@@ -43,7 +47,7 @@ export default class PostgresUniqueTestEntity extends Entity<
   }
 
   public static async dropPostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (hasTable) {
       await knex.schema.dropTable(tableName);
@@ -107,9 +111,3 @@ export const postgresTestEntityConfiguration =
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'redis',
   });
-
-const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: PostgresUniqueTestEntity,
-  entityConfiguration: postgresTestEntityConfiguration,
-  privacyPolicyClass: PostgresUniqueTestEntityPrivacyPolicy,
-});

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -23,18 +23,23 @@ export default class PostgresValidatorTestEntity extends Entity<
   string,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresValidatorTestEntityFields,
     string,
     ViewerContext,
     PostgresValidatorTestEntity,
     PostgresValidatorTestEntityPrivacyPolicy
   > {
-    return postgresTestEntityCompanionDefinition;
+    return {
+      entityClass: PostgresValidatorTestEntity,
+      entityConfiguration: postgresTestEntityConfiguration,
+      privacyPolicyClass: PostgresValidatorTestEntityPrivacyPolicy,
+      mutationValidators: [new ThrowConditionallyTrigger('name', 'beforeCreateAndBeforeUpdate')],
+    };
   }
 
   public static async createOrTruncatePostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (!hasTable) {
       await knex.schema.createTable(tableName, (table) => {
@@ -46,7 +51,7 @@ export default class PostgresValidatorTestEntity extends Entity<
   }
 
   public static async dropPostgresTable(knex: Knex): Promise<void> {
-    const tableName = this.getCompanionDefinition().entityConfiguration.tableName;
+    const tableName = 'postgres_test_entities';
     const hasTable = await knex.schema.hasTable(tableName);
     if (hasTable) {
       await knex.schema.dropTable(tableName);
@@ -140,10 +145,3 @@ export const postgresTestEntityConfiguration =
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'redis',
   });
-
-const postgresTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: PostgresValidatorTestEntity,
-  entityConfiguration: postgresTestEntityConfiguration,
-  privacyPolicyClass: PostgresValidatorTestEntityPrivacyPolicy,
-  mutationValidators: () => [new ThrowConditionallyTrigger('name', 'beforeCreateAndBeforeUpdate')],
-});

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -23,7 +23,7 @@ import { ExampleViewerContext } from '../viewerContexts';
  * Otherwise, it defers to the next rule in the policy.
  */
 export default class AllowIfUserOwnerPrivacyRule<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TEntity extends ReadonlyEntity<TFields, TID, ExampleViewerContext>,
   TSelectedFields extends keyof TFields = keyof TFields

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -20,43 +20,41 @@ export interface NoteFields {
  * A simple entity representing a "notes" table/collection. Each note has an owner, title, and body.
  */
 export default class NoteEntity extends Entity<NoteFields, string, ExampleViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  /**
+   * The companion provides configuration instructions to the Entity framework for this type
+   * of entity. In some languages, this would be representable as "abstract" static members
+   * of the class itself, but TypeScript disallows static generic and abstract methods.
+   */
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     NoteFields,
     string,
     ExampleViewerContext,
     NoteEntity,
     NotePrivacyPolicy
   > {
-    return noteEntityCompanion;
+    return {
+      entityClass: NoteEntity,
+      entityConfiguration: new EntityConfiguration<NoteFields>({
+        idField: 'id',
+        tableName: 'notes',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+          }),
+          userID: new UUIDField({
+            columnName: 'user_id',
+          }),
+          title: new StringField({
+            columnName: 'title',
+          }),
+          body: new StringField({
+            columnName: 'body',
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: NotePrivacyPolicy,
+    };
   }
 }
-
-/**
- * The companion provides configuration instructions to the Entity framework for this type
- * of entity. In some languages, this would be representable as "abstract" static members
- * of the class itself, but TypeScript disallows static generic and abstract methods.
- */
-export const noteEntityCompanion = new EntityCompanionDefinition({
-  entityClass: NoteEntity,
-  entityConfiguration: new EntityConfiguration<NoteFields>({
-    idField: 'id',
-    tableName: 'notes',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-      }),
-      userID: new UUIDField({
-        columnName: 'user_id',
-      }),
-      title: new StringField({
-        columnName: 'title',
-      }),
-      body: new StringField({
-        columnName: 'body',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  }),
-  privacyPolicyClass: NotePrivacyPolicy,
-});

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -43,14 +43,18 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 class TestEntity extends Entity<TestFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy
   > {
-    return testEntityCompanion;
+    return {
+      entityClass: TestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    };
   }
 }
 
@@ -72,12 +76,6 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-});
-
-const testEntityCompanion = new EntityCompanionDefinition({
-  entityClass: TestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
 });
 
 async function createOrTruncatePostgresTables(knex: Knex): Promise<void> {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -48,33 +48,41 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
   const othersTableName = uuidv4();
 
   class CategoryEntity extends Entity<CategoryFields, string, ViewerContext> {
-    static getCompanionDefinition(): EntityCompanionDefinition<
+    static defineCompanionDefinition(): EntityCompanionDefinition<
       CategoryFields,
       string,
       ViewerContext,
       CategoryEntity,
       PrivacyPolicy
     > {
-      return categoryEntityCompanion;
+      return {
+        entityClass: CategoryEntity,
+        entityConfiguration: categoryEntityConfiguration,
+        privacyPolicyClass: PrivacyPolicy,
+      };
     }
   }
 
   class OtherEntity extends Entity<OtherFields, string, ViewerContext> {
-    static getCompanionDefinition(): EntityCompanionDefinition<
+    static defineCompanionDefinition(): EntityCompanionDefinition<
       OtherFields,
       string,
       ViewerContext,
       OtherEntity,
       PrivacyPolicy
     > {
-      return otherEntityCompanion;
+      return {
+        entityClass: OtherEntity,
+        entityConfiguration: otherEntityConfiguration,
+        privacyPolicyClass: PrivacyPolicy,
+      };
     }
   }
 
   const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
     idField: 'id',
     tableName: categoriesTableName,
-    getInboundEdges: () => [OtherEntity],
+    inboundEdges: [OtherEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -84,7 +92,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         columnName: 'parent_other_id',
         cache: true,
         association: {
-          getAssociatedEntityClass: () => OtherEntity,
+          associatedEntityClass: OtherEntity,
           edgeDeletionBehavior,
         },
       }),
@@ -93,16 +101,10 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
     cacheAdapterFlavor: 'redis',
   });
 
-  const categoryEntityCompanion = new EntityCompanionDefinition({
-    entityClass: CategoryEntity,
-    entityConfiguration: categoryEntityConfiguration,
-    privacyPolicyClass: PrivacyPolicy,
-  });
-
   const otherEntityConfiguration = new EntityConfiguration<OtherFields>({
     idField: 'id',
     tableName: othersTableName,
-    getInboundEdges: () => [CategoryEntity],
+    inboundEdges: [CategoryEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -112,19 +114,13 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
         columnName: 'parent_category_id',
         cache: true,
         association: {
-          getAssociatedEntityClass: () => CategoryEntity,
+          associatedEntityClass: CategoryEntity,
           edgeDeletionBehavior,
         },
       }),
     },
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'redis',
-  });
-
-  const otherEntityCompanion = new EntityCompanionDefinition({
-    entityClass: OtherEntity,
-    entityConfiguration: otherEntityConfiguration,
-    privacyPolicyClass: PrivacyPolicy,
   });
 
   await knex.schema.createTable(categoriesTableName, (table) => {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -32,40 +32,36 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerCon
 }
 
 export default class ChildEntity extends Entity<ChildFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     ChildFields,
     string,
     ViewerContext,
     ChildEntity,
     TestEntityPrivacyPolicy
   > {
-    return childEntityCompanion;
+    return {
+      entityClass: ChildEntity,
+      entityConfiguration: new EntityConfiguration<ChildFields>({
+        idField: 'id',
+        tableName: 'children',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+            cache: true,
+          }),
+          parent_id: new UUIDField({
+            columnName: 'parent_id',
+            cache: true,
+            association: {
+              associatedEntityClass: ParentEntity,
+              edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY,
+            },
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    };
   }
 }
-
-const childEntityConfiguration = new EntityConfiguration<ChildFields>({
-  idField: 'id',
-  tableName: 'children',
-  schema: {
-    id: new UUIDField({
-      columnName: 'id',
-      cache: true,
-    }),
-    parent_id: new UUIDField({
-      columnName: 'parent_id',
-      cache: true,
-      association: {
-        getAssociatedEntityClass: () => ParentEntity,
-        edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE_ONLY,
-      },
-    }),
-  },
-  databaseAdapterFlavor: 'postgres',
-  cacheAdapterFlavor: 'redis',
-});
-
-const childEntityCompanion = new EntityCompanionDefinition({
-  entityClass: ChildEntity,
-  entityConfiguration: childEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-});

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -30,33 +30,29 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerCon
 }
 
 export default class ParentEntity extends Entity<ParentFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     ParentFields,
     string,
     ViewerContext,
     ParentEntity,
     TestEntityPrivacyPolicy
   > {
-    return parentEntityCompanion;
+    return {
+      entityClass: ParentEntity,
+      entityConfiguration: new EntityConfiguration<ParentFields>({
+        idField: 'id',
+        tableName: 'parents',
+        inboundEdges: [ChildEntity],
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+            cache: true,
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    };
   }
 }
-
-const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
-  idField: 'id',
-  tableName: 'parents',
-  getInboundEdges: () => [ChildEntity],
-  schema: {
-    id: new UUIDField({
-      columnName: 'id',
-      cache: true,
-    }),
-  },
-  databaseAdapterFlavor: 'postgres',
-  cacheAdapterFlavor: 'redis',
-});
-
-const parentEntityCompanion = new EntityCompanionDefinition({
-  entityClass: ParentEntity,
-  entityConfiguration: parentEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-});

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -33,14 +33,18 @@ export default class LocalMemoryTestEntity extends Entity<
   string,
   ViewerContext
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     LocalMemoryTestEntityFields,
     string,
     ViewerContext,
     LocalMemoryTestEntity,
     LocalMemoryTestEntityPrivacyPolicy
   > {
-    return localMemoryTestEntityCompanionDefinition;
+    return {
+      entityClass: LocalMemoryTestEntity,
+      entityConfiguration: localMemoryTestEntityConfiguration,
+      privacyPolicyClass: LocalMemoryTestEntityPrivacyPolicy,
+    };
   }
 }
 
@@ -99,12 +103,6 @@ export const localMemoryTestEntityConfiguration =
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'local-memory',
   });
-
-const localMemoryTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: LocalMemoryTestEntity,
-  entityConfiguration: localMemoryTestEntityConfiguration,
-  privacyPolicyClass: LocalMemoryTestEntityPrivacyPolicy,
-});
 
 export const createTestEntityCompanionProvider = (
   metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()

--- a/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
@@ -15,14 +15,18 @@ export type RedisTestEntityFields = {
 };
 
 export default class RedisTestEntity extends Entity<RedisTestEntityFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     RedisTestEntityFields,
     string,
     ViewerContext,
     RedisTestEntity,
     RedisTestEntityPrivacyPolicy
   > {
-    return redisTestEntityCompanionDefinition;
+    return {
+      entityClass: RedisTestEntity,
+      entityConfiguration: redisTestEntityConfiguration,
+      privacyPolicyClass: RedisTestEntityPrivacyPolicy,
+    };
   }
 }
 
@@ -79,10 +83,4 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-});
-
-const redisTestEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: RedisTestEntity,
-  entityConfiguration: redisTestEntityConfiguration,
-  privacyPolicyClass: RedisTestEntityPrivacyPolicy,
 });

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -14,7 +14,7 @@ import { mapMap } from './utils/collections/maps';
  * if the loads are not successful.
  */
 export default class EnforcingEntityLoader<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -26,7 +26,7 @@ import ViewerContext from './ViewerContext';
  * own EntityCompanionDefinition.
  */
 export default abstract class Entity<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields
@@ -38,7 +38,7 @@ export default abstract class Entity<
    * @returns mutator for creating an entity
    */
   static creator<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
@@ -79,7 +79,7 @@ export default abstract class Entity<
    * @returns mutator for updating existingEntity
    */
   static updater<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -120,7 +120,7 @@ export default abstract class Entity<
    * @param queryContext - query context in which to perform the delete
    */
   static deleteAsync<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -162,7 +162,7 @@ export default abstract class Entity<
    * @param queryContext - query context in which to perform the delete
    */
   static enforceDeleteAsync<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -215,7 +215,7 @@ export default abstract class Entity<
    * @param queryContext - query context in which to perform the check
    */
   static async canViewerUpdateAsync<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -246,7 +246,7 @@ export default abstract class Entity<
     const companion = existingEntity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this);
-    const privacyPolicy = new (this.getCompanionDefinition().privacyPolicyClass)();
+    const privacyPolicy = companion.entityCompanion.privacyPolicy;
     const evaluationResult = await asyncResult(
       privacyPolicy.authorizeUpdateAsync(
         existingEntity.getViewerContext(),
@@ -269,7 +269,7 @@ export default abstract class Entity<
    * @param queryContext - query context in which to perform the check
    */
   static async canViewerDeleteAsync<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -300,7 +300,7 @@ export default abstract class Entity<
     const companion = existingEntity
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this);
-    const privacyPolicy = new (this.getCompanionDefinition().privacyPolicyClass)();
+    const privacyPolicy = companion.entityCompanion.privacyPolicy;
     const evaluationResult = await asyncResult(
       privacyPolicy.authorizeDeleteAsync(
         existingEntity.getViewerContext(),
@@ -318,7 +318,7 @@ export default abstract class Entity<
  * An interface to pass in constructor (class) of an Entity as a function argument.
  */
 export interface IEntityClass<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -331,8 +331,13 @@ export interface IEntityClass<
   >,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  new (viewerContext: TViewerContext, obj: Readonly<TFields>): TEntity;
-  getCompanionDefinition(): EntityCompanionDefinition<
+  new (constructorParam: {
+    viewerContext: TViewerContext;
+    id: TID;
+    databaseFields: Readonly<TFields>;
+    selectedFields: Readonly<Pick<TFields, TSelectedFields>>;
+  }): TEntity;
+  defineCompanionDefinition(): EntityCompanionDefinition<
     TFields,
     TID,
     TViewerContext,

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -337,6 +337,12 @@ export interface IEntityClass<
     databaseFields: Readonly<TFields>;
     selectedFields: Readonly<Pick<TFields, TSelectedFields>>;
   }): TEntity;
+
+  /**
+   * Returns a EntityCompanionDefinition for this entity.
+   *
+   * Memoized by the entity framework.
+   */
   defineCompanionDefinition(): EntityCompanionDefinition<
     TFields,
     TID,

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -12,7 +12,7 @@ import ViewerContext from './ViewerContext';
  * by foreign keys.
  */
 export default class EntityAssociationLoader<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -29,7 +29,7 @@ export default class EntityAssociationLoader<
    */
   async loadAssociatedEntityAsync<
     TIdentifyingField extends keyof Pick<TFields, TSelectedFields>,
-    TAssociatedFields,
+    TAssociatedFields extends object,
     TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
@@ -91,7 +91,7 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the load
    */
   async loadManyAssociatedEntitiesAsync<
-    TAssociatedFields,
+    TAssociatedFields extends object,
     TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
@@ -144,7 +144,7 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the load
    */
   async loadAssociatedEntityByFieldEqualingAsync<
-    TAssociatedFields,
+    TAssociatedFields extends object,
     TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
@@ -201,7 +201,7 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the load
    */
   async loadManyAssociatedEntitiesByFieldEqualingAsync<
-    TAssociatedFields,
+    TAssociatedFields extends object,
     TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
@@ -257,7 +257,7 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TFields2,
+    TFields2 extends object,
     TID2 extends NonNullable<TFields2[TSelectedFields2]>,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
@@ -291,7 +291,7 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TFields2,
+    TFields2 extends object,
     TID2 extends NonNullable<TFields2[TSelectedFields2]>,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
@@ -301,7 +301,7 @@ export default class EntityAssociationLoader<
       TEntity2,
       TSelectedFields2
     >,
-    TFields3,
+    TFields3 extends object,
     TID3 extends NonNullable<TFields3[TSelectedFields3]>,
     TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
@@ -346,7 +346,7 @@ export default class EntityAssociationLoader<
    * @param queryContext - query context in which to perform the loads
    */
   async loadAssociatedEntityThroughAsync<
-    TFields2,
+    TFields2 extends object,
     TID2 extends NonNullable<TFields2[TSelectedFields2]>,
     TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
@@ -356,7 +356,7 @@ export default class EntityAssociationLoader<
       TEntity2,
       TSelectedFields2
     >,
-    TFields3,
+    TFields3 extends object,
     TID3 extends NonNullable<TFields3[TSelectedFields3]>,
     TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
@@ -366,7 +366,7 @@ export default class EntityAssociationLoader<
       TEntity3,
       TSelectedFields3
     >,
-    TFields4,
+    TFields4 extends object,
     TID4 extends NonNullable<TFields4[TSelectedFields4]>,
     TEntity4 extends ReadonlyEntity<TFields4, TID4, TViewerContext, TSelectedFields4>,
     TPrivacyPolicy4 extends EntityPrivacyPolicy<
@@ -482,7 +482,7 @@ export default class EntityAssociationLoader<
 export interface EntityLoadThroughDirective<
   TViewerContext extends ViewerContext,
   TFields,
-  TAssociatedFields,
+  TAssociatedFields extends object,
   TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
   TAssociatedEntity extends ReadonlyEntity<
     TAssociatedFields,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -49,8 +49,8 @@ export interface CacheAdapterFlavorDefinition {
  * Definition for constructing a companion for an entity. Defines the core set of objects
  * used to power the entity framework for a particular type of entity.
  */
-export class EntityCompanionDefinition<
-  TFields,
+export interface EntityCompanionDefinition<
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -63,6 +63,9 @@ export class EntityCompanionDefinition<
   >,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
+  /**
+   * The concrete Entity class for which this is the definition.
+   */
   readonly entityClass: IEntityClass<
     TFields,
     TID,
@@ -71,85 +74,45 @@ export class EntityCompanionDefinition<
     TPrivacyPolicy,
     TSelectedFields
   >;
+
+  /**
+   * The EntityConfiguration for this entity.
+   */
   readonly entityConfiguration: EntityConfiguration<TFields>;
+
+  /**
+   * The EntityPrivacyPolicy class for this entity.
+   */
   readonly privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
-  readonly mutationValidators: () => EntityMutationValidator<
+
+  /**
+   * An optional list of EntityMutationValidator for this entity.
+   */
+  readonly mutationValidators?: EntityMutationValidator<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
   >[];
-  readonly mutationTriggers: () => EntityMutationTriggerConfiguration<
+
+  /**
+   * An optional list of EntityMutationTrigger for this entity.
+   */
+  readonly mutationTriggers?: EntityMutationTriggerConfiguration<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
   >;
-  readonly entitySelectedFields: TSelectedFields[];
 
-  constructor({
-    entityClass,
-    entityConfiguration,
-    privacyPolicyClass,
-    mutationValidators = () => [],
-    mutationTriggers = () => ({}),
-    entitySelectedFields = Array.from(entityConfiguration.schema.keys()) as TSelectedFields[],
-  }: {
-    /**
-     * The concrete Entity class for which this is the definition.
-     */
-    entityClass: IEntityClass<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntity,
-      TPrivacyPolicy,
-      TSelectedFields
-    >;
-    /**
-     * The EntityConfiguration for this entity.
-     */
-    entityConfiguration: EntityConfiguration<TFields>;
-    /**
-     * The EntityPrivacyPolicy class for this entity.
-     */
-    privacyPolicyClass: IPrivacyPolicyClass<TPrivacyPolicy>;
-    /**
-     * An optional list of EntityMutationValidator for this entity.
-     */
-    mutationValidators?: () => EntityMutationValidator<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntity,
-      TSelectedFields
-    >[];
-    /**
-     * An optional list of EntityMutationTrigger for this entity.
-     */
-    mutationTriggers?: () => EntityMutationTriggerConfiguration<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntity,
-      TSelectedFields
-    >;
-    /**
-     * An optional subset of fields defined in the EntityConfiguration which belong to this entity.
-     * For use when multiple types of entities are backed by a single table (EntityConfiguration) yet
-     * only expose a subset of the fields.
-     */
-    entitySelectedFields?: TSelectedFields[];
-  }) {
-    this.entityClass = entityClass;
-    this.entityConfiguration = entityConfiguration;
-    this.privacyPolicyClass = privacyPolicyClass;
-    this.mutationValidators = mutationValidators;
-    this.mutationTriggers = mutationTriggers;
-    this.entitySelectedFields = entitySelectedFields;
-  }
+  /**
+   * An optional subset of fields defined in the EntityConfiguration which belong to this entity.
+   * For use when multiple types of entities are backed by a single table (EntityConfiguration) yet
+   * only expose a subset of the fields.
+   */
+  readonly entitySelectedFields?: TSelectedFields[];
 }
 
 /**
@@ -162,6 +125,10 @@ export class EntityCompanionDefinition<
  * EntityCompanion for each type of Entity.
  */
 export default class EntityCompanionProvider {
+  private readonly companionDefinitionMap: Map<
+    string,
+    EntityCompanionDefinition<any, any, any, any, any, any>
+  > = new Map();
   private readonly companionMap: Map<string, EntityCompanion<any, any, any, any, any, any>> =
     new Map();
   private readonly tableDataCoordinatorMap: Map<string, EntityTableDataCoordinator<any>> =
@@ -187,10 +154,9 @@ export default class EntityCompanionProvider {
    * companion is constructed using the configuration provided by the factory.
    *
    * @param entityClass - entity class to load
-   * @param factory - entity companion factory
    */
   getCompanionForEntity<
-    TFields,
+    TFields extends object,
     TID extends NonNullable<TFields[TSelectedFields]>,
     TViewerContext extends ViewerContext,
     TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -210,27 +176,22 @@ export default class EntityCompanionProvider {
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
-    >,
-    entityCompanionDefinition: EntityCompanionDefinition<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntity,
-      TPrivacyPolicy,
-      TSelectedFields
     >
   ): EntityCompanion<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
+    const entityCompanionDefinition = computeIfAbsent(
+      this.companionDefinitionMap,
+      entityClass.name,
+      () => entityClass.defineCompanionDefinition()
+    );
     const tableDataCoordinator = this.getTableDataCoordinatorForEntity(
       entityCompanionDefinition.entityConfiguration,
       entityClass.name
     );
     return computeIfAbsent(this.companionMap, entityClass.name, () => {
       return new EntityCompanion(
-        entityCompanionDefinition.entityClass,
+        this,
+        entityCompanionDefinition,
         tableDataCoordinator,
-        entityCompanionDefinition.privacyPolicyClass,
-        entityCompanionDefinition.mutationValidators(),
-        entityCompanionDefinition.mutationTriggers(),
         this.metricsAdapter
       );
     });

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -13,7 +13,7 @@ export default class EntityConfiguration<TFields> {
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly cacheKeyVersion: number;
 
-  readonly getInboundEdges: () => IEntityClass<any, any, any, any, any, any>[];
+  readonly inboundEdges: IEntityClass<any, any, any, any, any, any>[];
   readonly schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>;
   readonly entityToDBFieldsKeyMapping: ReadonlyMap<keyof TFields, string>;
   readonly dbToEntityFieldsKeyMapping: ReadonlyMap<string, keyof TFields>;
@@ -25,7 +25,7 @@ export default class EntityConfiguration<TFields> {
     idField,
     tableName,
     schema,
-    getInboundEdges = () => [],
+    inboundEdges = [],
     cacheKeyVersion = 0,
     databaseAdapterFlavor,
     cacheAdapterFlavor,
@@ -48,7 +48,7 @@ export default class EntityConfiguration<TFields> {
     /**
      * List of other entity types that reference this type in EntityFieldDefinition associations.
      */
-    getInboundEdges?: () => IEntityClass<any, any, any, any, any, any>[];
+    inboundEdges?: IEntityClass<any, any, any, any, any, any>[];
 
     /**
      * Cache key version for this entity type. Should be bumped when a field is added to, removed from, or changed
@@ -71,8 +71,7 @@ export default class EntityConfiguration<TFields> {
     this.cacheKeyVersion = cacheKeyVersion;
     this.databaseAdapterFlavor = databaseAdapterFlavor;
     this.cacheAdapterFlavor = cacheAdapterFlavor;
-
-    this.getInboundEdges = getInboundEdges;
+    this.inboundEdges = inboundEdges;
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups

--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -41,7 +41,7 @@ export enum EntityEdgeDeletionBehavior {
  */
 export interface EntityAssociationDefinition<
   TViewerContext extends ViewerContext,
-  TAssociatedFields,
+  TAssociatedFields extends object,
   TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
   TAssociatedEntity extends ReadonlyEntity<
     TAssociatedFields,
@@ -61,7 +61,7 @@ export interface EntityAssociationDefinition<
   /**
    * Class of entity on the other end of this edge.
    */
-  getAssociatedEntityClass: () => IEntityClass<
+  associatedEntityClass: IEntityClass<
     TAssociatedFields,
     TAssociatedID,
     TViewerContext,

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -1,5 +1,4 @@
-import { IEntityClass } from './Entity';
-import EntityConfiguration from './EntityConfiguration';
+import EntityCompanion from './EntityCompanion';
 import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -12,7 +11,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  * The primary entry point for loading entities.
  */
 export default class EntityLoaderFactory<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -26,8 +25,7 @@ export default class EntityLoaderFactory<
   TSelectedFields extends keyof TFields
 > {
   constructor(
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
-    private readonly entityClass: IEntityClass<
+    private readonly entityCompanion: EntityCompanion<
       TFields,
       TID,
       TViewerContext,
@@ -35,7 +33,6 @@ export default class EntityLoaderFactory<
       TPrivacyPolicy,
       TSelectedFields
     >,
-    private readonly privacyPolicyClass: TPrivacyPolicy,
     private readonly dataManager: EntityDataManager<TFields>,
     protected readonly metricsAdapter: IEntityMetricsAdapter
   ) {}
@@ -54,9 +51,10 @@ export default class EntityLoaderFactory<
       viewerContext,
       queryContext,
       privacyPolicyEvaluationContext,
-      this.entityConfiguration,
-      this.entityClass,
-      this.privacyPolicyClass,
+      this.entityCompanion.entityCompanionDefinition.entityConfiguration,
+      this.entityCompanion.entityCompanionDefinition.entityClass,
+      this.entityCompanion.entityCompanionDefinition.entitySelectedFields,
+      this.entityCompanion.privacyPolicy,
       this.dataManager,
       this.metricsAdapter
     );

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -8,7 +8,7 @@ export enum EntityMutationType {
 }
 
 export type EntityValidatorMutationInfo<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -39,7 +39,7 @@ export type EntityCascadingDeletionInfo = {
 };
 
 export type EntityTriggerMutationInfo<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -7,7 +7,7 @@ import ViewerContext from './ViewerContext';
  * Interface to define trigger behavior for entities.
  */
 export default interface EntityMutationTriggerConfiguration<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -70,7 +70,7 @@ export default interface EntityMutationTriggerConfiguration<
  * the transaction if a transaction is supplied.
  */
 export abstract class EntityMutationTrigger<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -89,7 +89,7 @@ export abstract class EntityMutationTrigger<
  * since they explicitly occur outside of the transaction.
  */
 export abstract class EntityNonTransactionalMutationTrigger<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -8,7 +8,7 @@ import ViewerContext from './ViewerContext';
  * same transaction as the mutation itself before creating or updating an entity.
  */
 export default abstract class EntityMutationValidator<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -1,4 +1,5 @@
 import Entity, { IEntityClass } from './Entity';
+import EntityCompanionProvider from './EntityCompanionProvider';
 import EntityConfiguration from './EntityConfiguration';
 import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
@@ -14,7 +15,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  * The primary interface for creating, mutating, and deleting entities.
  */
 export default class EntityMutatorFactory<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -28,6 +29,7 @@ export default class EntityMutatorFactory<
   TSelectedFields extends keyof TFields = keyof TFields
 > {
   constructor(
+    private readonly entityCompanionProvider: EntityCompanionProvider,
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly entityClass: IEntityClass<
       TFields,
@@ -75,6 +77,7 @@ export default class EntityMutatorFactory<
     queryContext: EntityQueryContext
   ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new CreateMutator(
+      this.entityCompanionProvider,
       viewerContext,
       queryContext,
       this.entityConfiguration,
@@ -99,6 +102,7 @@ export default class EntityMutatorFactory<
     queryContext: EntityQueryContext
   ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new UpdateMutator(
+      this.entityCompanionProvider,
       existingEntity.getViewerContext(),
       queryContext,
       this.entityConfiguration,
@@ -123,6 +127,7 @@ export default class EntityMutatorFactory<
     queryContext: EntityQueryContext
   ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     return new DeleteMutator(
+      this.entityCompanionProvider,
       existingEntity.getViewerContext(),
       queryContext,
       this.entityConfiguration,

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -41,7 +41,7 @@ export enum EntityPrivacyPolicyEvaluationMode {
 }
 
 export type EntityPrivacyPolicyEvaluator<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -92,7 +92,7 @@ export enum EntityAuthorizationAction {
  * ```
  */
 export default abstract class EntityPrivacyPolicy<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -45,7 +45,7 @@ export interface ISecondaryEntityCache<TFields, TLoadParams> {
  */
 export default abstract class EntitySecondaryCacheLoader<
   TLoadParams,
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -31,7 +31,7 @@ export default class ViewerContext {
   }
 
   getViewerScopedEntityCompanionForClass<
-    TMFields,
+    TMFields extends object,
     TMID extends NonNullable<TMFields[TMSelectedFields]>,
     TMViewerContext extends ViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
@@ -60,10 +60,7 @@ export default class ViewerContext {
     TMPrivacyPolicy,
     TMSelectedFields
   > {
-    return this.viewerScopedEntityCompanionProvider.getViewerScopedCompanionForEntity(
-      entityClass,
-      entityClass.getCompanionDefinition()
-    );
+    return this.viewerScopedEntityCompanionProvider.getViewerScopedCompanionForEntity(entityClass);
   }
 
   /**

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -12,7 +12,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  * from the viewer-scoped entity companion provider.
  */
 export default class ViewerScopedEntityCompanion<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -26,7 +26,7 @@ export default class ViewerScopedEntityCompanion<
   TSelectedFields extends keyof TFields
 > {
   constructor(
-    private readonly entityCompanion: EntityCompanion<
+    public readonly entityCompanion: EntityCompanion<
       TFields,
       TID,
       TViewerContext,

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -1,5 +1,5 @@
 import { IEntityClass } from './Entity';
-import EntityCompanionProvider, { EntityCompanionDefinition } from './EntityCompanionProvider';
+import EntityCompanionProvider from './EntityCompanionProvider';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
@@ -19,10 +19,10 @@ export default class ViewerScopedEntityCompanionProvider {
    * companion is constructed using the configuration provided by the factory.
    *
    * @param entityClass - entity class to load
-   * @param factory - entity companion factory
+   * @param entityCompanionDefinitionFn - function defining entity companion definition
    */
   getViewerScopedCompanionForEntity<
-    TFields,
+    TFields extends object,
     TID extends NonNullable<TFields[TSelectedFields]>,
     TViewerContext extends ViewerContext,
     TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -42,14 +42,6 @@ export default class ViewerScopedEntityCompanionProvider {
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
-    >,
-    entityCompanionDefinition: EntityCompanionDefinition<
-      TFields,
-      TID,
-      TViewerContext,
-      TEntity,
-      TPrivacyPolicy,
-      TSelectedFields
     >
   ): ViewerScopedEntityCompanion<
     TFields,
@@ -60,7 +52,7 @@ export default class ViewerScopedEntityCompanionProvider {
     TSelectedFields
   > {
     return new ViewerScopedEntityCompanion(
-      this.entityCompanionProvider.getCompanionForEntity(entityClass, entityCompanionDefinition),
+      this.entityCompanionProvider.getCompanionForEntity(entityClass),
       this.viewerContext as TViewerContext
     );
   }

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -9,7 +9,7 @@ import ViewerContext from './ViewerContext';
  * Provides a cleaner API for loading entities by passing through the ViewerContext.
  */
 export default class ViewerScopedEntityLoaderFactory<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -9,7 +9,7 @@ import ViewerContext from './ViewerContext';
  * Provides a cleaner API for mutating entities by passing through the ViewerContext.
  */
 export default class ViewerScopedEntityMutatorFactory<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -330,6 +330,7 @@ describe(EnforcingEntityLoader, () => {
       'tryConstructEntities',
       'validateFieldValues',
       'constructAndAuthorizeEntitiesAsync',
+      'constructEntity',
     ];
     expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));
 

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -26,7 +26,12 @@ describe(Entity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestEntity(viewerContext, data);
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       expect(SimpleTestEntity.updater(testEntity)).toBeInstanceOf(UpdateMutator);
     });
   });
@@ -38,7 +43,12 @@ describe(Entity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestDenyDeleteEntity(viewerContext, data);
+      const testEntity = new SimpleTestDenyDeleteEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       const canViewerUpdate = await SimpleTestDenyDeleteEntity.canViewerUpdateAsync(testEntity);
       expect(canViewerUpdate).toBe(true);
     });
@@ -49,7 +59,12 @@ describe(Entity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestDenyUpdateEntity(viewerContext, data);
+      const testEntity = new SimpleTestDenyUpdateEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       const canViewerUpdate = await SimpleTestDenyUpdateEntity.canViewerUpdateAsync(testEntity);
       expect(canViewerUpdate).toBe(false);
     });
@@ -62,7 +77,12 @@ describe(Entity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestDenyUpdateEntity(viewerContext, data);
+      const testEntity = new SimpleTestDenyUpdateEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       const canViewerDelete = await SimpleTestDenyUpdateEntity.canViewerDeleteAsync(testEntity);
       expect(canViewerDelete).toBe(true);
     });
@@ -73,7 +93,12 @@ describe(Entity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestDenyDeleteEntity(viewerContext, data);
+      const testEntity = new SimpleTestDenyDeleteEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       const canViewerDelete = await SimpleTestDenyDeleteEntity.canViewerDeleteAsync(testEntity);
       expect(canViewerDelete).toBe(false);
     });
@@ -177,37 +202,33 @@ class SimpleTestDenyDeleteEntityPrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestEntityFields,
     string,
     ViewerContext,
     SimpleTestDenyUpdateEntity,
     SimpleTestDenyUpdateEntityPrivacyPolicy
   > {
-    return simpleTestDenyUpdateEntityCompanion;
+    return {
+      entityClass: SimpleTestDenyUpdateEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: SimpleTestDenyUpdateEntityPrivacyPolicy,
+    };
   }
 }
 
-const simpleTestDenyUpdateEntityCompanion = new EntityCompanionDefinition({
-  entityClass: SimpleTestDenyUpdateEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: SimpleTestDenyUpdateEntityPrivacyPolicy,
-});
-
 class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestEntityFields,
     string,
     ViewerContext,
     SimpleTestDenyDeleteEntity,
     SimpleTestDenyDeleteEntityPrivacyPolicy
   > {
-    return simpleTestDenyDeleteEntityCompanion;
+    return {
+      entityClass: SimpleTestDenyDeleteEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: SimpleTestDenyDeleteEntityPrivacyPolicy,
+    };
   }
 }
-
-const simpleTestDenyDeleteEntityCompanion = new EntityCompanionDefinition({
-  entityClass: SimpleTestDenyDeleteEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: SimpleTestDenyDeleteEntityPrivacyPolicy,
-});

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -31,14 +31,32 @@ type BlahFields = {
 };
 
 class BlahEntity extends Entity<BlahFields, string, TestUserViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
     string,
     TestUserViewerContext,
     BlahEntity,
     BlahEntityPrivacyPolicy
   > {
-    return blahCompanion;
+    return {
+      entityClass: BlahEntity,
+      entityConfiguration: new EntityConfiguration<BlahFields>({
+        idField: 'id',
+        tableName: 'blah_table',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+            cache: true,
+          }),
+          ownerID: new UUIDField({
+            columnName: 'owner_id',
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: BlahEntityPrivacyPolicy,
+    };
   }
 }
 
@@ -83,26 +101,6 @@ class BlahEntityPrivacyPolicy extends EntityPrivacyPolicy<
     new AlwaysDenyPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
   ];
 }
-
-const blahCompanion = new EntityCompanionDefinition({
-  entityClass: BlahEntity,
-  entityConfiguration: new EntityConfiguration<BlahFields>({
-    idField: 'id',
-    tableName: 'blah_table',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-        cache: true,
-      }),
-      ownerID: new UUIDField({
-        columnName: 'owner_id',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  }),
-  privacyPolicyClass: BlahEntityPrivacyPolicy,
-});
 
 it('runs through a common workflow', async () => {
   // will be one entity companion provider for each request, so

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -1,27 +1,24 @@
 import { instance, mock, when } from 'ts-mockito';
 
 import EntityCompanion from '../EntityCompanion';
+import EntityCompanionProvider from '../EntityCompanionProvider';
 import EntityLoaderFactory from '../EntityLoaderFactory';
 import EntityMutatorFactory from '../EntityMutatorFactory';
 import EntityTableDataCoordinator from '../internal/EntityTableDataCoordinator';
 import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
-import TestEntity, {
-  TestEntityPrivacyPolicy,
-  testEntityConfiguration,
-  TestFields,
-} from '../testfixtures/TestEntity';
+import TestEntity, { testEntityConfiguration, TestFields } from '../testfixtures/TestEntity';
 
 describe(EntityCompanion, () => {
   it('correctly instantiates mutator and loader factories', () => {
+    const entityCompanionProvider = instance(mock<EntityCompanionProvider>());
+
     const tableDataCoordinatorMock = mock<EntityTableDataCoordinator<TestFields>>();
     when(tableDataCoordinatorMock.entityConfiguration).thenReturn(testEntityConfiguration);
 
     const companion = new EntityCompanion(
-      TestEntity,
+      entityCompanionProvider,
+      TestEntity.defineCompanionDefinition(),
       instance(tableDataCoordinatorMock),
-      TestEntityPrivacyPolicy,
-      [],
-      {},
       instance(mock<IEntityMetricsAdapter>())
     );
     expect(companion.getLoaderFactory()).toBeInstanceOf(EntityLoaderFactory);

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -23,26 +23,34 @@ const blahConfiguration = new EntityConfiguration<BlahFields>({
 });
 
 class Blah1Entity extends Entity<BlahFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
     string,
     ViewerContext,
     Blah1Entity,
     NoOpTest1PrivacyPolicy
   > {
-    return blah1CompanionDefinition;
+    return {
+      entityClass: Blah1Entity,
+      entityConfiguration: blahConfiguration,
+      privacyPolicyClass: NoOpTest1PrivacyPolicy,
+    };
   }
 }
 
 class Blah2Entity extends Entity<BlahFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
     string,
     ViewerContext,
     Blah2Entity,
     NoOpTest2PrivacyPolicy
   > {
-    return blah2CompanionDefinition;
+    return {
+      entityClass: Blah2Entity,
+      entityConfiguration: blahConfiguration,
+      privacyPolicyClass: NoOpTest2PrivacyPolicy,
+    };
   }
 }
 
@@ -59,31 +67,11 @@ class NoOpTest2PrivacyPolicy extends EntityPrivacyPolicy<
   Blah2Entity
 > {}
 
-const blah1CompanionDefinition = new EntityCompanionDefinition({
-  entityClass: Blah1Entity,
-  entityConfiguration: blahConfiguration,
-  privacyPolicyClass: NoOpTest1PrivacyPolicy,
-});
-
-const blah2CompanionDefinition = new EntityCompanionDefinition({
-  entityClass: Blah2Entity,
-  entityConfiguration: blahConfiguration,
-  privacyPolicyClass: NoOpTest2PrivacyPolicy,
-});
-
 describe(EntityCompanionProvider, () => {
   it('returns different instances for different entity types, but share table data coordinators', () => {
     const entityCompanionProvider = createUnitTestEntityCompanionProvider();
-    const companion1 = entityCompanionProvider.getCompanionForEntity(
-      Blah1Entity,
-      blah1CompanionDefinition
-    );
-
-    const companion2 = entityCompanionProvider.getCompanionForEntity(
-      Blah2Entity,
-      blah2CompanionDefinition
-    );
-
+    const companion1 = entityCompanionProvider.getCompanionForEntity(Blah1Entity);
+    const companion2 = entityCompanionProvider.getCompanionForEntity(Blah2Entity);
     expect(companion1).not.toEqual(companion2);
     expect(companion1['tableDataCoordinator']).toEqual(companion2['tableDataCoordinator']);
   });

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -322,45 +322,78 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
   }
 
   class ParentEntity extends Entity<ParentFields, string, TestViewerContext> {
-    static getCompanionDefinition(): EntityCompanionDefinition<
+    static defineCompanionDefinition(): EntityCompanionDefinition<
       ParentFields,
       string,
       TestViewerContext,
       ParentEntity,
       TestEntityPrivacyPolicy
     > {
-      return parentEntityCompanion;
+      return {
+        entityClass: ParentEntity,
+        entityConfiguration: parentEntityConfiguration,
+        privacyPolicyClass: TestEntityPrivacyPolicy,
+        mutationTriggers: {
+          beforeDelete: [new ParentCheckInfoDeletionTrigger()],
+          afterDelete: [new ParentCheckInfoDeletionTrigger()],
+
+          beforeUpdate: [new ParentCheckInfoUpdateTrigger()],
+          afterUpdate: [new ParentCheckInfoUpdateTrigger()],
+        },
+      };
     }
   }
 
   class ChildEntity extends Entity<ChildFields, string, TestViewerContext> {
-    static getCompanionDefinition(): EntityCompanionDefinition<
+    static defineCompanionDefinition(): EntityCompanionDefinition<
       ChildFields,
       string,
       TestViewerContext,
       ChildEntity,
       TestEntityPrivacyPolicy
     > {
-      return childEntityCompanion;
+      return {
+        entityClass: ChildEntity,
+        entityConfiguration: childEntityConfiguration,
+        privacyPolicyClass: TestEntityPrivacyPolicy,
+        mutationTriggers: {
+          beforeDelete: [new ChildCheckInfoDeletionTrigger()],
+          afterDelete: [new ChildCheckInfoDeletionTrigger()],
+
+          beforeUpdate: [new ChildCheckInfoUpdateTrigger()],
+          afterUpdate: [new ChildCheckInfoUpdateTrigger()],
+        },
+      };
     }
   }
 
   class GrandChildEntity extends Entity<GrandChildFields, string, TestViewerContext> {
-    static getCompanionDefinition(): EntityCompanionDefinition<
+    static defineCompanionDefinition(): EntityCompanionDefinition<
       GrandChildFields,
       string,
       TestViewerContext,
       GrandChildEntity,
       TestEntityPrivacyPolicy
     > {
-      return grandChildEntityCompanion;
+      return {
+        entityClass: GrandChildEntity,
+        entityConfiguration: grandChildEntityConfiguration,
+        privacyPolicyClass: TestEntityPrivacyPolicy,
+        mutationTriggers: {
+          beforeDelete: [new GrandChildCheckInfoDeletionTrigger()],
+          afterDelete: [new GrandChildCheckInfoDeletionTrigger()],
+
+          beforeUpdate: [new GrandChildCheckInfoUpdateTrigger()],
+          afterUpdate: [new GrandChildCheckInfoUpdateTrigger()],
+        },
+      };
     }
   }
 
   const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
     idField: 'id',
     tableName: 'parents',
-    getInboundEdges: () => [ChildEntity],
+    inboundEdges: [ChildEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -374,7 +407,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
   const childEntityConfiguration = new EntityConfiguration<ChildFields>({
     idField: 'id',
     tableName: 'children',
-    getInboundEdges: () => [GrandChildEntity],
+    inboundEdges: [GrandChildEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -384,7 +417,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         columnName: 'parent_id',
         cache: true,
         association: {
-          getAssociatedEntityClass: () => ParentEntity,
+          associatedEntityClass: ParentEntity,
           edgeDeletionBehavior,
         },
       }),
@@ -405,52 +438,13 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
         columnName: 'parent_id',
         cache: true,
         association: {
-          getAssociatedEntityClass: () => ChildEntity,
+          associatedEntityClass: ChildEntity,
           edgeDeletionBehavior,
         },
       }),
     },
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'redis',
-  });
-
-  const parentEntityCompanion = new EntityCompanionDefinition({
-    entityClass: ParentEntity,
-    entityConfiguration: parentEntityConfiguration,
-    privacyPolicyClass: TestEntityPrivacyPolicy,
-    mutationTriggers: () => ({
-      beforeDelete: [new ParentCheckInfoDeletionTrigger()],
-      afterDelete: [new ParentCheckInfoDeletionTrigger()],
-
-      beforeUpdate: [new ParentCheckInfoUpdateTrigger()],
-      afterUpdate: [new ParentCheckInfoUpdateTrigger()],
-    }),
-  });
-
-  const childEntityCompanion = new EntityCompanionDefinition({
-    entityClass: ChildEntity,
-    entityConfiguration: childEntityConfiguration,
-    privacyPolicyClass: TestEntityPrivacyPolicy,
-    mutationTriggers: () => ({
-      beforeDelete: [new ChildCheckInfoDeletionTrigger()],
-      afterDelete: [new ChildCheckInfoDeletionTrigger()],
-
-      beforeUpdate: [new ChildCheckInfoUpdateTrigger()],
-      afterUpdate: [new ChildCheckInfoUpdateTrigger()],
-    }),
-  });
-
-  const grandChildEntityCompanion = new EntityCompanionDefinition({
-    entityClass: GrandChildEntity,
-    entityConfiguration: grandChildEntityConfiguration,
-    privacyPolicyClass: TestEntityPrivacyPolicy,
-    mutationTriggers: () => ({
-      beforeDelete: [new GrandChildCheckInfoDeletionTrigger()],
-      afterDelete: [new GrandChildCheckInfoDeletionTrigger()],
-
-      beforeUpdate: [new GrandChildCheckInfoUpdateTrigger()],
-      afterUpdate: [new GrandChildCheckInfoUpdateTrigger()],
-    }),
   });
 
   return {

--- a/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
@@ -87,17 +87,22 @@ export default class TestEntity extends Entity<
   ViewerContext,
   TestFieldSelection
 > {
-  constructor(viewerContext: ViewerContext, rawFields: Readonly<TestFields>) {
-    if (rawFields.id === ID_SENTINEL_THROW_LITERAL) {
+  constructor(constructorParams: {
+    viewerContext: ViewerContext;
+    id: string;
+    databaseFields: Readonly<TestFields>;
+    selectedFields: Readonly<TestFields>;
+  }) {
+    if (constructorParams.selectedFields.id === ID_SENTINEL_THROW_LITERAL) {
       // eslint-disable-next-line no-throw-literal,@typescript-eslint/no-throw-literal
       throw 'hello';
-    } else if (rawFields.id === ID_SENTINEL_THROW_ERROR) {
+    } else if (constructorParams.selectedFields.id === ID_SENTINEL_THROW_ERROR) {
       throw new Error('world');
     }
-    super(viewerContext, rawFields);
+    super(constructorParams);
   }
 
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
@@ -105,15 +110,13 @@ export default class TestEntity extends Entity<
     TestEntityPrivacyPolicy,
     TestFieldSelection
   > {
-    return testEntityCompanion;
+    return {
+      entityClass: TestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    };
   }
 }
-
-export const testEntityCompanion = new EntityCompanionDefinition({
-  entityClass: TestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-});
 
 describe(EntityLoader, () => {
   it('handles thrown errors and literals from constructor', async () => {
@@ -158,6 +161,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManager,
       metricsAdapter

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -75,6 +75,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManager,
       metricsAdapter
@@ -177,6 +178,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManager,
       metricsAdapter
@@ -275,6 +277,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManager,
       metricsAdapter
@@ -353,6 +356,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManager,
       metricsAdapter
@@ -385,6 +389,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManagerInstance,
       metricsAdapter
@@ -412,6 +417,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManagerInstance,
       metricsAdapter
@@ -442,6 +448,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManagerInstance,
       metricsAdapter
@@ -486,6 +493,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManagerInstance,
       metricsAdapter
@@ -519,6 +527,7 @@ describe(EntityLoader, () => {
       privacyPolicyEvaluationContext,
       testEntityConfiguration,
       TestEntity,
+      /* entitySelectedFields */ undefined,
       privacyPolicy,
       dataManagerInstance,
       metricsAdapter

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -34,36 +34,34 @@ class BlahEntityPrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
     string,
     ViewerContext,
     BlahEntity,
     BlahEntityPrivacyPolicy
   > {
-    return blahCompanion;
+    return {
+      entityClass: BlahEntity,
+      entityConfiguration: new EntityConfiguration<BlahFields>({
+        idField: 'id',
+        tableName: 'blah_table',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+            cache: true,
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: BlahEntityPrivacyPolicy,
+      mutationTriggers: {
+        afterCommit: [new TestNonTransactionalMutationTrigger()],
+      },
+    };
   }
 }
-
-const blahCompanion = new EntityCompanionDefinition({
-  entityClass: BlahEntity,
-  entityConfiguration: new EntityConfiguration<BlahFields>({
-    idField: 'id',
-    tableName: 'blah_table',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-        cache: true,
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  }),
-  privacyPolicyClass: BlahEntityPrivacyPolicy,
-  mutationTriggers: () => ({
-    afterCommit: [new TestNonTransactionalMutationTrigger()],
-  }),
-});
 
 class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutationTrigger<
   BlahFields,

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -26,14 +26,28 @@ type BlahFields = {
 };
 
 class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
     string,
     ViewerContext,
     BlahEntity,
     any
   > {
-    return blahEntityCompanionDefinition;
+    return {
+      entityClass: BlahEntity,
+      entityConfiguration: new EntityConfiguration<BlahFields>({
+        idField: 'id',
+        tableName: 'blah_table',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: AlwaysDenyPolicy,
+    };
   }
 }
 
@@ -226,22 +240,6 @@ class EmptyPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext,
   protected override readonly deleteRules = [];
 }
 
-const blahEntityCompanionDefinition = new EntityCompanionDefinition({
-  entityClass: BlahEntity,
-  entityConfiguration: new EntityConfiguration<BlahFields>({
-    idField: 'id',
-    tableName: 'blah_table',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  }),
-  privacyPolicyClass: AlwaysDenyPolicy,
-});
-
 describe(EntityPrivacyPolicy, () => {
   describe(EntityPrivacyPolicyEvaluationMode.ENFORCE.toString(), () => {
     it('throws EntityNotAuthorizedError when deny', async () => {
@@ -250,7 +248,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new AlwaysDenyPolicy();
       await expect(
         policy.authorizeCreateAsync(
@@ -279,7 +282,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new AlwaysAllowPolicy();
       const approvedEntity = await policy.authorizeCreateAsync(
         viewerContext,
@@ -307,7 +315,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new SkipAllPolicy();
       await expect(
         policy.authorizeCreateAsync(
@@ -336,7 +349,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new EmptyPolicy();
       await expect(
         policy.authorizeCreateAsync(
@@ -365,7 +383,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new ThrowAllPolicy();
       await expect(
         policy.authorizeCreateAsync(
@@ -387,7 +410,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new DryRunAlwaysDenyPolicy();
 
       const policySpy = spy(policy);
@@ -421,7 +449,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new DryRunAlwaysAllowPolicy();
 
       const policySpy = spy(policy);
@@ -455,7 +488,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new DryRunThrowAllPolicy();
 
       const policySpy = spy(policy);
@@ -483,7 +521,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new LoggingEnforceAlwaysDenyPolicy();
 
       const policySpy = spy(policy);
@@ -518,7 +561,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new LoggingEnforceAlwaysAllowPolicy();
 
       const policySpy = spy(policy);
@@ -552,7 +600,12 @@ describe(EntityPrivacyPolicy, () => {
       const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
-      const entity = new BlahEntity(viewerContext, { id: '1' });
+      const entity = new BlahEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: { id: '1' },
+        selectedFields: { id: '1' },
+      });
       const policy = new LoggingEnforceThrowAllPolicy();
 
       const policySpy = spy(policy);

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -39,21 +39,25 @@ class CategoryPrivacyPolicy extends EntityPrivacyPolicy<
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
   class CategoryEntity extends Entity<CategoryFields, string, TestViewerContext> {
-    static getCompanionDefinition(): EntityCompanionDefinition<
+    static defineCompanionDefinition(): EntityCompanionDefinition<
       CategoryFields,
       string,
       TestViewerContext,
       CategoryEntity,
       CategoryPrivacyPolicy
     > {
-      return categoryEntityCompanion;
+      return {
+        entityClass: CategoryEntity,
+        entityConfiguration: categoryEntityConfiguration,
+        privacyPolicyClass: CategoryPrivacyPolicy,
+      };
     }
   }
 
   const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
     idField: 'id',
     tableName: 'categories',
-    getInboundEdges: () => [CategoryEntity],
+    inboundEdges: [CategoryEntity],
     schema: {
       id: new UUIDField({
         columnName: 'id',
@@ -63,19 +67,13 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
         columnName: 'parent_category_id',
         cache: true,
         association: {
-          getAssociatedEntityClass: () => CategoryEntity,
+          associatedEntityClass: CategoryEntity,
           edgeDeletionBehavior,
         },
       }),
     },
     databaseAdapterFlavor: 'postgres',
     cacheAdapterFlavor: 'redis',
-  });
-
-  const categoryEntityCompanion = new EntityCompanionDefinition({
-    entityClass: CategoryEntity,
-    entityConfiguration: categoryEntityConfiguration,
-    privacyPolicyClass: CategoryPrivacyPolicy,
   });
 
   return {

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -15,7 +15,12 @@ describe(ReadonlyEntity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestEntity(viewerContext, data);
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       expect(testEntity.getID()).toEqual('what');
     });
   });
@@ -26,7 +31,12 @@ describe(ReadonlyEntity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestEntity(viewerContext, data);
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       expect(testEntity.toString()).toEqual('SimpleTestEntity[what]');
     });
   });
@@ -34,11 +44,25 @@ describe(ReadonlyEntity, () => {
   describe('getUniqueIdentifier', () => {
     it('returns a different value for two different entities of the same type', () => {
       const viewerContext = instance(mock(ViewerContext));
-      const testEntity = new SimpleTestEntity(viewerContext, {
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
         id: '1',
+        databaseFields: {
+          id: '1',
+        },
+        selectedFields: {
+          id: '1',
+        },
       });
-      const testEntity2 = new SimpleTestEntity(viewerContext, {
+      const testEntity2 = new SimpleTestEntity({
+        viewerContext,
         id: '2',
+        databaseFields: {
+          id: '2',
+        },
+        selectedFields: {
+          id: '2',
+        },
       });
       expect(testEntity.getUniqueIdentifier()).not.toEqual(testEntity2.getUniqueIdentifier());
     });
@@ -47,22 +71,43 @@ describe(ReadonlyEntity, () => {
       const viewerContext = instance(mock(ViewerContext));
       const viewerContext2 = instance(mock(ViewerContext));
       const data = { id: '1' };
-      const testEntity = new SimpleTestEntity(viewerContext, data);
-      const testEntity2 = new SimpleTestEntity(viewerContext2, data);
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: data,
+        selectedFields: data,
+      });
+      const testEntity2 = new SimpleTestEntity({
+        viewerContext: viewerContext2,
+        id: '1',
+        databaseFields: data,
+        selectedFields: data,
+      });
       expect(testEntity.getUniqueIdentifier()).toEqual(testEntity2.getUniqueIdentifier());
     });
 
     it('returns a different value for different entities even if same ID', () => {
       const viewerContext = instance(mock(ViewerContext));
       const data = { id: '1' };
-      const testEntity = new SimpleTestEntity(viewerContext, data);
-      const testEntity2 = new TestEntity(viewerContext, {
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
+      const data2 = {
         customIdField: '1',
         testIndexedField: '2',
         stringField: '3',
         intField: 4,
         dateField: new Date(),
         nullableField: null,
+      };
+      const testEntity2 = new TestEntity({
+        viewerContext,
+        id: '1',
+        databaseFields: data2,
+        selectedFields: data2,
       });
       expect(testEntity.getUniqueIdentifier()).not.toEqual(testEntity2.getUniqueIdentifier());
     });
@@ -72,16 +117,27 @@ describe(ReadonlyEntity, () => {
     const viewerContext = instance(mock(ViewerContext));
     const dataWithoutID = {};
     expect(() => {
-      new SimpleTestEntity(viewerContext, dataWithoutID as any); // eslint-disable-line no-new
+      // eslint-disable-next-line no-new
+      new SimpleTestEntity({
+        viewerContext,
+        id: undefined as any,
+        databaseFields: dataWithoutID as any,
+        selectedFields: dataWithoutID as any,
+      });
     }).toThrow();
   });
 
-  it('returns correct viewerContext from instantiation', () => {
+  it('returns correct viewerCo}ntext from instantiation', () => {
     const viewerContext = instance(mock(ViewerContext));
     const data = {
       id: 'what',
     };
-    const testEntity = new SimpleTestEntity(viewerContext, data);
+    const testEntity = new SimpleTestEntity({
+      viewerContext,
+      id: 'what',
+      databaseFields: data,
+      selectedFields: data,
+    });
     expect(testEntity.getViewerContext()).toBe(viewerContext);
   });
 
@@ -90,7 +146,12 @@ describe(ReadonlyEntity, () => {
     const data = {
       id: 'what',
     };
-    const testEntity = new SimpleTestEntity(viewerContext, data);
+    const testEntity = new SimpleTestEntity({
+      viewerContext,
+      id: 'what',
+      databaseFields: data,
+      selectedFields: data,
+    });
     expect(testEntity.getField('id')).toEqual('what');
     expect(testEntity.getAllFields()).toEqual(data);
   });
@@ -102,7 +163,12 @@ describe(ReadonlyEntity, () => {
       const data = {
         id: 'what',
       };
-      const testEntity = new SimpleTestEntity(viewerContext, data);
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
       expect(testEntity.associationLoader()).toBeInstanceOf(EntityAssociationLoader);
     });
   });

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanionProvider-test.ts
@@ -4,7 +4,7 @@ import EntityCompanionProvider from '../EntityCompanionProvider';
 import ViewerContext from '../ViewerContext';
 import ViewerScopedEntityCompanion from '../ViewerScopedEntityCompanion';
 import ViewerScopedEntityCompanionProvider from '../ViewerScopedEntityCompanionProvider';
-import TestEntity, { testEntityCompanion } from '../testfixtures/TestEntity';
+import TestEntity from '../testfixtures/TestEntity';
 
 describe(ViewerScopedEntityCompanionProvider, () => {
   it('returns viewer scoped entity companion', () => {
@@ -15,10 +15,7 @@ describe(ViewerScopedEntityCompanionProvider, () => {
       vc
     );
     expect(
-      viewerScopedEntityCompanionProvider.getViewerScopedCompanionForEntity(
-        TestEntity,
-        testEntityCompanion
-      )
+      viewerScopedEntityCompanionProvider.getViewerScopedCompanionForEntity(TestEntity)
     ).toBeInstanceOf(ViewerScopedEntityCompanion);
   });
 });

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -122,14 +122,19 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerCon
 }
 
 class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {
-  constructor(viewerContext: ViewerContext, rawFields: Readonly<TestFields>) {
-    if (rawFields.entity_type !== EntityType.ONE) {
+  constructor(constructorParams: {
+    viewerContext: ViewerContext;
+    id: string;
+    databaseFields: Readonly<TestFields>;
+    selectedFields: Readonly<Pick<TestFields, OneTestFields>>;
+  }) {
+    if (constructorParams.selectedFields.entity_type !== EntityType.ONE) {
       throw new Error('OneTestEntity must be instantiated with one data');
     }
-    super(viewerContext, rawFields);
+    super(constructorParams);
   }
 
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
@@ -137,19 +142,29 @@ class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFie
     TestEntityPrivacyPolicy,
     OneTestFields
   > {
-    return oneTestEntityCompanion;
+    return {
+      entityClass: OneTestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+      entitySelectedFields: ['id', 'entity_type', 'common_other_field'],
+    };
   }
 }
 
 class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFields> {
-  constructor(viewerContext: ViewerContext, rawFields: Readonly<TestFields>) {
-    if (rawFields.entity_type !== EntityType.TWO) {
+  constructor(constructorParams: {
+    viewerContext: ViewerContext;
+    id: string;
+    databaseFields: Readonly<TestFields>;
+    selectedFields: Readonly<Pick<TestFields, TwoTestFields>>;
+  }) {
+    if (constructorParams.selectedFields.entity_type !== EntityType.TWO) {
       throw new Error('TwoTestEntity must be instantiated with two data');
     }
-    super(viewerContext, rawFields);
+    super(constructorParams);
   }
 
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
@@ -157,20 +172,11 @@ class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFie
     TestEntityPrivacyPolicy,
     TwoTestFields
   > {
-    return twoTestEntityCompanion;
+    return {
+      entityClass: TwoTestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+      entitySelectedFields: ['id', 'other_field', 'common_other_field', 'entity_type'],
+    };
   }
 }
-
-const oneTestEntityCompanion = new EntityCompanionDefinition({
-  entityClass: OneTestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-  entitySelectedFields: ['id', 'entity_type', 'common_other_field'],
-});
-
-const twoTestEntityCompanion = new EntityCompanionDefinition({
-  entityClass: TwoTestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-  entitySelectedFields: ['id', 'other_field', 'common_other_field', 'entity_type'],
-});

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -130,7 +130,7 @@ class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerCon
 }
 
 class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
@@ -138,12 +138,17 @@ class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFie
     TestEntityPrivacyPolicy,
     OneTestFields
   > {
-    return oneTestEntityCompanion;
+    return {
+      entityClass: OneTestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+      entitySelectedFields: ['id', 'fake_field'],
+    };
   }
 }
 
 class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFields> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
@@ -151,20 +156,11 @@ class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFie
     TestEntityPrivacyPolicy,
     TwoTestFields
   > {
-    return twoTestEntityCompanion;
+    return {
+      entityClass: TwoTestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+      entitySelectedFields: ['id', 'other_field', 'fake_field'],
+    };
   }
 }
-
-const oneTestEntityCompanion = new EntityCompanionDefinition({
-  entityClass: OneTestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-  entitySelectedFields: ['id', 'fake_field'],
-});
-
-const twoTestEntityCompanion = new EntityCompanionDefinition({
-  entityClass: TwoTestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-  entitySelectedFields: ['id', 'other_field', 'fake_field'],
-});

--- a/packages/entity/src/errors/EntityInvalidFieldValueError.ts
+++ b/packages/entity/src/errors/EntityInvalidFieldValueError.ts
@@ -5,7 +5,7 @@ import ViewerContext from '../ViewerContext';
 import EntityError, { EntityErrorCode, EntityErrorState } from './EntityError';
 
 export default class EntityInvalidFieldValueError<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/errors/EntityNotAuthorizedError.ts
+++ b/packages/entity/src/errors/EntityNotAuthorizedError.ts
@@ -4,7 +4,7 @@ import ViewerContext from '../ViewerContext';
 import EntityError, { EntityErrorCode, EntityErrorState } from './EntityError';
 
 export default class EntityNotAuthorizedError<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/errors/EntityNotFoundError.ts
+++ b/packages/entity/src/errors/EntityNotFoundError.ts
@@ -5,7 +5,7 @@ import ViewerContext from '../ViewerContext';
 import EntityError, { EntityErrorCode, EntityErrorState } from './EntityError';
 
 export default class EntityNotFoundError<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
  * Privacy policy rule that always allows.
  */
 export default class AlwaysAllowPrivacyPolicyRule<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
  * Privacy policy rule that always denies.
  */
 export default class AlwaysDenyPrivacyPolicyRule<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
  * A no-op policy rule that always skips.
  */
 export default class AlwaysSkipPrivacyPolicyRule<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -37,7 +37,7 @@ export enum RuleEvaluationResult {
  *   would be named something like `DenyIfViewerHasBeenBlockedPrivacyPolicyRule`.
  */
 export default abstract class PrivacyPolicyRule<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -43,19 +43,17 @@ export class DateIDTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 export default class DateIDTestEntity extends Entity<DateIDTestFields, Date, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     DateIDTestFields,
     Date,
     ViewerContext,
     DateIDTestEntity,
     DateIDTestEntityPrivacyPolicy
   > {
-    return dateIDTestEntityCompanion;
+    return {
+      entityClass: DateIDTestEntity,
+      entityConfiguration: dateIDTestEntityConfiguration,
+      privacyPolicyClass: DateIDTestEntityPrivacyPolicy,
+    };
   }
 }
-
-export const dateIDTestEntityCompanion = new EntityCompanionDefinition({
-  entityClass: DateIDTestEntity,
-  entityConfiguration: dateIDTestEntityConfiguration,
-  privacyPolicyClass: DateIDTestEntityPrivacyPolicy,
-});

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -75,7 +75,7 @@ export default class SimpleTestEntity extends Entity<
   ViewerContext,
   SimpleTestFieldSelection
 > {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     SimpleTestFields,
     string,
     ViewerContext,
@@ -83,12 +83,10 @@ export default class SimpleTestEntity extends Entity<
     SimpleTestEntityPrivacyPolicy,
     SimpleTestFieldSelection
   > {
-    return testEntityCompanion;
+    return {
+      entityClass: SimpleTestEntity,
+      entityConfiguration: simpleTestEntityConfiguration,
+      privacyPolicyClass: SimpleTestEntityPrivacyPolicy,
+    };
   }
 }
-
-export const testEntityCompanion = new EntityCompanionDefinition({
-  entityClass: SimpleTestEntity,
-  entityConfiguration: simpleTestEntityConfiguration,
-  privacyPolicyClass: SimpleTestEntityPrivacyPolicy,
-});

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -66,14 +66,18 @@ export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 export default class TestEntity extends Entity<TestFields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
     string,
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy
   > {
-    return testEntityCompanion;
+    return {
+      entityClass: TestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    };
   }
 
   getBlah(): string {
@@ -81,14 +85,20 @@ export default class TestEntity extends Entity<TestFields, string, ViewerContext
   }
 
   static async hello(viewerContext: ViewerContext, testValue: string): Promise<Result<TestEntity>> {
+    const fields = {
+      customIdField: testValue,
+      testIndexedField: 'hello',
+      stringField: 'hello',
+      intField: 1,
+      dateField: new Date(),
+      nullableField: null,
+    };
     return result(
-      new TestEntity(viewerContext, {
-        customIdField: testValue,
-        testIndexedField: 'hello',
-        stringField: 'hello',
-        intField: 1,
-        dateField: new Date(),
-        nullableField: null,
+      new TestEntity({
+        viewerContext,
+        id: testValue,
+        databaseFields: fields,
+        selectedFields: fields,
       })
     );
   }
@@ -105,9 +115,3 @@ export default class TestEntity extends Entity<TestFields, string, ViewerContext
     return testValue;
   }
 }
-
-export const testEntityCompanion = new EntityCompanionDefinition({
-  entityClass: TestEntity,
-  entityConfiguration: testEntityConfiguration,
-  privacyPolicyClass: TestEntityPrivacyPolicy,
-});

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -47,19 +47,17 @@ export class TestEntity2PrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 export default class TestEntity2 extends Entity<Test2Fields, string, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     Test2Fields,
     string,
     ViewerContext,
     TestEntity2,
     TestEntity2PrivacyPolicy
   > {
-    return testEntity2Companion;
+    return {
+      entityClass: TestEntity2,
+      entityConfiguration: testEntity2Configuration,
+      privacyPolicyClass: TestEntity2PrivacyPolicy,
+    };
   }
 }
-
-export const testEntity2Companion = new EntityCompanionDefinition({
-  entityClass: TestEntity2,
-  entityConfiguration: testEntity2Configuration,
-  privacyPolicyClass: TestEntity2PrivacyPolicy,
-});

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -43,19 +43,17 @@ export class NumberKeyPrivacyPolicy extends EntityPrivacyPolicy<
 }
 
 export default class NumberKeyEntity extends Entity<NumberKeyFields, number, ViewerContext> {
-  static getCompanionDefinition(): EntityCompanionDefinition<
+  static defineCompanionDefinition(): EntityCompanionDefinition<
     NumberKeyFields,
     number,
     ViewerContext,
     NumberKeyEntity,
     NumberKeyPrivacyPolicy
   > {
-    return numberKeyEntityCompanion;
+    return {
+      entityClass: NumberKeyEntity,
+      entityConfiguration: numberKeyEntityConfiguration,
+      privacyPolicyClass: NumberKeyPrivacyPolicy,
+    };
   }
 }
-
-export const numberKeyEntityCompanion = new EntityCompanionDefinition({
-  entityClass: NumberKeyEntity,
-  entityConfiguration: numberKeyEntityConfiguration,
-  privacyPolicyClass: NumberKeyPrivacyPolicy,
-});

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -5,7 +5,7 @@ import ViewerContext from '../../ViewerContext';
 import PrivacyPolicyRule, { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule';
 
 export interface Case<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -18,7 +18,7 @@ export interface Case<
 }
 
 export type CaseMap<
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -29,7 +29,7 @@ export type CaseMap<
  * Useful for defining test cases that have async preconditions.
  */
 export const describePrivacyPolicyRuleWithAsyncTestCase = <
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -92,7 +92,7 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
  * For test simple privacy rules that don't have complex async preconditions.
  */
 export const describePrivacyPolicyRule = <
-  TFields,
+  TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,


### PR DESCRIPTION
# Why

We're seeing an increasing number of circular reference reports caused by the requirement to maintain the companion definition singularity/singleton property in the application, usually by defining it in a module-top-level property. This has historically caused issues due to some properties in the companion/configuration using top-level definitions of entity types or other classes. 

In the past, we fixed this piece-by-piece, making the companion definition or configuration fields that could cause circular references functions so that circular references would be less likely. https://github.com/expo/entity/pull/89 https://github.com/expo/entity/pull/93

This PR expands upon this but should fix it once-and-for-all by maintaining the singleton requirement in the framework itself rather than pushing the responsibility to the application.

# How

This PR does a few things sequentially (yet procedurally) to accomplish the goal:
1. `getCompanionDefinition` -> `defineCompanionDefinition` - this signals to the application developer that this is a definition and that the framework will handle the singleton.
2. Instantiate a companion definition instance in `EntityCompanionProvider`. This will serve as the instance of the entity companion for the entity and is responsible for making this a singleton. Note that this doesn't need to be a singleton since these are objects, but since this method is called so frequently this memoization is a nice speedup.
3. Make all companion definition accesses occur through `EntityCompanionProvider`, for example: `viewerContext.entityCompanionProvider.getCompanionForEntity(EntityClass).entityCompanionDefinition.entityConfiguration.tableName`
4. Change thunk fields of `EntityCompanionDefinition` and `EntityConfiguration` to non-thunks due to the top-level being a thunk itself and accomplishing the lazy evaluation.
5. Move entity instantiation to `EntityLoader.constructEntity` to make it type-safe and prevent needing to access companion definition in the entity instances themselves (which would be infinite loop). This requires changing the constructor signature for `Entity` itself but that shouldn't be an issue since it is so rarely used outside of the framework itself.

# Test Plan

Run all tests.

Also `yarn link` this into a large codebase (Expo www) and ensure that this fixes circular issues and doesn't break anything.
