### PR TITLE
chore: set codecov default branch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
+codecov:
+  branch: main
 ignore:
   - "packages/entity-example"


### PR DESCRIPTION
# Why

For some reason, codecov still defaults to master for the default branch.

# How

Explicitly specify default branch.

# Test Plan

```
$ curl -X POST --data-binary @codecov.yml https://codecov.io/validate
Valid!

{
  "codecov": {
    "branch": "main"
  },
  "ignore": [
    "^packages/entity-example.*"
  ]
}
```
