### PR TITLE
chore: ignore entity-example package from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "packages/entity-example"


### PR DESCRIPTION
# Why

This package is purely for demonstration purposes, and while it does have tests, they're more to demonstrate a testing strategy for an application that uses entity rather than as a thing that needs test coverage in this repo.

# How

Ignore the package.

# Test Plan

Wait for CI.
