### PR TITLE
chore: add more tests for stub database adapter and test utils

### DIFF
--- a/packages/entity/src/utils/testing/__tests__/PrivacyPolicyRuleTestUtils-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/PrivacyPolicyRuleTestUtils-test.ts
@@ -1,0 +1,40 @@
+import { anything, instance, mock } from 'ts-mockito';
+
+import { EntityPrivacyPolicyEvaluationContext } from '../../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../../EntityQueryContext';
+import ViewerContext from '../../../ViewerContext';
+import AlwaysAllowPrivacyPolicyRule from '../../../rules/AlwaysAllowPrivacyPolicyRule';
+import AlwaysDenyPrivacyPolicyRule from '../../../rules/AlwaysDenyPrivacyPolicyRule';
+import { describePrivacyPolicyRuleWithAsyncTestCase } from '../PrivacyPolicyRuleTestUtils';
+
+describe(describePrivacyPolicyRuleWithAsyncTestCase, () => {
+  describe('default args do not execute', () => {
+    describePrivacyPolicyRuleWithAsyncTestCase(new AlwaysAllowPrivacyPolicyRule(), {
+      allowCases: new Map([
+        [
+          'case',
+          async () => ({
+            viewerContext: instance(mock(ViewerContext)),
+            queryContext: instance(mock(EntityQueryContext)),
+            evaluationContext: instance(mock<EntityPrivacyPolicyEvaluationContext>()),
+            entity: anything(),
+          }),
+        ],
+      ]),
+    });
+
+    describePrivacyPolicyRuleWithAsyncTestCase(new AlwaysDenyPrivacyPolicyRule(), {
+      denyCases: new Map([
+        [
+          'case',
+          async () => ({
+            viewerContext: instance(mock(ViewerContext)),
+            queryContext: instance(mock(EntityQueryContext)),
+            evaluationContext: instance(mock<EntityPrivacyPolicyEvaluationContext>()),
+            entity: anything(),
+          }),
+        ],
+      ]),
+    });
+  });
+});

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -334,6 +334,34 @@ describe(StubDatabaseAdapter, () => {
         testIndexedField: 'h1',
       });
     });
+
+    it('throws error when empty update to match common DBMS behavior', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+        testEntityConfiguration,
+        StubDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 3,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ])
+        )
+      );
+      await expect(
+        databaseAdapter.updateAsync(queryContext, 'customIdField', 'hello', {})
+      ).rejects.toThrowError(`Empty update (custom_id = hello)`);
+    });
   });
 
   describe('deleteAsync', () => {
@@ -435,6 +463,20 @@ describe(StubDatabaseAdapter, () => {
             }
           )
         ).toEqual(expectedResult);
+      });
+
+      it('works for empty', () => {
+        expect(
+          StubDatabaseAdapter['compareByOrderBys'](
+            [],
+            {
+              hello: 'test',
+            },
+            {
+              hello: 'blah',
+            }
+          )
+        ).toEqual(0);
       });
     });
 


### PR DESCRIPTION
# Why

Similar to https://github.com/expo/entity/pull/229, this adds more tests for pieces of the code that are untested.

# How

Add test, check coverage.

# Test Plan

Run test, check coverage.
