### PR TITLE
fix: convert privacy policy rule definition to functions

### DIFF
--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -98,34 +98,63 @@ export default abstract class EntityPrivacyPolicy<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
-  protected readonly createRules: readonly PrivacyPolicyRule<
+  protected abstract getCreateRules?(): readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
-  >[] = [];
-  protected readonly readRules: readonly PrivacyPolicyRule<
+  >[];
+  protected abstract getReadRules?(): readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
-  >[] = [];
-  protected readonly updateRules: readonly PrivacyPolicyRule<
+  >[];
+  protected abstract getUpdateRules?(): readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
-  >[] = [];
-  protected readonly deleteRules: readonly PrivacyPolicyRule<
+  >[];
+  protected abstract getDeleteRules?(): readonly PrivacyPolicyRule<
     TFields,
     TID,
     TViewerContext,
     TEntity,
     TSelectedFields
-  >[] = [];
+  >[];
+
+  private createRules: readonly PrivacyPolicyRule<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[] = this.getCreateRules ? this.getCreateRules() : [];
+  private readRules: readonly PrivacyPolicyRule<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[] = this.getReadRules ? this.getReadRules() : [];
+  private updateRules: readonly PrivacyPolicyRule<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[] = this.getUpdateRules ? this.getUpdateRules() : [];
+  private deleteRules: readonly PrivacyPolicyRule<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[] = this.getDeleteRules ? this.getDeleteRules() : [];
 
   /**
    * Get the privacy policy evaluation mode and deny handler for this policy.

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -6,6 +6,7 @@ import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
 import ViewerContext from '../../ViewerContext';
 import { successfulResults, failedResults } from '../../entityUtils';
 import AlwaysAllowPrivacyPolicyRule from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import PrivacyPolicyRule from '../../rules/PrivacyPolicyRule';
 import { createUnitTestEntityCompanionProvider } from '../../utils/testing/createUnitTestEntityCompanionProvider';
 
 describe('Two entities backed by the same table', () => {
@@ -107,18 +108,45 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
 });
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
-  protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
-  ];
-  protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
-  ];
-  protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
-  ];
-  protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
-  ];
+  protected override getReadRules(): readonly PrivacyPolicyRule<
+    any,
+    string,
+    ViewerContext,
+    any,
+    any
+  >[] {
+    return [new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>()];
+  }
+
+  protected override getCreateRules(): readonly PrivacyPolicyRule<
+    any,
+    string,
+    ViewerContext,
+    any,
+    any
+  >[] {
+    return [new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>()];
+  }
+
+  protected override getUpdateRules(): readonly PrivacyPolicyRule<
+    any,
+    string,
+    ViewerContext,
+    any,
+    any
+  >[] {
+    return [new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>()];
+  }
+
+  protected override getDeleteRules(): readonly PrivacyPolicyRule<
+    any,
+    string,
+    ViewerContext,
+    any,
+    any
+  >[] {
+    return [new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>()];
+  }
 }
 
 class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {


### PR DESCRIPTION
# Why

Closes ENG-10810.

This is a good direction to go to further prevent import cycles. Related to https://github.com/expo/entity/pull/210.

# How

Convert to functions so that they aren't run when imported.

# Test Plan

This is unfinished, but CI.
