### PR TITLE
fix: constrain entity fields type to string-keyed object

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -13,7 +13,9 @@ export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
 type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
 export type LocalMemoryCache<TFields> = LRUCache<string, LocalMemoryCacheValue<TFields>>;
 
-export default class GenericLocalMemoryCacher<TFields> implements IEntityGenericCacher<TFields> {
+export default class GenericLocalMemoryCacher<TFields extends Record<string, any>>
+  implements IEntityGenericCacher<TFields>
+{
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly localMemoryCache: LocalMemoryCache<TFields>

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -39,7 +39,7 @@ export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdap
     private readonly localMemoryCacheCreator: <TFields>() => LocalMemoryCache<TFields>
   ) {}
 
-  public getCacheAdapter<TFields>(
+  public getCacheAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): IEntityCacheAdapter<TFields> {
     return computeIfAbsent(this.localMemoryCacheAdapterMap, entityConfiguration.tableName, () => {

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -57,7 +57,9 @@ export interface GenericRedisCacheContext {
   ttlSecondsNegative: number;
 }
 
-export default class GenericRedisCacher<TFields> implements IEntityGenericCacher<TFields> {
+export default class GenericRedisCacher<TFields extends Record<string, any>>
+  implements IEntityGenericCacher<TFields>
+{
   constructor(
     private readonly context: GenericRedisCacheContext,
     private readonly entityConfiguration: EntityConfiguration<TFields>

--- a/packages/entity-cache-adapter-redis/src/RedisCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-redis/src/RedisCacheAdapterProvider.ts
@@ -10,7 +10,7 @@ import GenericRedisCacher, { GenericRedisCacheContext } from './GenericRedisCach
 export default class RedisCacheAdapterProvider implements IEntityCacheAdapterProvider {
   constructor(private readonly context: GenericRedisCacheContext) {}
 
-  getCacheAdapter<TFields>(
+  getCacheAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): IEntityCacheAdapter<TFields> {
     return new GenericEntityCacheAdapter(new GenericRedisCacher(this.context, entityConfiguration));

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -12,7 +12,9 @@ import { Knex } from 'knex';
 import { JSONArrayField, MaybeJSONArrayField } from './EntityFields';
 import wrapNativePostgresCallAsync from './errors/wrapNativePostgresCallAsync';
 
-export default class PostgresEntityDatabaseAdapter<TFields> extends EntityDatabaseAdapter<TFields> {
+export default class PostgresEntityDatabaseAdapter<
+  TFields extends Record<string, any>
+> extends EntityDatabaseAdapter<TFields> {
   protected getFieldTransformerMap(): FieldTransformerMap {
     return new Map<string, FieldTransformer<any>>([
       [

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
@@ -9,7 +9,7 @@ import PostgresEntityDatabaseAdapter from './PostgresEntityDatabaseAdapter';
 export default class PostgresEntityDatabaseAdapterProvider
   implements IEntityDatabaseAdapterProvider
 {
-  getDatabaseAdapter<TFields>(
+  getDatabaseAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): EntityDatabaseAdapter<TFields> {
     return new PostgresEntityDatabaseAdapter(entityConfiguration);

--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 const dbObjects: Readonly<{ [key: string]: any }>[] = [];
 
 export class InMemoryDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
-  getDatabaseAdapter<TFields>(
+  getDatabaseAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): EntityDatabaseAdapter<TFields> {
     return new InMemoryDatabaseAdapter(entityConfiguration);
@@ -26,7 +26,7 @@ export class InMemoryDatabaseAdapterProvider implements IEntityDatabaseAdapterPr
  * In-memory database adapter for entity for the purposes of this example. Normally `@expo/entity-database-adapter-knex`
  * or another production adapter would be used. Very similar to StubDatabaseAdapter but shared in a way more akin to a normal database.
  */
-class InMemoryDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
+class InMemoryDatabaseAdapter<T extends Record<string, any>> extends EntityDatabaseAdapter<T> {
   protected getFieldTransformerMap(): FieldTransformerMap {
     return new Map();
   }

--- a/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
@@ -12,7 +12,7 @@ import {
  * TLoadParams must be JSON stringifyable.
  */
 export default class LocalMemorySecondaryEntityCache<
-  TFields,
+  TFields extends Record<string, any>,
   TLoadParams
 > extends GenericSecondaryEntityCache<TFields, TLoadParams> {
   constructor(

--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -5,7 +5,7 @@ import { GenericRedisCacheContext, GenericRedisCacher } from '@expo/entity-cache
  * A redis GenericSecondaryEntityCache.
  */
 export default class RedisSecondaryEntityCache<
-  TFields,
+  TFields extends Record<string, any>,
   TLoadParams
 > extends GenericSecondaryEntityCache<TFields, TLoadParams> {
   constructor(

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -209,7 +209,7 @@ export default class EntityCompanionProvider {
     return entityDatabaseAdapterFlavor.queryContextProvider;
   }
 
-  private getTableDataCoordinatorForEntity<TFields>(
+  private getTableDataCoordinatorForEntity<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>,
     entityClassName: string
   ): EntityTableDataCoordinator<TFields> {

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -7,7 +7,7 @@ import { mapMap, invertMap, reduceMap } from './utils/collections/maps';
  * The data storage configuration for a type of Entity. Contains information relating to IDs,
  * cachable fields, field mappings, and types of cache and database adapter.
  */
-export default class EntityConfiguration<TFields> {
+export default class EntityConfiguration<TFields extends Record<string, any>> {
   readonly idField: keyof TFields;
   readonly tableName: string;
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
@@ -76,7 +76,7 @@ export default class EntityConfiguration<TFields> {
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups
     // TODO(wschurman): validate schema
-    this.schema = new Map(Object.entries(schema) as any);
+    this.schema = new Map(Object.entries(schema));
 
     this.cacheableKeys = EntityConfiguration.computeCacheableKeys(this.schema);
     this.entityToDBFieldsKeyMapping = EntityConfiguration.computeEntityToDBFieldsKeyMapping(

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -113,7 +113,7 @@ export interface TableQuerySelectionModifiersWithOrderByRaw extends TableQuerySe
  * handles all entity field transformation. Subclasses are responsible for
  * implementing database-specific logic for a type of database.
  */
-export default abstract class EntityDatabaseAdapter<TFields> {
+export default abstract class EntityDatabaseAdapter<TFields extends Record<string, any>> {
   private readonly fieldTransformerMap: FieldTransformerMap;
 
   constructor(private readonly entityConfiguration: EntityConfiguration<TFields>) {

--- a/packages/entity/src/IEntityCacheAdapterProvider.ts
+++ b/packages/entity/src/IEntityCacheAdapterProvider.ts
@@ -9,7 +9,7 @@ export default interface IEntityCacheAdapterProvider {
   /**
    * Vend a cache adapter for an entity configuration.
    */
-  getCacheAdapter<TFields>(
+  getCacheAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): IEntityCacheAdapter<TFields>;
 }

--- a/packages/entity/src/IEntityDatabaseAdapterProvider.ts
+++ b/packages/entity/src/IEntityDatabaseAdapterProvider.ts
@@ -9,7 +9,7 @@ export default interface IEntityDatabaseAdapterProvider {
   /**
    * Vend a database adapter.
    */
-  getDatabaseAdapter<TFields>(
+  getDatabaseAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): EntityDatabaseAdapter<TFields>;
 }

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -23,7 +23,9 @@ const entityConfiguration = new EntityConfiguration<BlahFields>({
 export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
 type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
 
-class TestLocalCacheAdapter<TFields> implements IEntityCacheAdapter<TFields> {
+class TestLocalCacheAdapter<TFields extends Record<string, any>>
+  implements IEntityCacheAdapter<TFields>
+{
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly cache: Map<string, LocalMemoryCacheValue<TFields>>

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -303,7 +303,7 @@ const createEntityMutatorFactory = (
     )
   );
   const customStubDatabaseAdapterProvider: IEntityDatabaseAdapterProvider = {
-    getDatabaseAdapter<TFields>(
+    getDatabaseAdapter<TFields extends Record<string, any>>(
       _entityConfiguration: EntityConfiguration<TFields>
     ): EntityDatabaseAdapter<TFields> {
       return databaseAdapter as any as EntityDatabaseAdapter<TFields>;

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -25,7 +25,7 @@ import { computeIfAbsent, zipToMap } from '../utils/collections/maps';
  *
  * It is also responsible for invalidating all sources of data when mutated using EntityMutator.
  */
-export default class EntityDataManager<TFields> {
+export default class EntityDataManager<TFields extends Record<string, any>> {
   private readonly fieldDataLoaders: Map<
     keyof TFields,
     DataLoader<NonNullable<TFields[keyof TFields]>, readonly Readonly<TFields>[]>

--- a/packages/entity/src/internal/EntityFieldTransformationUtils.ts
+++ b/packages/entity/src/internal/EntityFieldTransformationUtils.ts
@@ -20,7 +20,7 @@ export interface FieldTransformer<T> {
  */
 export type FieldTransformerMap = Map<string, FieldTransformer<any>>;
 
-export const getDatabaseFieldForEntityField = <TFields>(
+export const getDatabaseFieldForEntityField = <TFields extends Record<string, any>>(
   entityConfiguration: EntityConfiguration<TFields>,
   entityField: keyof TFields
 ): string => {
@@ -29,7 +29,7 @@ export const getDatabaseFieldForEntityField = <TFields>(
   return databaseField!;
 };
 
-export const transformDatabaseObjectToFields = <TFields>(
+export const transformDatabaseObjectToFields = <TFields extends Record<string, any>>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   databaseObject: { [key: string]: any }
@@ -50,7 +50,7 @@ export const transformDatabaseObjectToFields = <TFields>(
   return fields;
 };
 
-export const transformFieldsToDatabaseObject = <TFields>(
+export const transformFieldsToDatabaseObject = <TFields extends Record<string, any>>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   fields: Readonly<Partial<TFields>>
@@ -70,7 +70,7 @@ export const transformFieldsToDatabaseObject = <TFields>(
   return databaseObject;
 };
 
-export const transformCacheObjectToFields = <TFields>(
+export const transformCacheObjectToFields = <TFields extends Record<string, any>>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   cacheObject: { [key: string]: any }
@@ -88,7 +88,7 @@ export const transformCacheObjectToFields = <TFields>(
   return fields;
 };
 
-export const transformFieldsToCacheObject = <TFields>(
+export const transformFieldsToCacheObject = <TFields extends Record<string, any>>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   fields: Readonly<Partial<TFields>>
@@ -106,7 +106,10 @@ export const transformFieldsToCacheObject = <TFields>(
   return cacheObject;
 };
 
-const maybeTransformDatabaseValueToFieldValue = <TFields, N extends keyof TFields>(
+const maybeTransformDatabaseValueToFieldValue = <
+  TFields extends Record<string, any>,
+  N extends keyof TFields
+>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
@@ -120,7 +123,10 @@ const maybeTransformDatabaseValueToFieldValue = <TFields, N extends keyof TField
   return readTransformer ? readTransformer(value) : value;
 };
 
-const maybeTransformFieldValueToDatabaseValue = <TFields, N extends keyof TFields>(
+const maybeTransformFieldValueToDatabaseValue = <
+  TFields extends Record<string, any>,
+  N extends keyof TFields
+>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
@@ -132,7 +138,10 @@ const maybeTransformFieldValueToDatabaseValue = <TFields, N extends keyof TField
   return writeTransformer ? writeTransformer(value) : value;
 };
 
-const maybeTransformCacheValueToFieldValue = <TFields, N extends keyof TFields>(
+const maybeTransformCacheValueToFieldValue = <
+  TFields extends Record<string, any>,
+  N extends keyof TFields
+>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
@@ -148,7 +157,10 @@ const maybeTransformCacheValueToFieldValue = <TFields, N extends keyof TFields>(
   return readTransformer ? readTransformer(value) : value;
 };
 
-const maybeTransformFieldValueToCacheValue = <TFields, N extends keyof TFields>(
+const maybeTransformFieldValueToCacheValue = <
+  TFields extends Record<string, any>,
+  N extends keyof TFields
+>(
   entityConfiguration: EntityConfiguration<TFields>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,

--- a/packages/entity/src/internal/EntityTableDataCoordinator.ts
+++ b/packages/entity/src/internal/EntityTableDataCoordinator.ts
@@ -13,7 +13,7 @@ import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
  * table. Note that one instance is shared amongst all entities that read from
  * the table to ensure cross-entity data consistency.
  */
-export default class EntityTableDataCoordinator<TFields> {
+export default class EntityTableDataCoordinator<TFields extends Record<string, any>> {
   readonly databaseAdapter: EntityDatabaseAdapter<TFields>;
   readonly cacheAdapter: IEntityCacheAdapter<TFields>;
   readonly dataManager: EntityDataManager<TFields>;

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -26,7 +26,7 @@ export type CacheLoadResult<TFields> =
  * A read-through entity cache is responsible for coordinating EntityDatabaseAdapter and
  * EntityCacheAdapter within the EntityDataManager.
  */
-export default class ReadThroughEntityCache<TFields> {
+export default class ReadThroughEntityCache<TFields extends Record<string, any>> {
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     private readonly entityCacheAdapter: IEntityCacheAdapter<TFields>

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -6,7 +6,7 @@ import IEntityCacheAdapterProvider from '../../IEntityCacheAdapterProvider';
 import { CacheStatus, CacheLoadResult } from '../../internal/ReadThroughEntityCache';
 
 export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
-  getCacheAdapter<TFields>(
+  getCacheAdapter<TFields extends Record<string, any>>(
     _entityConfiguration: EntityConfiguration<TFields>
   ): IEntityCacheAdapter<TFields> {
     return new NoCacheStubCacheAdapter();
@@ -45,7 +45,7 @@ export class NoCacheStubCacheAdapter<TFields> implements IEntityCacheAdapter<TFi
 export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
   cache: Map<string, Readonly<object>> = new Map();
 
-  getCacheAdapter<TFields>(
+  getCacheAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): IEntityCacheAdapter<TFields> {
     return new InMemoryFullCacheStubCacheAdapter(
@@ -55,7 +55,9 @@ export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAd
   }
 }
 
-export class InMemoryFullCacheStubCacheAdapter<TFields> implements IEntityCacheAdapter<TFields> {
+export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, any>>
+  implements IEntityCacheAdapter<TFields>
+{
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields>,
     readonly cache: Map<string, Readonly<TFields>>

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -16,7 +16,9 @@ import {
 } from '../../internal/EntityFieldTransformationUtils';
 import { computeIfAbsent, mapMap } from '../collections/maps';
 
-export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
+export default class StubDatabaseAdapter<
+  T extends Record<string, any>
+> extends EntityDatabaseAdapter<T> {
   constructor(
     private readonly entityConfiguration2: EntityConfiguration<T>,
     private readonly dataStore: Map<string, Readonly<{ [key: string]: any }>[]>
@@ -24,7 +26,7 @@ export default class StubDatabaseAdapter<T> extends EntityDatabaseAdapter<T> {
     super(entityConfiguration2);
   }
 
-  public static convertFieldObjectsToDataStore<T>(
+  public static convertFieldObjectsToDataStore<T extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<T>,
     dataStore: Map<string, Readonly<T>[]>
   ): Map<string, Readonly<{ [key: string]: any }>[]> {

--- a/packages/entity/src/utils/testing/StubDatabaseAdapterProvider.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapterProvider.ts
@@ -6,7 +6,7 @@ import IEntityDatabaseAdapterProvider from '../../IEntityDatabaseAdapterProvider
 export default class StubDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
   private readonly objectCollection = new Map();
 
-  getDatabaseAdapter<TFields>(
+  getDatabaseAdapter<TFields extends Record<string, any>>(
     entityConfiguration: EntityConfiguration<TFields>
   ): EntityDatabaseAdapter<TFields> {
     return new StubDatabaseAdapter(entityConfiguration, this.objectCollection);


### PR DESCRIPTION
# Why

This allows us to remove the `any` typecast in EntityConfiguration.ts and is more correct: only string-keyed field objects are allowed.

This is in preparation for addressing this comment: https://github.com/expo/entity/pull/233#discussion_r1625121092

# How

Add type constraint where necessary.

# Test Plan

`yarn tsc`
