### PR TITLE
fix: remove unused field from redis configuration

### DIFF
--- a/packages/entity-cache-adapter-redis/README.md
+++ b/packages/entity-cache-adapter-redis/README.md
@@ -21,7 +21,6 @@ const genericRedisCacherContext = {
     return escapedParts.join(delimiter);
   },
   cacheKeyPrefix: 'ent-',
-  cacheKeyVersion: 1,
   ttlSecondsPositive: 86400, // 1 day
   ttlSecondsNegative: 600, // 10 minutes
 };

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -39,12 +39,6 @@ export interface GenericRedisCacheContext {
   makeKeyFn: (...parts: string[]) => string;
 
   /**
-   * Global cache version for the entity framework. Bumping this version will
-   * invalidate the cache for all entities at once.
-   */
-  cacheKeyVersion: number;
-
-  /**
    * Prefix prepended to all entity cache keys. Useful for adding a short, human-readable
    * distintion for entity keys, e.g. `ent-`
    */

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -74,7 +74,6 @@ describe(GenericRedisCacher, () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -24,7 +24,6 @@ describe(GenericRedisCacher, () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -25,7 +25,6 @@ describe(GenericRedisCacher, () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -23,7 +23,6 @@ describe(GenericRedisCacher, () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -34,7 +34,6 @@ describe(GenericRedisCacher, () => {
         {
           redisClient: instance(mockRedisClient),
           makeKeyFn: (...parts) => parts.join(':'),
-          cacheKeyVersion: 1,
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -65,7 +64,6 @@ describe(GenericRedisCacher, () => {
         {
           redisClient: instance(mock<Redis>()),
           makeKeyFn: (...parts) => parts.join(':'),
-          cacheKeyVersion: 1,
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -98,7 +96,6 @@ describe(GenericRedisCacher, () => {
         {
           redisClient: instance(mockRedisClient),
           makeKeyFn: (...parts) => parts.join(':'),
-          cacheKeyVersion: 1,
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -138,7 +135,6 @@ describe(GenericRedisCacher, () => {
         {
           redisClient: instance(mockRedisClient),
           makeKeyFn: (...parts) => parts.join(':'),
-          cacheKeyVersion: 1,
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -167,7 +163,6 @@ describe(GenericRedisCacher, () => {
         {
           redisClient: instance(mockRedisClient),
           makeKeyFn: (...parts) => parts.join(':'),
-          cacheKeyVersion: 1,
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -186,7 +181,6 @@ describe(GenericRedisCacher, () => {
         {
           redisClient: instance(mock<Redis>()),
           makeKeyFn: (...parts) => parts.join(':'),
-          cacheKeyVersion: 1,
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -119,7 +119,6 @@ describe('Entity cache inconsistency', () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -57,7 +57,6 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -196,7 +196,6 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         return escapedParts.join(delimiter);
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -62,7 +62,6 @@ describe(RedisSecondaryEntityCache, () => {
         throw new Error('should not be used by this test');
       },
       cacheKeyPrefix: 'test-',
-      cacheKeyVersion: 1,
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
     };


### PR DESCRIPTION
# Why

This was added in the initial commit https://github.com/expo/entity/commit/ebe5ffdaea5583b3fa699ef77fff15fec4b114eb#diff-7060247da0b983e4354f340658d6c10fc547b357df02344a42921f6204399c22R19 but was never used. Only the cacheKeyVersion from each entity configuration is used.

In www we just put it in the prefix, which is sufficient and serves the same purpose: 
```
const REDIS_CACHER_KEY_VERSION = 1;
const REDIS_CACHER_KEY_PREFIX = `v${REDIS_CACHER_KEY_VERSION}`;
```

# How

Remove, `tsc`

# Test Plan

CI
