### PR TITLE
feat: Allow UUIDv6/7/8 in UUIDField validation

### DIFF
--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -1,6 +1,8 @@
-import { validate as validateUUID } from 'uuid';
-
 import { EntityFieldDefinition } from './EntityFieldDefinition';
+
+// Use our own regex since the `uuid` package doesn't support validating UUIDv6/7/8 yet
+const UUID_REGEX =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
 
 /**
  * EntityFieldDefinition for a column with a JS string type.
@@ -17,7 +19,7 @@ export class StringField extends EntityFieldDefinition<string> {
  */
 export class UUIDField extends StringField {
   protected override validateInputValueInternal(value: string): boolean {
-    return validateUUID(value);
+    return super.validateInputValueInternal(value) && UUID_REGEX.test(value);
   }
 }
 

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -55,7 +55,13 @@ describe(EntityFieldDefinition, () => {
 describeFieldTestCase(new StringField({ columnName: 'wat' }), ['hello', ''], [1, true, {}, [[]]]);
 describeFieldTestCase(
   new UUIDField({ columnName: 'wat' }),
-  [uuidv1(), uuidv3('wat', uuidv3.DNS), uuidv4(), uuidv5('wat', uuidv5.DNS)],
+  [
+    uuidv1(),
+    uuidv3('wat', uuidv3.DNS),
+    uuidv4(),
+    uuidv5('wat', uuidv5.DNS),
+    /* UUIDv7 */ '018ebfda-dc80-782d-a891-22a0aa057d52',
+  ],
   [uuidv4().replace('-', ''), '', 'hello']
 );
 describeFieldTestCase(new DateField({ columnName: 'wat' }), [new Date()], [Date.now()]);


### PR DESCRIPTION
Why
---
Currently the UUIDField type supports only UUIDv1-5 and to use a newer UUID version we need to use StringField.

How
---
Manually implemented UUID validation, adding support for versions 6, 7, and 8. Also added support for the "max" UUID, which is now part of the spec.

Test Plan
---
Added a UUIDv7 value (from https://uuid7.com/) to the test cases.
