### PR TITLE
feat: add privacy policy rule reordering

### DIFF
--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -1,9 +1,10 @@
 import {
-  PrivacyPolicyRule,
   ReadonlyEntity,
   EntityQueryContext,
   RuleEvaluationResult,
   EntityPrivacyPolicyEvaluationContext,
+  RuleComplexity,
+  AllowOrSkipPrivacyPolicyRule,
 } from '@expo/entity';
 
 import { ExampleViewerContext } from '../viewerContexts';
@@ -27,17 +28,19 @@ export default class AllowIfUserOwnerPrivacyRule<
   TID extends NonNullable<TFields[TSelectedFields]>,
   TEntity extends ReadonlyEntity<TFields, TID, ExampleViewerContext>,
   TSelectedFields extends keyof TFields = keyof TFields
-> extends PrivacyPolicyRule<TFields, TID, ExampleViewerContext, TEntity> {
+> extends AllowOrSkipPrivacyPolicyRule<TFields, TID, ExampleViewerContext, TEntity> {
   constructor(private readonly entityOwnerField: keyof TFields) {
     super();
   }
+
+  override complexity = RuleComplexity.CONSTANT_TIME;
 
   async evaluateAsync(
     viewerContext: ExampleViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     entity: TEntity
-  ): Promise<RuleEvaluationResult> {
+  ): Promise<RuleEvaluationResult.ALLOW | RuleEvaluationResult.SKIP> {
     if (viewerContext.isUserViewerContext()) {
       if (String(entity.getField(this.entityOwnerField)) === viewerContext.userID) {
         return RuleEvaluationResult.ALLOW;

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -33,7 +33,7 @@ export default class AllowIfUserOwnerPrivacyRule<
     super();
   }
 
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 
   async evaluateAsync(
     viewerContext: ExampleViewerContext,

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -145,7 +145,14 @@ export default abstract class EntityPrivacyPolicy<
     };
   }
 
-  protected readonly shouldAutoReorderRulesAccordingToComplexity: boolean = false;
+  protected async shouldAutoReorderRulesAccordingToComplexityAsync(
+    _viewerContext: TViewerContext,
+    _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
+    _action: EntityAuthorizationAction
+  ): Promise<boolean> {
+    return false;
+  }
 
   /**
    * Authorize an entity against creation policy.
@@ -267,7 +274,13 @@ export default abstract class EntityPrivacyPolicy<
     metricsAdapter: IEntityMetricsAdapter
   ): Promise<TEntity> {
     const privacyPolicyEvaluator = this.getPrivacyPolicyEvaluator(viewerContext);
-    const ruleset = this.shouldAutoReorderRulesAccordingToComplexity
+    const shouldAutoReorder = await this.shouldAutoReorderRulesAccordingToComplexityAsync(
+      viewerContext,
+      queryContext,
+      evaluationContext,
+      action
+    );
+    const ruleset = shouldAutoReorder
       ? reorderRulesByRuleComplexityGroups(rulesetOriginalOrder)
       : rulesetOriginalOrder;
     switch (privacyPolicyEvaluator.mode) {

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -12,7 +12,8 @@ import { enforceResultsAsync } from '../entityUtils';
 import EntityNotAuthorizedError from '../errors/EntityNotAuthorizedError';
 import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
 import AlwaysDenyPrivacyPolicyRule from '../rules/AlwaysDenyPrivacyPolicyRule';
-import PrivacyPolicyRule, { RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
+import { RuleComplexity, RuleEvaluationResult } from '../rules/PrivacyPolicyRuleEnums';
+import { DenyOrSkipPrivacyPolicyRule } from '../rules/PrivacyPolicyRuleTypes';
 import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
 
 class TestUserViewerContext extends ViewerContext {
@@ -60,18 +61,20 @@ class BlahEntity extends Entity<BlahFields, string, TestUserViewerContext> {
   }
 }
 
-class DenyIfNotOwnerPrivacyPolicyRule extends PrivacyPolicyRule<
+class DenyIfNotOwnerPrivacyPolicyRule extends DenyOrSkipPrivacyPolicyRule<
   BlahFields,
   string,
   TestUserViewerContext,
   BlahEntity
 > {
+  override complexity = RuleComplexity.CONSTANT_TIME;
+
   async evaluateAsync(
     viewerContext: TestUserViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     entity: BlahEntity
-  ): Promise<RuleEvaluationResult> {
+  ): Promise<RuleEvaluationResult.DENY | RuleEvaluationResult.SKIP> {
     if (viewerContext.getUserID() === entity.getField('ownerID')) {
       return RuleEvaluationResult.SKIP;
     }

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -67,7 +67,7 @@ class DenyIfNotOwnerPrivacyPolicyRule extends DenyOrSkipPrivacyPolicyRule<
   TestUserViewerContext,
   BlahEntity
 > {
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 
   async evaluateAsync(
     viewerContext: TestUserViewerContext,

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -13,7 +13,8 @@ import EntityPrivacyPolicy, {
 } from '../EntityPrivacyPolicy';
 import { EntityTransactionalQueryContext, EntityQueryContext } from '../EntityQueryContext';
 import { CacheStatus } from '../internal/ReadThroughEntityCache';
-import PrivacyPolicyRule, { RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
+import { RuleComplexity, RuleEvaluationResult } from '../rules/PrivacyPolicyRuleEnums';
+import { AllowOrSkipPrivacyPolicyRule } from '../rules/PrivacyPolicyRuleTypes';
 import TestViewerContext from '../testfixtures/TestViewerContext';
 import { InMemoryFullCacheStubCacheAdapter } from '../utils/testing/StubCacheAdapter';
 import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
@@ -66,13 +67,15 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     },
   };
 
-  class AlwaysAllowPrivacyPolicyRuleThatRecords extends PrivacyPolicyRule<
+  class AlwaysAllowPrivacyPolicyRuleThatRecords extends AllowOrSkipPrivacyPolicyRule<
     any,
     string,
     TestViewerContext,
     any,
     any
   > {
+    override complexity = RuleComplexity.CONSTANT_TIME;
+
     constructor(private readonly action: EntityAuthorizationAction) {
       super();
     }
@@ -82,7 +85,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _queryContext: EntityQueryContext,
       evaluationContext: EntityPrivacyPolicyEvaluationContext,
       entity: any
-    ): Promise<RuleEvaluationResult> {
+    ): Promise<RuleEvaluationResult.ALLOW> {
       if (privacyPolicyEvaluationRecords.shouldRecord) {
         (privacyPolicyEvaluationRecords as any)[entity.constructor.name][this.action].push(
           evaluationContext

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -74,7 +74,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     any,
     any
   > {
-    override complexity = RuleComplexity.CONSTANT_TIME;
+    override complexity = RuleComplexity.LOW;
 
     constructor(private readonly action: EntityAuthorizationAction) {
       super();

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -179,7 +179,7 @@ class AlwaysThrowPrivacyPolicyRule extends AllowOrSkipPrivacyPolicyRule<
   ViewerContext,
   BlahEntity
 > {
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 
   evaluateAsync(
     _viewerContext: ViewerContext,

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -19,7 +19,8 @@ import IEntityMetricsAdapter, {
 import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
 import AlwaysDenyPrivacyPolicyRule from '../rules/AlwaysDenyPrivacyPolicyRule';
 import AlwaysSkipPrivacyPolicyRule from '../rules/AlwaysSkipPrivacyPolicyRule';
-import PrivacyPolicyRule, { RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
+import { RuleComplexity, RuleEvaluationResult } from '../rules/PrivacyPolicyRuleEnums';
+import { AllowOrSkipPrivacyPolicyRule } from '../rules/PrivacyPolicyRuleTypes';
 
 type BlahFields = {
   id: string;
@@ -172,18 +173,20 @@ class SkipAllPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContex
   ];
 }
 
-class AlwaysThrowPrivacyPolicyRule extends PrivacyPolicyRule<
+class AlwaysThrowPrivacyPolicyRule extends AllowOrSkipPrivacyPolicyRule<
   BlahFields,
   string,
   ViewerContext,
   BlahEntity
 > {
+  override complexity = RuleComplexity.CONSTANT_TIME;
+
   evaluateAsync(
     _viewerContext: ViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: BlahEntity
-  ): Promise<RuleEvaluationResult> {
+  ): Promise<RuleEvaluationResult.ALLOW> {
     throw new Error('WooHoo!');
   }
 }

--- a/packages/entity/src/__tests__/EntityPrivacyPolicyOrdering-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicyOrdering-test.ts
@@ -1,0 +1,261 @@
+import { mock, instance } from 'ts-mockito';
+
+import Entity from '../Entity';
+import { EntityCompanionDefinition } from '../EntityCompanionProvider';
+import EntityConfiguration from '../EntityConfiguration';
+import { UUIDField } from '../EntityFields';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../EntityQueryContext';
+import ViewerContext from '../ViewerContext';
+import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
+import { RuleComplexity, RuleEvaluationResult } from '../rules/PrivacyPolicyRuleEnums';
+import {
+  AllowOrSkipPrivacyPolicyRule,
+  DenyOrSkipPrivacyPolicyRule,
+  SkipPrivacyPolicyRule,
+} from '../rules/PrivacyPolicyRuleTypes';
+
+type BlahFields = {
+  id: string;
+};
+
+class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
+  static defineCompanionDefinition(): EntityCompanionDefinition<
+    BlahFields,
+    string,
+    ViewerContext,
+    BlahEntity,
+    any
+  > {
+    return {
+      entityClass: BlahEntity,
+      entityConfiguration: new EntityConfiguration<BlahFields>({
+        idField: 'id',
+        tableName: 'blah_table',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      }),
+      privacyPolicyClass: ReorderablePolicy,
+    };
+  }
+}
+
+class LargeAsyncComplexityAllowRule extends AllowOrSkipPrivacyPolicyRule<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.ALLOW> {
+    return RuleEvaluationResult.SKIP;
+  }
+  override complexity = RuleComplexity.LARGE_ASYNC;
+}
+
+class ConstantTimeComplexityAllowRule extends AllowOrSkipPrivacyPolicyRule<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.ALLOW> {
+    return RuleEvaluationResult.SKIP;
+  }
+  override complexity = RuleComplexity.CONSTANT_TIME;
+}
+
+class LargeAsyncComplexitySkipRule extends SkipPrivacyPolicyRule<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP> {
+    return RuleEvaluationResult.SKIP;
+  }
+  override complexity = RuleComplexity.LARGE_ASYNC;
+}
+
+class ConstantTimeComplexitySkipRule extends SkipPrivacyPolicyRule<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP> {
+    return RuleEvaluationResult.SKIP;
+  }
+  override complexity = RuleComplexity.CONSTANT_TIME;
+}
+
+class LargeAsyncComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.DENY> {
+    return RuleEvaluationResult.SKIP;
+  }
+  override complexity = RuleComplexity.LARGE_ASYNC;
+}
+
+class ConstantTimeComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.DENY> {
+    return RuleEvaluationResult.SKIP;
+  }
+  override complexity = RuleComplexity.CONSTANT_TIME;
+}
+
+class ReorderablePolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
+  protected override shouldAutoReorderRulesAccordingToComplexity = true;
+
+  protected override readonly createRules = [
+    new LargeAsyncComplexityDenyRule(),
+    new ConstantTimeComplexityDenyRule(),
+
+    new LargeAsyncComplexityAllowRule(),
+    new ConstantTimeComplexitySkipRule(),
+    new ConstantTimeComplexityAllowRule(),
+
+    new LargeAsyncComplexityDenyRule(),
+    new LargeAsyncComplexitySkipRule(),
+  ];
+  protected override readonly readRules = [];
+  protected override readonly updateRules = [];
+  protected override readonly deleteRules = [];
+}
+
+class NonReorderablePolicy extends EntityPrivacyPolicy<
+  BlahFields,
+  string,
+  ViewerContext,
+  BlahEntity
+> {
+  protected override readonly createRules = [
+    new LargeAsyncComplexityDenyRule(),
+    new ConstantTimeComplexityDenyRule(),
+
+    new LargeAsyncComplexityAllowRule(),
+    new ConstantTimeComplexitySkipRule(),
+    new ConstantTimeComplexityAllowRule(),
+
+    new LargeAsyncComplexityDenyRule(),
+    new LargeAsyncComplexitySkipRule(),
+  ];
+  protected override readonly readRules = [];
+  protected override readonly updateRules = [];
+  protected override readonly deleteRules = [];
+}
+
+describe(EntityPrivacyPolicy, () => {
+  test('reorderable policy', async () => {
+    const viewerContext = instance(mock(ViewerContext));
+    const queryContext = instance(mock(EntityQueryContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
+    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+    const metricsAdapter = instance(metricsAdapterMock);
+    const entity = new BlahEntity({
+      viewerContext,
+      id: '1',
+      databaseFields: { id: '1' },
+      selectedFields: { id: '1' },
+    });
+    const policy = new ReorderablePolicy();
+
+    const spy0 = jest.spyOn(policy['createRules'][0]!, 'evaluateAsync');
+    const spy1 = jest.spyOn(policy['createRules'][1]!, 'evaluateAsync');
+    const spy2 = jest.spyOn(policy['createRules'][2]!, 'evaluateAsync');
+    const spy3 = jest.spyOn(policy['createRules'][3]!, 'evaluateAsync');
+    const spy4 = jest.spyOn(policy['createRules'][4]!, 'evaluateAsync');
+    const spy5 = jest.spyOn(policy['createRules'][5]!, 'evaluateAsync');
+    const spy6 = jest.spyOn(policy['createRules'][6]!, 'evaluateAsync');
+
+    // this will deny since all rules skip, but we only care about rule evaluation order
+    try {
+      await policy.authorizeCreateAsync(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        entity,
+        metricsAdapter
+      );
+    } catch {}
+
+    const spy0CallOrder = spy0.mock.invocationCallOrder[0]!;
+    const spy1CallOrder = spy1.mock.invocationCallOrder[0]!;
+    const spy2CallOrder = spy2.mock.invocationCallOrder[0]!;
+    const spy3CallOrder = spy3.mock.invocationCallOrder[0]!;
+    const spy4CallOrder = spy4.mock.invocationCallOrder[0]!;
+    const spy5CallOrder = spy5.mock.invocationCallOrder[0]!;
+    const spy6CallOrder = spy6.mock.invocationCallOrder[0]!;
+
+    // expected reordering: 1, 0, 3, 4, 2, 5, 6
+    expect(spy1CallOrder).toBeLessThan(spy0CallOrder);
+    expect(spy0CallOrder).toBeLessThan(spy3CallOrder);
+    expect(spy3CallOrder).toBeLessThan(spy4CallOrder);
+    expect(spy4CallOrder).toBeLessThan(spy2CallOrder);
+    expect(spy2CallOrder).toBeLessThan(spy5CallOrder);
+    expect(spy5CallOrder).toBeLessThan(spy6CallOrder);
+  });
+
+  test('non-reorderable policy', async () => {
+    const viewerContext = instance(mock(ViewerContext));
+    const queryContext = instance(mock(EntityQueryContext));
+    const privacyPolicyEvaluationContext = instance(mock<EntityPrivacyPolicyEvaluationContext>());
+    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+    const metricsAdapter = instance(metricsAdapterMock);
+    const entity = new BlahEntity({
+      viewerContext,
+      id: '1',
+      databaseFields: { id: '1' },
+      selectedFields: { id: '1' },
+    });
+    const policy = new NonReorderablePolicy();
+
+    const spy0 = jest.spyOn(policy['createRules'][0]!, 'evaluateAsync');
+    const spy1 = jest.spyOn(policy['createRules'][1]!, 'evaluateAsync');
+    const spy2 = jest.spyOn(policy['createRules'][2]!, 'evaluateAsync');
+    const spy3 = jest.spyOn(policy['createRules'][3]!, 'evaluateAsync');
+    const spy4 = jest.spyOn(policy['createRules'][4]!, 'evaluateAsync');
+    const spy5 = jest.spyOn(policy['createRules'][5]!, 'evaluateAsync');
+    const spy6 = jest.spyOn(policy['createRules'][6]!, 'evaluateAsync');
+
+    // this will deny since all rules skip, but we only care about rule evaluation order
+    try {
+      await policy.authorizeCreateAsync(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        entity,
+        metricsAdapter
+      );
+    } catch {}
+
+    const spy0CallOrder = spy0.mock.invocationCallOrder[0]!;
+    const spy1CallOrder = spy1.mock.invocationCallOrder[0]!;
+    const spy2CallOrder = spy2.mock.invocationCallOrder[0]!;
+    const spy3CallOrder = spy3.mock.invocationCallOrder[0]!;
+    const spy4CallOrder = spy4.mock.invocationCallOrder[0]!;
+    const spy5CallOrder = spy5.mock.invocationCallOrder[0]!;
+    const spy6CallOrder = spy6.mock.invocationCallOrder[0]!;
+
+    // expected reordering: 0, 1, 2, 3, 4, 5, 6
+    expect(spy0CallOrder).toBeLessThan(spy1CallOrder);
+    expect(spy1CallOrder).toBeLessThan(spy2CallOrder);
+    expect(spy2CallOrder).toBeLessThan(spy3CallOrder);
+    expect(spy3CallOrder).toBeLessThan(spy4CallOrder);
+    expect(spy4CallOrder).toBeLessThan(spy5CallOrder);
+    expect(spy5CallOrder).toBeLessThan(spy6CallOrder);
+  });
+});

--- a/packages/entity/src/__tests__/EntityPrivacyPolicyOrdering-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicyOrdering-test.ts
@@ -54,7 +54,7 @@ class LargeAsyncComplexityAllowRule extends AllowOrSkipPrivacyPolicyRule<
   override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.ALLOW> {
     return RuleEvaluationResult.SKIP;
   }
-  override complexity = RuleComplexity.LARGE_ASYNC;
+  override complexity = RuleComplexity.HIGH;
 }
 
 class ConstantTimeComplexityAllowRule extends AllowOrSkipPrivacyPolicyRule<
@@ -66,7 +66,7 @@ class ConstantTimeComplexityAllowRule extends AllowOrSkipPrivacyPolicyRule<
   override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.ALLOW> {
     return RuleEvaluationResult.SKIP;
   }
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 }
 
 class LargeAsyncComplexitySkipRule extends SkipPrivacyPolicyRule<
@@ -78,7 +78,7 @@ class LargeAsyncComplexitySkipRule extends SkipPrivacyPolicyRule<
   override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP> {
     return RuleEvaluationResult.SKIP;
   }
-  override complexity = RuleComplexity.LARGE_ASYNC;
+  override complexity = RuleComplexity.HIGH;
 }
 
 class ConstantTimeComplexitySkipRule extends SkipPrivacyPolicyRule<
@@ -90,7 +90,7 @@ class ConstantTimeComplexitySkipRule extends SkipPrivacyPolicyRule<
   override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP> {
     return RuleEvaluationResult.SKIP;
   }
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 }
 
 class LargeAsyncComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
@@ -102,7 +102,7 @@ class LargeAsyncComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
   override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.DENY> {
     return RuleEvaluationResult.SKIP;
   }
-  override complexity = RuleComplexity.LARGE_ASYNC;
+  override complexity = RuleComplexity.HIGH;
 }
 
 class ConstantTimeComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
@@ -114,7 +114,7 @@ class ConstantTimeComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
   override async evaluateAsync(): Promise<RuleEvaluationResult.SKIP | RuleEvaluationResult.DENY> {
     return RuleEvaluationResult.SKIP;
   }
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 }
 
 class ReorderablePolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {

--- a/packages/entity/src/__tests__/EntityPrivacyPolicyOrdering-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicyOrdering-test.ts
@@ -4,7 +4,10 @@ import Entity from '../Entity';
 import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';
-import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import EntityPrivacyPolicy, {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
@@ -118,7 +121,14 @@ class ConstantTimeComplexityDenyRule extends DenyOrSkipPrivacyPolicyRule<
 }
 
 class ReorderablePolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
-  protected override shouldAutoReorderRulesAccordingToComplexity = true;
+  protected override async shouldAutoReorderRulesAccordingToComplexityAsync(
+    _viewerContext: ViewerContext,
+    _queryContext: EntityQueryContext,
+    _evaluationContext: EntityPrivacyPolicyEvaluationContext,
+    _action: EntityAuthorizationAction
+  ): Promise<boolean> {
+    return true;
+  }
 
   protected override readonly createRules = [
     new LargeAsyncComplexityDenyRule(),

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -66,8 +66,8 @@ export { default as NoOpEntityMetricsAdapter } from './metrics/NoOpEntityMetrics
 export { default as AlwaysAllowPrivacyPolicyRule } from './rules/AlwaysAllowPrivacyPolicyRule';
 export { default as AlwaysDenyPrivacyPolicyRule } from './rules/AlwaysDenyPrivacyPolicyRule';
 export { default as AlwaysSkipPrivacyPolicyRule } from './rules/AlwaysSkipPrivacyPolicyRule';
-export { default as PrivacyPolicyRule } from './rules/PrivacyPolicyRule';
-export * from './rules/PrivacyPolicyRule';
+export * from './rules/PrivacyPolicyRuleEnums';
+export * from './rules/PrivacyPolicyRuleTypes';
 export * from './utils/testing/PrivacyPolicyRuleTestUtils';
 export * from './utils/testing/StubCacheAdapter';
 export { default as describeFieldTestCase } from './utils/testing/describeFieldTestCase';

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -15,7 +15,7 @@ export default class AlwaysAllowPrivacyPolicyRule<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > extends AllowOrSkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 
   async evaluateAsync(
     _viewerContext: TViewerContext,

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -1,4 +1,5 @@
-import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
+import { RuleComplexity, RuleEvaluationResult } from './PrivacyPolicyRuleEnums';
+import { AllowOrSkipPrivacyPolicyRule } from './PrivacyPolicyRuleTypes';
 import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
@@ -13,13 +14,15 @@ export default class AlwaysAllowPrivacyPolicyRule<
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends AllowOrSkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  override complexity = RuleComplexity.CONSTANT_TIME;
+
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: TEntity
-  ): Promise<RuleEvaluationResult> {
+  ): Promise<RuleEvaluationResult.ALLOW | RuleEvaluationResult.SKIP> {
     return RuleEvaluationResult.ALLOW;
   }
 }

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -15,7 +15,7 @@ export default class AlwaysDenyPrivacyPolicyRule<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > extends DenyOrSkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 
   async evaluateAsync(
     _viewerContext: TViewerContext,

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -1,4 +1,5 @@
-import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
+import { RuleComplexity, RuleEvaluationResult } from './PrivacyPolicyRuleEnums';
+import { DenyOrSkipPrivacyPolicyRule } from './PrivacyPolicyRuleTypes';
 import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
@@ -13,13 +14,15 @@ export default class AlwaysDenyPrivacyPolicyRule<
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends DenyOrSkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  override complexity = RuleComplexity.CONSTANT_TIME;
+
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: TEntity
-  ): Promise<RuleEvaluationResult> {
+  ): Promise<RuleEvaluationResult.DENY | RuleEvaluationResult.SKIP> {
     return RuleEvaluationResult.DENY;
   }
 }

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -1,4 +1,5 @@
-import PrivacyPolicyRule, { RuleEvaluationResult } from './PrivacyPolicyRule';
+import { RuleComplexity, RuleEvaluationResult } from './PrivacyPolicyRuleEnums';
+import { SkipPrivacyPolicyRule } from './PrivacyPolicyRuleTypes';
 import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import ReadonlyEntity from '../ReadonlyEntity';
@@ -13,13 +14,15 @@ export default class AlwaysSkipPrivacyPolicyRule<
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends SkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  override complexity = RuleComplexity.CONSTANT_TIME;
+
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext,
     _entity: TEntity
-  ): Promise<RuleEvaluationResult> {
+  ): Promise<RuleEvaluationResult.SKIP> {
     return RuleEvaluationResult.SKIP;
   }
 }

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -15,7 +15,7 @@ export default class AlwaysSkipPrivacyPolicyRule<
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > extends SkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
-  override complexity = RuleComplexity.CONSTANT_TIME;
+  override complexity = RuleComplexity.LOW;
 
   async evaluateAsync(
     _viewerContext: TViewerContext,

--- a/packages/entity/src/rules/PrivacyPolicyRuleEnums.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRuleEnums.ts
@@ -19,23 +19,25 @@ export enum RuleEvaluationResult {
 }
 
 /**
- * Estimated complexity of a privacy policy rule.
+ * Estimated complexity of a privacy policy rule. Definition of what rules fall into what complexity category
+ * is application-specific, but the AlwaysAllow/AlwaysDeny/AlwaysSkip rules provided are all defined as LOW
+ * complexity.
  */
 export enum RuleComplexity {
   /**
-   * Rule doesn't make any async calls.
+   * Rule complexity is low. Definition dependent on application.
    */
-  CONSTANT_TIME = 0,
+  LOW = 0,
 
   /**
-   * Rule makes an small amount of async calls. Definition of small dependent on application.
+   * Rule complexity is medium. Definition dependent on application.
    */
-  SMALL_ASYNC = 1,
+  MEDIUM = 1,
 
   /**
-   * Rule makes a large amount of async calls. Definition of large dependent on application.
+   * Rule complexity is high. Definition dependent on application.
    */
-  LARGE_ASYNC = 2,
+  HIGH = 2,
 }
 
 /**

--- a/packages/entity/src/rules/PrivacyPolicyRuleEnums.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRuleEnums.ts
@@ -1,0 +1,59 @@
+/**
+ * Enum return type of privacy policy rule evaluation.
+ */
+export enum RuleEvaluationResult {
+  /**
+   * Deny viewer access to the entity.
+   */
+  DENY = -1,
+
+  /**
+   * Defer entity viewer access to subsequent rule in the privacy policy.
+   */
+  SKIP = 0,
+
+  /**
+   * Allow viewer access to the entity.
+   */
+  ALLOW = 1,
+}
+
+/**
+ * Estimated complexity of a privacy policy rule.
+ */
+export enum RuleComplexity {
+  /**
+   * Rule doesn't make any async calls.
+   */
+  CONSTANT_TIME = 0,
+
+  /**
+   * Rule makes an small amount of async calls. Definition of small dependent on application.
+   */
+  SMALL_ASYNC = 1,
+
+  /**
+   * Rule makes a large amount of async calls. Definition of large dependent on application.
+   */
+  LARGE_ASYNC = 2,
+}
+
+/**
+ * Used for disambiguation between classes of privacy policy rules at runtime.
+ * Multiple rules of the same type in a row can be reordered safely to improve policy evaluation time
+ * based on complexities.
+ */
+export enum RuleEvaluationResultType {
+  /**
+   * Rule is a DenyOrSkipPrivacyPolicyRule. Can be safely reordered with other sequential DenyOrSkipPrivacyPolicyRule or SkipPrivacyPolicyRule in a policy.
+   */
+  DENY_OR_SKIP,
+  /**
+   * Rule is a SkipPrivacyPolicyRule. Can be safely reordered with any other sequential privacy policy rules in a policy.
+   */
+  SKIP,
+  /**
+   * Rule is an AllowOrSkipPrivacyPolicyRule. Can be safely reordered with other sequential AllowOrSkipPrivacyPolicyRule or SkipPrivacyPolicyRule in a policy.
+   */
+  ALLOW_OR_SKIP,
+}

--- a/packages/entity/src/rules/PrivacyPolicyRuleTypes.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRuleTypes.ts
@@ -1,0 +1,68 @@
+import { RuleEvaluationResult, RuleEvaluationResultType } from './PrivacyPolicyRuleEnums';
+import { PrivacyPolicyRuleInternal } from './internal/PrivacyPolicyRule';
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../EntityQueryContext';
+import ReadonlyEntity from '../ReadonlyEntity';
+import ViewerContext from '../ViewerContext';
+
+export type PrivacyPolicyRule<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> =
+  | AllowOrSkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+  | DenyOrSkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>
+  | SkipPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
+
+export abstract class AllowOrSkipPrivacyPolicyRule<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends PrivacyPolicyRuleInternal<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  abstract override evaluateAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext,
+    entity: TEntity
+  ): Promise<RuleEvaluationResult.ALLOW | RuleEvaluationResult.SKIP>;
+
+  override resultType = RuleEvaluationResultType.ALLOW_OR_SKIP;
+}
+
+export abstract class DenyOrSkipPrivacyPolicyRule<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends PrivacyPolicyRuleInternal<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  abstract override evaluateAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext,
+    entity: TEntity
+  ): Promise<RuleEvaluationResult.DENY | RuleEvaluationResult.SKIP>;
+
+  override resultType = RuleEvaluationResultType.DENY_OR_SKIP;
+}
+
+export abstract class SkipPrivacyPolicyRule<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields
+> extends PrivacyPolicyRuleInternal<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  abstract override evaluateAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext,
+    entity: TEntity
+  ): Promise<RuleEvaluationResult.SKIP>;
+
+  override resultType = RuleEvaluationResultType.SKIP;
+}

--- a/packages/entity/src/rules/internal/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/internal/PrivacyPolicyRule.ts
@@ -1,24 +1,12 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../EntityQueryContext';
-import ReadonlyEntity from '../ReadonlyEntity';
-import ViewerContext from '../ViewerContext';
-
-export enum RuleEvaluationResult {
-  /**
-   * Deny viewer access to the entity.
-   */
-  DENY = -1,
-
-  /**
-   * Defer entity viewer access to subsequent rule in the privacy policy.
-   */
-  SKIP = 0,
-
-  /**
-   * Allow viewer access to the entity.
-   */
-  ALLOW = 1,
-}
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../EntityQueryContext';
+import ReadonlyEntity from '../../ReadonlyEntity';
+import ViewerContext from '../../ViewerContext';
+import {
+  RuleComplexity,
+  RuleEvaluationResult,
+  RuleEvaluationResultType,
+} from '../PrivacyPolicyRuleEnums';
 
 /**
  * A single unit of which declarative privacy policies are composed, allowing for simple
@@ -36,17 +24,24 @@ export enum RuleEvaluationResult {
  * - Blocking. For example, a user blocks another user from seeing their posts, and the rule
  *   would be named something like `DenyIfViewerHasBeenBlockedPrivacyPolicyRule`.
  */
-export default abstract class PrivacyPolicyRule<
+export abstract class PrivacyPolicyRuleInternal<
   TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields
 > {
+  /**
+   * Estimated complexity of a privacy policy rule. Used for automatic (safe) rule reordering.
+   */
+  abstract readonly complexity: RuleComplexity;
+
   abstract evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext,
     entity: TEntity
   ): Promise<RuleEvaluationResult>;
+
+  abstract readonly resultType: RuleEvaluationResultType;
 }

--- a/packages/entity/src/rules/internal/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/internal/PrivacyPolicyRule.ts
@@ -33,6 +33,7 @@ export abstract class PrivacyPolicyRuleInternal<
 > {
   /**
    * Estimated complexity of a privacy policy rule. Used for automatic (safe) rule reordering.
+   * Typed as a number so that applications can define their own complexity scale.
    */
   abstract readonly complexity: RuleComplexity;
 

--- a/packages/entity/src/rules/internal/PrivacyPolicyRuleOrdering.ts
+++ b/packages/entity/src/rules/internal/PrivacyPolicyRuleOrdering.ts
@@ -1,0 +1,70 @@
+import invariant from 'invariant';
+
+import { RuleComplexity, RuleEvaluationResultType } from '../PrivacyPolicyRuleEnums';
+
+/**
+ * Privacy policy list of PrivacyPolicyRule can be reordered safely according to
+ * the following constraints on RuleEvaluationResultType:
+ * 1. Two adjacent ALLOW_OR_SKIP rules can be swapped.
+ * 2. Two adjacent DENY_OR_SKIP rules can be swapped.
+ * 3. SKIP rules can be swapped with any other adjacent rule.
+ *
+ * @param rulesetOriginalOrder - ruleset with original ordering defined in code
+ * @returns reordered ruleset depending on constraints above
+ */
+export function reorderRulesByRuleComplexityGroups<
+  TRule extends { resultType: RuleEvaluationResultType; complexity: RuleComplexity }
+>(rulesetOriginalOrder: readonly TRule[]): readonly TRule[] {
+  // first, group the rules according to constraints
+  const groups = groupRulesByResultType(rulesetOriginalOrder);
+
+  // sort the groups by declared complexity
+  const internallySortedGroups = groups.map((group) => sortGroupByComplexity(group));
+
+  // flatten the groups
+  return internallySortedGroups.flat();
+}
+
+export function sortGroupByComplexity<TRule extends { complexity: RuleComplexity }>(
+  ruleGroup: readonly TRule[]
+): readonly TRule[] {
+  return [...ruleGroup].sort((a, b) => a.complexity - b.complexity);
+}
+
+export function groupRulesByResultType<TRule extends { resultType: RuleEvaluationResultType }>(
+  ruleset: readonly TRule[]
+): readonly (readonly TRule[])[] {
+  const groups: TRule[][] = [[]];
+  let currentGroupIdx = 0;
+  let currentGroupType:
+    | RuleEvaluationResultType.ALLOW_OR_SKIP
+    | RuleEvaluationResultType.DENY_OR_SKIP
+    | null = null;
+
+  for (const rule of ruleset) {
+    // if group type of this rule is not compatible with the current group type, start a new group
+    if (
+      currentGroupType !== null &&
+      rule.resultType !== currentGroupType &&
+      rule.resultType !== RuleEvaluationResultType.SKIP
+    ) {
+      currentGroupIdx += 1;
+      groups.push([]);
+      currentGroupType = null;
+    }
+
+    // add the current rule to the current group
+    const currentGroup = groups[currentGroupIdx];
+    invariant(currentGroup, `invalid groups index ${currentGroupIdx}`);
+    currentGroup.push(rule);
+
+    // if there isn't a known group type yet for the current group, set it to the group type of the rule.
+    // note that if there isn't a known group type yet and the current rule is SKIP, we'll
+    // continue to the next rule to determine group type
+    if (currentGroupType === null && rule.resultType !== RuleEvaluationResultType.SKIP) {
+      currentGroupType = rule.resultType;
+    }
+  }
+
+  return groups;
+}

--- a/packages/entity/src/rules/internal/PrivacyPolicyRuleOrdering.ts
+++ b/packages/entity/src/rules/internal/PrivacyPolicyRuleOrdering.ts
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 
-import { RuleComplexity, RuleEvaluationResultType } from '../PrivacyPolicyRuleEnums';
+import { RuleEvaluationResultType } from '../PrivacyPolicyRuleEnums';
 
 /**
  * Privacy policy list of PrivacyPolicyRule can be reordered safely according to
@@ -13,7 +13,7 @@ import { RuleComplexity, RuleEvaluationResultType } from '../PrivacyPolicyRuleEn
  * @returns reordered ruleset depending on constraints above
  */
 export function reorderRulesByRuleComplexityGroups<
-  TRule extends { resultType: RuleEvaluationResultType; complexity: RuleComplexity }
+  TRule extends { resultType: RuleEvaluationResultType; complexity: number }
 >(rulesetOriginalOrder: readonly TRule[]): readonly TRule[] {
   // first, group the rules according to constraints
   const groups = groupRulesByResultType(rulesetOriginalOrder);
@@ -25,7 +25,7 @@ export function reorderRulesByRuleComplexityGroups<
   return internallySortedGroups.flat();
 }
 
-export function sortGroupByComplexity<TRule extends { complexity: RuleComplexity }>(
+export function sortGroupByComplexity<TRule extends { complexity: number }>(
   ruleGroup: readonly TRule[]
 ): readonly TRule[] {
   return [...ruleGroup].sort((a, b) => a.complexity - b.complexity);

--- a/packages/entity/src/rules/internal/__tests__/PrivacyPolicyRuleOrdering-test.ts
+++ b/packages/entity/src/rules/internal/__tests__/PrivacyPolicyRuleOrdering-test.ts
@@ -75,13 +75,13 @@ describe(groupRulesByResultType, () => {
   );
 });
 
-type TestRuleJustComplexity = { id: number; complexity: RuleComplexity };
+type TestRuleJustComplexity = { id: number; complexity: number };
 
 describe(sortGroupByComplexity, () => {
-  const rule1 = { id: 1, complexity: RuleComplexity.CONSTANT_TIME };
-  const rule2 = { id: 2, complexity: RuleComplexity.CONSTANT_TIME };
-  const rule3 = { id: 3, complexity: RuleComplexity.SMALL_ASYNC };
-  const rule5 = { id: 3, complexity: RuleComplexity.LARGE_ASYNC };
+  const rule1 = { id: 1, complexity: RuleComplexity.LOW };
+  const rule2 = { id: 2, complexity: RuleComplexity.LOW };
+  const rule3 = { id: 3, complexity: RuleComplexity.MEDIUM };
+  const rule5 = { id: 3, complexity: RuleComplexity.HIGH };
 
   test.each([
     { ruleGroup: [rule1, rule2], expectedRuleGroup: [rule1, rule2] },
@@ -103,38 +103,38 @@ describe(sortGroupByComplexity, () => {
   );
 });
 
-type TestRule = { id: number; resultType: RuleEvaluationResultType; complexity: RuleComplexity };
+type TestRule = { id: number; resultType: RuleEvaluationResultType; complexity: number };
 
 describe(reorderRulesByRuleComplexityGroups, () => {
   const rule1 = {
     id: 1,
     resultType: RuleEvaluationResultType.ALLOW_OR_SKIP,
-    complexity: RuleComplexity.LARGE_ASYNC,
+    complexity: RuleComplexity.HIGH,
   };
   const rule2 = {
     id: 2,
     resultType: RuleEvaluationResultType.ALLOW_OR_SKIP,
-    complexity: RuleComplexity.CONSTANT_TIME,
+    complexity: RuleComplexity.LOW,
   };
   const rule3 = {
     id: 3,
     resultType: RuleEvaluationResultType.SKIP,
-    complexity: RuleComplexity.CONSTANT_TIME,
+    complexity: RuleComplexity.LOW,
   };
   const rule4 = {
     id: 4,
     resultType: RuleEvaluationResultType.SKIP,
-    complexity: RuleComplexity.LARGE_ASYNC,
+    complexity: RuleComplexity.HIGH,
   };
   const rule5 = {
     id: 5,
     resultType: RuleEvaluationResultType.DENY_OR_SKIP,
-    complexity: RuleComplexity.SMALL_ASYNC,
+    complexity: RuleComplexity.MEDIUM,
   };
   const rule6 = {
     id: 6,
     resultType: RuleEvaluationResultType.DENY_OR_SKIP,
-    complexity: RuleComplexity.CONSTANT_TIME,
+    complexity: RuleComplexity.LOW,
   };
 
   test.each([

--- a/packages/entity/src/rules/internal/__tests__/PrivacyPolicyRuleOrdering-test.ts
+++ b/packages/entity/src/rules/internal/__tests__/PrivacyPolicyRuleOrdering-test.ts
@@ -1,0 +1,152 @@
+import { RuleComplexity, RuleEvaluationResultType } from '../../PrivacyPolicyRuleEnums';
+import {
+  groupRulesByResultType,
+  reorderRulesByRuleComplexityGroups,
+  sortGroupByComplexity,
+} from '../PrivacyPolicyRuleOrdering';
+
+type TestRuleJustResultType = { id: number; resultType: RuleEvaluationResultType };
+
+describe(groupRulesByResultType, () => {
+  const rule1 = { id: 1, resultType: RuleEvaluationResultType.ALLOW_OR_SKIP };
+  const rule2 = { id: 2, resultType: RuleEvaluationResultType.ALLOW_OR_SKIP };
+  const rule3 = { id: 3, resultType: RuleEvaluationResultType.SKIP };
+  const rule4 = { id: 4, resultType: RuleEvaluationResultType.SKIP };
+  const rule5 = { id: 5, resultType: RuleEvaluationResultType.DENY_OR_SKIP };
+  const rule6 = { id: 6, resultType: RuleEvaluationResultType.DENY_OR_SKIP };
+
+  test.each([
+    // two adjacent of the same type should be grouped
+    { ruleset: [rule1, rule2], expectedResultGroups: [[rule1, rule2]] },
+    { ruleset: [rule3, rule4], expectedResultGroups: [[rule3, rule4]] },
+    { ruleset: [rule5, rule6], expectedResultGroups: [[rule5, rule6]] },
+
+    // two adjacent of ALLOW_OR_SKIP or DENY_OR_SKIP should not be grouped
+    { ruleset: [rule1, rule5], expectedResultGroups: [[rule1], [rule5]] },
+    { ruleset: [rule5, rule1], expectedResultGroups: [[rule5], [rule1]] },
+
+    // adjacent (ALLOW_OR_SKIP and SKIP) or (DENY_OR_SKIP and SKIP) should be grouped
+    { ruleset: [rule1, rule2, rule3], expectedResultGroups: [[rule1, rule2, rule3]] },
+    { ruleset: [rule1, rule2, rule3, rule4], expectedResultGroups: [[rule1, rule2, rule3, rule4]] },
+    { ruleset: [rule5, rule6, rule3], expectedResultGroups: [[rule5, rule6, rule3]] },
+    { ruleset: [rule5, rule6, rule3, rule4], expectedResultGroups: [[rule5, rule6, rule3, rule4]] },
+
+    // skip cases group with first group
+    {
+      ruleset: [rule1, rule2, rule3, rule4, rule5, rule6],
+      expectedResultGroups: [
+        [rule1, rule2, rule3, rule4],
+        [rule5, rule6],
+      ],
+    },
+
+    // skip in first N slots should take the first group type
+    {
+      ruleset: [rule3, rule4, rule1, rule2, rule5, rule6],
+      expectedResultGroups: [
+        [rule3, rule4, rule1, rule2],
+        [rule5, rule6],
+      ],
+    },
+
+    // lots of groups
+    {
+      ruleset: [rule1, rule5, rule3, rule2, rule6, rule4],
+      expectedResultGroups: [[rule1], [rule5, rule3], [rule2], [rule6, rule4]],
+    },
+
+    // skip in first N slots
+    {
+      ruleset: [rule3, rule4, rule5, rule1],
+      expectedResultGroups: [[rule3, rule4, rule5], [rule1]],
+    },
+  ])(
+    'case %#',
+    ({
+      ruleset,
+      expectedResultGroups,
+    }: {
+      ruleset: TestRuleJustResultType[];
+      expectedResultGroups: TestRuleJustResultType[][];
+    }) => {
+      const resultGroups = groupRulesByResultType(ruleset);
+      expect(resultGroups).toStrictEqual(expectedResultGroups);
+    }
+  );
+});
+
+type TestRuleJustComplexity = { id: number; complexity: RuleComplexity };
+
+describe(sortGroupByComplexity, () => {
+  const rule1 = { id: 1, complexity: RuleComplexity.CONSTANT_TIME };
+  const rule2 = { id: 2, complexity: RuleComplexity.CONSTANT_TIME };
+  const rule3 = { id: 3, complexity: RuleComplexity.SMALL_ASYNC };
+  const rule5 = { id: 3, complexity: RuleComplexity.LARGE_ASYNC };
+
+  test.each([
+    { ruleGroup: [rule1, rule2], expectedRuleGroup: [rule1, rule2] },
+    { ruleGroup: [rule1, rule3], expectedRuleGroup: [rule1, rule3] },
+    { ruleGroup: [rule1, rule3, rule5], expectedRuleGroup: [rule1, rule3, rule5] },
+    { ruleGroup: [rule5, rule3, rule1], expectedRuleGroup: [rule1, rule3, rule5] },
+  ])(
+    'case %#',
+    ({
+      ruleGroup,
+      expectedRuleGroup,
+    }: {
+      ruleGroup: TestRuleJustComplexity[];
+      expectedRuleGroup: TestRuleJustComplexity[];
+    }) => {
+      const resultGroup = sortGroupByComplexity(ruleGroup);
+      expect(resultGroup).toStrictEqual(expectedRuleGroup);
+    }
+  );
+});
+
+type TestRule = { id: number; resultType: RuleEvaluationResultType; complexity: RuleComplexity };
+
+describe(reorderRulesByRuleComplexityGroups, () => {
+  const rule1 = {
+    id: 1,
+    resultType: RuleEvaluationResultType.ALLOW_OR_SKIP,
+    complexity: RuleComplexity.LARGE_ASYNC,
+  };
+  const rule2 = {
+    id: 2,
+    resultType: RuleEvaluationResultType.ALLOW_OR_SKIP,
+    complexity: RuleComplexity.CONSTANT_TIME,
+  };
+  const rule3 = {
+    id: 3,
+    resultType: RuleEvaluationResultType.SKIP,
+    complexity: RuleComplexity.CONSTANT_TIME,
+  };
+  const rule4 = {
+    id: 4,
+    resultType: RuleEvaluationResultType.SKIP,
+    complexity: RuleComplexity.LARGE_ASYNC,
+  };
+  const rule5 = {
+    id: 5,
+    resultType: RuleEvaluationResultType.DENY_OR_SKIP,
+    complexity: RuleComplexity.SMALL_ASYNC,
+  };
+  const rule6 = {
+    id: 6,
+    resultType: RuleEvaluationResultType.DENY_OR_SKIP,
+    complexity: RuleComplexity.CONSTANT_TIME,
+  };
+
+  test.each([
+    {
+      ruleset: [rule1, rule2, rule3, rule4, rule5, rule6],
+      expectedRuleset: [rule2, rule3, rule1, rule4, rule6, rule5],
+    },
+  ])(
+    'case %#',
+    ({ ruleset, expectedRuleset }: { ruleset: TestRule[]; expectedRuleset: TestRule[] }) => {
+      const resultRuleset = reorderRulesByRuleComplexityGroups(ruleset);
+      expect(resultRuleset).toStrictEqual(expectedRuleset);
+    }
+  );
+});

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -2,7 +2,8 @@ import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy'
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ReadonlyEntity from '../../ReadonlyEntity';
 import ViewerContext from '../../ViewerContext';
-import PrivacyPolicyRule, { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule';
+import { RuleEvaluationResult } from '../../rules/PrivacyPolicyRuleEnums';
+import { PrivacyPolicyRule } from '../../rules/PrivacyPolicyRuleTypes';
 
 export interface Case<
   TFields extends object,


### PR DESCRIPTION
# Why

This adds the ability to direct privacy policies to do "smart reordering" of the rules within a policy. The benefit here is that we can optimize the policy at evaluation time to do less-computationally-expensive rules earlier in the hopes that they are definitive in their evaluation results and therefore we don't evaluate the later more-computationally-expensive rules.

This comes with some notable caveats though so it is an opt-in behavior. The caveats are:
- Sometimes SKIP rules are used to do things like log, dry-run, etc. In this case, if they are reordered in an unexpected way, they may not log or execute.
- Sometimes rule execution order matters. Example:
    - AllowRule1 - Allow rule that checks if X is true and allows if so, otherwise skips
    - AllowRule2 - Allow rule that throws a hard exception if X is false, but always Allows.
    - In this instance, a non-reorderable policy with [AllowRule1, AllowRule2] would never throw a hard exception.
    - But if allowed to be reorderable, AllowRule2 may run before AllowRule1 (depending on complexity).
    - It is best not to write non-reorderable rules.

# How

1. Change privacy rule subclasses to make them categorize themselves into AllowOrSkip, Skip, or DenyOrSkip. (AllowOrDeny is not allowed).
2. Add complexity field to privacy policy rules. This is programmer-defined. Getting it wrong isn't the end of the world since it just means that the policy execution will be slightly more expensive at worst (not incorrect).
1. Add rule ordering and tests for the functionality.

# Test Plan

Run tests.
