### PR TITLE
chore: add more tests for privacy policy rules and nested transaction query contexts

### DIFF
--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -380,7 +380,9 @@ export default abstract class EntityPrivacyPolicy<
         case RuleEvaluationResult.ALLOW:
           return entity;
         default:
-          throw new Error('should not be a fourth type of rule evaluation result');
+          throw new Error(
+            `Invalid RuleEvaluationResult returned from rule: ${entity} (viewer = ${viewerContext}, action = ${EntityAuthorizationAction[action]}, ruleIndex = ${i})`
+          );
       }
     }
 

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -172,7 +172,8 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
  * to EntityMutator and EntityLoader methods, those methods and their
  * dependent triggers and validators will run within the nested transaction.
  *
- * This exists to forward post-commit callbacks to the parent query context.
+ * This exists to forward post-commit callbacks to the parent query context but only after
+ * successful commit of the nested transaction.
  */
 export class EntityNestedTransactionalQueryContext extends EntityTransactionalQueryContext {
   private readonly postCommitInvalidationCallbacksToTransfer: PostCommitCallback[] = [];

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -128,6 +128,24 @@ describe(EntityQueryContext, () => {
       expect(postCommitCallback).toHaveBeenCalledTimes(2);
       expect(postCommitInvalidationCallback).toHaveBeenCalledTimes(2);
     });
+
+    it('does not support calling runPostCommitCallbacksAsync on nested transaction', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      await expect(
+        viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          'postgres',
+          async (queryContext) => {
+            await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+              await innerQueryContext.runPostCommitCallbacksAsync();
+            });
+          }
+        )
+      ).rejects.toThrowError(
+        'Must not call runPostCommitCallbacksAsync on EntityNestedTransactionalQueryContext'
+      );
+    });
   });
 
   describe('transaction config', () => {


### PR DESCRIPTION
# Why

Noticed that the test coverage of this was missing. Similar to https://github.com/expo/entity/pull/227, this was easy enough to add some coverage for (and it's important to have tests for this).

# How

Add tests.

# Test Plan

Run tests.
