### PR TITLE
fix: always reload entity after update since cascading changes may have changed it since commit

### DIFF
--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -1,0 +1,149 @@
+import {
+  EntityPrivacyPolicy,
+  ViewerContext,
+  AlwaysAllowPrivacyPolicyRule,
+  Entity,
+  EntityCompanionDefinition,
+  EntityConfiguration,
+  UUIDField,
+} from '@expo/entity';
+import { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis';
+import Redis from 'ioredis';
+import { knex, Knex } from 'knex';
+import nullthrows from 'nullthrows';
+import { URL } from 'url';
+import { v4 as uuidv4 } from 'uuid';
+
+import { createFullIntegrationTestEntityCompanionProvider } from '../testfixtures/createFullIntegrationTestEntityCompanionProvider';
+
+interface TestFields {
+  id: string;
+}
+
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
+  TestFields,
+  string,
+  ViewerContext,
+  TestEntity
+> {
+  protected override readonly readRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+  protected override readonly createRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+  protected override readonly updateRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+  protected override readonly deleteRules = [
+    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+  ];
+}
+
+class TestEntity extends Entity<TestFields, string, ViewerContext> {
+  static defineCompanionDefinition(): EntityCompanionDefinition<
+    TestFields,
+    string,
+    ViewerContext,
+    TestEntity,
+    TestEntityPrivacyPolicy
+  > {
+    return {
+      entityClass: TestEntity,
+      entityConfiguration: testEntityConfiguration,
+      privacyPolicyClass: TestEntityPrivacyPolicy,
+    };
+  }
+}
+
+const testEntityConfiguration = new EntityConfiguration<TestFields>({
+  idField: 'id',
+  tableName: 'testentities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
+});
+
+async function createOrTruncatePostgresTables(knex: Knex): Promise<void> {
+  await knex.schema.createTable('testentities', (table) => {
+    table.uuid('id').defaultTo(knex.raw('gen_random_uuid()')).primary();
+  });
+  await knex.into('testentities').truncate();
+}
+
+async function dropPostgresTable(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable('testentities')) {
+    await knex.schema.dropTable('testentities');
+  }
+}
+
+describe('Entity integrity', () => {
+  let knexInstance: Knex;
+  const redisClient = new Redis(new URL(process.env['REDIS_URL']!).toString());
+  let genericRedisCacheContext: GenericRedisCacheContext;
+
+  beforeAll(() => {
+    knexInstance = knex({
+      client: 'pg',
+      connection: {
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
+        host: 'localhost',
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
+        database: nullthrows(process.env['PGDATABASE']),
+      },
+    });
+    genericRedisCacheContext = {
+      redisClient,
+      makeKeyFn(...parts: string[]): string {
+        const delimiter = ':';
+        const escapedParts = parts.map((part) =>
+          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
+        );
+        return escapedParts.join(delimiter);
+      },
+      cacheKeyPrefix: 'test-',
+      ttlSecondsPositive: 86400, // 1 day
+      ttlSecondsNegative: 600, // 10 minutes
+    };
+  });
+
+  beforeEach(async () => {
+    await createOrTruncatePostgresTables(knexInstance);
+    await redisClient.flushdb();
+  });
+
+  afterAll(async () => {
+    await dropPostgresTable(knexInstance);
+    await knexInstance.destroy();
+    redisClient.disconnect();
+  });
+
+  test('cannot update ID', async () => {
+    const viewerContext = new ViewerContext(
+      createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext)
+    );
+
+    const entity1 = await TestEntity.creator(viewerContext).enforceCreateAsync();
+
+    await expect(
+      TestEntity.updater(entity1).setField('id', uuidv4()).enforceUpdateAsync()
+    ).rejects.toThrow('id field updates not supported: (entityClass = TestEntity)');
+
+    // ensure cache consistency
+    const viewerContextLast = new ViewerContext(
+      createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext)
+    );
+
+    const loadedById = await TestEntity.loader(viewerContextLast)
+      .enforcing()
+      .loadByIDAsync(entity1.getID());
+
+    expect(loadedById.getID()).toEqual(entity1.getID());
+  });
+});

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -518,7 +518,7 @@ export class UpdateMutator<
   private ensureStableIDField(updatedFields: Partial<TFields>): void {
     const originalId = this.originalEntity.getID();
     const idField = this.entityConfiguration.idField;
-    if (idField in updatedFields && originalId !== updatedFields[idField]) {
+    if (updatedFields.hasOwnProperty(idField) && originalId !== updatedFields[idField]) {
       throw new Error(`id field updates not supported: (entityClass = ${this.entityClass.name})`);
     }
   }

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -835,9 +835,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         ChildEntity: {
           [EntityAuthorizationAction.CREATE]: [],
 
-          // one READ auth action for child in order to update via cascade
+          // two READs auth action for child in order to update via cascade
           // no other entities are read since it is not cascaded past first entity
           [EntityAuthorizationAction.READ]: [
+            {
+              cascadingDeleteCause: {
+                entity: expect.any(ParentEntity),
+                cascadingDeleteCause: null,
+              },
+            },
             {
               cascadingDeleteCause: {
                 entity: expect.any(ParentEntity),


### PR DESCRIPTION
# Why

Noticed this while reading through mutator code. The issue is that previously we would not re-load the entity if `skipDatabaseUpdate` was true since we assumed the entity was unchanged. But there are some scenarios where this isn't true, namely `SET_NULL_INVALIDATE_CACHE_ONLY`.

For example, if a field in this entity is set null when cascade deleting, we want to reload it before calling the after-update triggers (especially the post-commit ones).

Closes ENG-12407.

# How

Always re-load the entity. Note that this requires an explicit check to ensure a stable ID. Previously this check was implicitly enforced by the database adapter.

# Test Plan

Run new tests.
