### PR TITLE
chore: add more tests for entity loader

### DIFF
--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -373,6 +373,7 @@ describe(EnforcingEntityLoader, () => {
       'tryConstructEntities',
       'validateFieldValues',
       'constructAndAuthorizeEntitiesAsync',
+      'constructAndAuthorizeEntitiesArrayAsync',
       'constructEntity',
     ];
     expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));


### PR DESCRIPTION
# Why

Similar to https://github.com/expo/entity/pull/228, there was some missing coverage for the loader. This completes the coverage.

# How

Add tests.

# Test Plan

Run tests, verify coverage.
