### PR TITLE
BREAKING CHANGE: hoist the responsibility of sharing local memory cache adapter into application

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/createLocalMemoryTestEntityCompanionProvider.ts
@@ -14,8 +14,8 @@ export const createLocalMemoryTestEntityCompanionProvider = (
 ): EntityCompanionProvider => {
   const localMemoryCacheAdapterProvider =
     localMemoryOptions.maxSize === 0 && localMemoryOptions.ttlSeconds === 0
-      ? LocalMemoryCacheAdapterProvider.getNoOpProvider()
-      : LocalMemoryCacheAdapterProvider.getProvider(localMemoryOptions);
+      ? LocalMemoryCacheAdapterProvider.createNoOpProvider()
+      : LocalMemoryCacheAdapterProvider.createProviderWithOptions(localMemoryOptions);
   return new EntityCompanionProvider(
     metricsAdapter,
     new Map([
@@ -38,7 +38,7 @@ export const createLocalMemoryTestEntityCompanionProvider = (
   );
 };
 
-export const createNoopLocalMemoryIntegrationTestEntityCompanionProvider = (
+export const createNoOpLocalMemoryIntegrationTestEntityCompanionProvider = (
   metricsAdapter: IEntityMetricsAdapter = new NoOpEntityMetricsAdapter()
 ): EntityCompanionProvider => {
   return createLocalMemoryTestEntityCompanionProvider(

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -122,7 +122,7 @@ export const createTestEntityCompanionProvider = (
       [
         'local-memory',
         {
-          cacheAdapterProvider: LocalMemoryCacheAdapterProvider.getProvider(),
+          cacheAdapterProvider: LocalMemoryCacheAdapterProvider.createProviderWithOptions(),
         },
       ],
     ])

--- a/packages/entity/src/IEntityCacheAdapterProvider.ts
+++ b/packages/entity/src/IEntityCacheAdapterProvider.ts
@@ -7,7 +7,7 @@ import IEntityCacheAdapter from './IEntityCacheAdapter';
  */
 export default interface IEntityCacheAdapterProvider {
   /**
-   * Vend a cache adapter.
+   * Vend a cache adapter for an entity configuration.
    */
   getCacheAdapter<TFields>(
     entityConfiguration: EntityConfiguration<TFields>


### PR DESCRIPTION
# Why

Closes ENG-6773.

The responsibility of defining the scope of how broadly or narrowly the shared cache should be shared should be the responsibility of the application. This way, the application can decide to share it amongst all requests or just have it be per-request (unlikely, but shouldn't be dictated by library).

Ref: https://github.com/expo/universe/pull/10701#pullrequestreview-1143120207

# How

Make `localMemoryCacheAdapterMap` per-instance of the `LocalMemoryCacheAdapterProvider`. Applications should create one instance of this provider per shared scope.

# Test Plan

Run tests.
