### PR TITLE
BREAKING CHANGE: make using non-enforcing entity loader explicit

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -64,7 +64,7 @@ describe(GenericLocalMemoryCacher, () => {
     const nonExistentId = uuidv4();
 
     const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
 
@@ -77,13 +77,13 @@ describe(GenericLocalMemoryCacher, () => {
 
     // load again through entities framework to ensure it reads negative result
     const entityNonExistentResult2 = await LocalMemoryTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly
     await LocalMemoryTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .invalidateFieldsAsync(entity1.getAllFields());
     const cachedResultMiss = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),
@@ -136,7 +136,7 @@ describe(GenericLocalMemoryCacher, () => {
     const nonExistentId = uuidv4();
 
     const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
 

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -63,8 +63,9 @@ describe(GenericLocalMemoryCacher, () => {
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
 
-    const entityNonExistentResult =
-      await LocalMemoryTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([
@@ -75,12 +76,15 @@ describe(GenericLocalMemoryCacher, () => {
     });
 
     // load again through entities framework to ensure it reads negative result
-    const entityNonExistentResult2 =
-      await LocalMemoryTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult2 = await LocalMemoryTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly
-    await LocalMemoryTestEntity.loader(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
+    await LocalMemoryTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .invalidateFieldsAsync(entity1.getAllFields());
     const cachedResultMiss = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),
     ]);
@@ -131,8 +135,9 @@ describe(GenericLocalMemoryCacher, () => {
     // a non existent db fetch should try to write negative result ('') but it's a noop cache, so it should be a miss
     const nonExistentId = uuidv4();
 
-    const entityNonExistentResult =
-      await LocalMemoryTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -146,7 +146,7 @@ describe(GenericRedisCacher, () => {
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
     const entityNonExistentResult = await RedisTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
     const cacheKeyNonExistent = cacheKeyMaker('id', nonExistentId);
@@ -154,13 +154,13 @@ describe(GenericRedisCacher, () => {
     expect(nonExistentCachedValue).toEqual('');
     // load again through entities framework to ensure it reads negative result
     const entityNonExistentResult2 = await RedisTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly in both caches
     await RedisTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .invalidateFieldsAsync(entity1.getAllFields());
     await expect(redis.get(cacheKeyEntity1)).resolves.toBeNull();
     await expect(redis.get(cacheKeyEntity1NameField)).resolves.toBeNull();

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -145,19 +145,23 @@ describe(GenericRedisCacher, () => {
 
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
-    const entityNonExistentResult =
-      await RedisTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult = await RedisTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
     const cacheKeyNonExistent = cacheKeyMaker('id', nonExistentId);
     const nonExistentCachedValue = await redis.get(cacheKeyNonExistent);
     expect(nonExistentCachedValue).toEqual('');
     // load again through entities framework to ensure it reads negative result
-    const entityNonExistentResult2 =
-      await RedisTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult2 = await RedisTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly in both caches
-    await RedisTestEntity.loader(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
+    await RedisTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .invalidateFieldsAsync(entity1.getAllFields());
     await expect(redis.get(cacheKeyEntity1)).resolves.toBeNull();
     await expect(redis.get(cacheKeyEntity1NameField)).resolves.toBeNull();
   });

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -67,8 +67,9 @@ describe(GenericRedisCacher, () => {
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
 
-    const entityNonExistentResult =
-      await RedisTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult = await RedisTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedValue = await (genericRedisCacheContext.redisClient as Redis).get(
@@ -77,12 +78,15 @@ describe(GenericRedisCacher, () => {
     expect(nonExistentCachedValue).toEqual('');
 
     // load again through entities framework to ensure it reads negative result
-    const entityNonExistentResult2 =
-      await RedisTestEntity.loader(viewerContext).loadByIDAsync(nonExistentId);
+    const entityNonExistentResult2 = await RedisTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly
-    await RedisTestEntity.loader(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
+    await RedisTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .invalidateFieldsAsync(entity1.getAllFields());
     const cachedValueNull = await (genericRedisCacheContext.redisClient as Redis).get(
       cacheKeyMaker('id', entity1.getID()),
     );

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -68,7 +68,7 @@ describe(GenericRedisCacher, () => {
     const nonExistentId = uuidv4();
 
     const entityNonExistentResult = await RedisTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult.ok).toBe(false);
 
@@ -79,13 +79,13 @@ describe(GenericRedisCacher, () => {
 
     // load again through entities framework to ensure it reads negative result
     const entityNonExistentResult2 = await RedisTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(nonExistentId);
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly
     await RedisTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .invalidateFieldsAsync(entity1.getAllFields());
     const cachedValueNull = await (genericRedisCacheContext.redisClient as Redis).get(
       cacheKeyMaker('id', entity1.getID()),

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -1,7 +1,6 @@
 import {
   OrderByOrdering,
   createUnitTestEntityCompanionProvider,
-  enforceResultsAsync,
   ViewerContext,
   TransactionIsolationLevel,
 } from '@expo/entity';
@@ -92,7 +91,7 @@ describe('postgres entity integration', () => {
       PostgresTestEntity.creator(vc1).setField('name', 'hello').createAsync(),
     );
 
-    await enforceAsyncResult(PostgresTestEntity.loader(vc1).loadByIDAsync(firstEntity.getID()));
+    await PostgresTestEntity.loader(vc1).enforcing().loadByIDAsync(firstEntity.getID());
 
     const errorToThrow = new Error('Intentional error');
 
@@ -111,9 +110,9 @@ describe('postgres entity integration', () => {
       ),
     ).rejects.toEqual(errorToThrow);
 
-    const entities = await enforceResultsAsync(
-      PostgresTestEntity.loader(vc1).loadManyByFieldEqualingAsync('name', 'hello'),
-    );
+    const entities = await PostgresTestEntity.loader(vc1)
+      .enforcing()
+      .loadManyByFieldEqualingAsync('name', 'hello');
     expect(entities).toHaveLength(1);
   });
 

--- a/packages/entity-example/src/routers/notesRouter.ts
+++ b/packages/entity-example/src/routers/notesRouter.ts
@@ -30,7 +30,9 @@ router.get('/', async (ctx) => {
 
 router.get('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
-  const noteResult = await NoteEntity.loader(viewerContext).loadByIDAsync(ctx.params['id']!);
+  const noteResult = await NoteEntity.loader(viewerContext)
+    .nonEnforcing()
+    .loadByIDAsync(ctx.params['id']!);
   if (!noteResult.ok) {
     ctx.throw(403, noteResult.reason);
     return;
@@ -72,7 +74,9 @@ router.put('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
   const { title, body } = ctx.request.body as any;
 
-  const noteLoadResult = await NoteEntity.loader(viewerContext).loadByIDAsync(ctx.params['id']!);
+  const noteLoadResult = await NoteEntity.loader(viewerContext)
+    .nonEnforcing()
+    .loadByIDAsync(ctx.params['id']!);
   if (!noteLoadResult.ok) {
     ctx.throw(403, noteLoadResult.reason);
     return;
@@ -95,7 +99,9 @@ router.put('/:id', async (ctx) => {
 router.delete('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
 
-  const noteLoadResult = await NoteEntity.loader(viewerContext).loadByIDAsync(ctx.params['id']!);
+  const noteLoadResult = await NoteEntity.loader(viewerContext)
+    .nonEnforcing()
+    .loadByIDAsync(ctx.params['id']!);
   if (!noteLoadResult.ok) {
     ctx.throw(403, noteLoadResult.reason);
     return;

--- a/packages/entity-example/src/routers/notesRouter.ts
+++ b/packages/entity-example/src/routers/notesRouter.ts
@@ -31,7 +31,7 @@ router.get('/', async (ctx) => {
 router.get('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
   const noteResult = await NoteEntity.loader(viewerContext)
-    .nonEnforcing()
+    .withAuthorizationResults()
     .loadByIDAsync(ctx.params['id']!);
   if (!noteResult.ok) {
     ctx.throw(403, noteResult.reason);
@@ -75,7 +75,7 @@ router.put('/:id', async (ctx) => {
   const { title, body } = ctx.request.body as any;
 
   const noteLoadResult = await NoteEntity.loader(viewerContext)
-    .nonEnforcing()
+    .withAuthorizationResults()
     .loadByIDAsync(ctx.params['id']!);
   if (!noteLoadResult.ok) {
     ctx.throw(403, noteLoadResult.reason);
@@ -100,7 +100,7 @@ router.delete('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
 
   const noteLoadResult = await NoteEntity.loader(viewerContext)
-    .nonEnforcing()
+    .withAuthorizationResults()
     .loadByIDAsync(ctx.params['id']!);
   if (!noteLoadResult.ok) {
     ctx.throw(403, noteLoadResult.reason);

--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -22,12 +22,12 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
 import { mapMap, mapMapAsync } from './utils/collections/maps';
 
 /**
- * Non-enforcing entity loader. All normal loads are batched,
+ * Authorization-result-based entity loader. All normal loads are batched,
  * cached, and authorized against the entity's EntityPrivacyPolicy. All loads through this
  * loader are are results (or null for some loader methods), where an unsuccessful result
- * means an authorization error occurred. Other errors are thrown.
+ * means an authorization error or entity construction error occurred. Other errors are thrown.
  */
-export default class NonEnforcingEntityLoader<
+export default class AuthorizationResultBasedEntityLoader<
   TFields extends object,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -3,15 +3,16 @@ import {
   QuerySelectionModifiers,
   QuerySelectionModifiersWithOrderByRaw,
 } from './EntityDatabaseAdapter';
-import EntityLoader from './EntityLoader';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import NonEnforcingEntityLoader from './NonEnforcingEntityLoader';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 import { mapMap } from './utils/collections/maps';
 
 /**
- * Enforcing view on an entity loader. All loads through this loader will throw
- * if the loads are not successful.
+ * Enforcing entity loader. All normal loads are batched,
+ * cached, and authorized against the entity's EntityPrivacyPolicy. All loads
+ * through this loader will throw if the load is not successful.
  */
 export default class EnforcingEntityLoader<
   TFields extends object,
@@ -28,7 +29,7 @@ export default class EnforcingEntityLoader<
   TSelectedFields extends keyof TFields,
 > {
   constructor(
-    private readonly entityLoader: EntityLoader<
+    private readonly entityLoader: NonEnforcingEntityLoader<
       TFields,
       TID,
       TViewerContext,

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -1,10 +1,10 @@
+import AuthorizationResultBasedEntityLoader from './AuthorizationResultBasedEntityLoader';
 import {
   FieldEqualityCondition,
   QuerySelectionModifiers,
   QuerySelectionModifiersWithOrderByRaw,
 } from './EntityDatabaseAdapter';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
-import NonEnforcingEntityLoader from './NonEnforcingEntityLoader';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 import { mapMap } from './utils/collections/maps';
@@ -29,7 +29,7 @@ export default class EnforcingEntityLoader<
   TSelectedFields extends keyof TFields,
 > {
   constructor(
-    private readonly entityLoader: NonEnforcingEntityLoader<
+    private readonly entityLoader: AuthorizationResultBasedEntityLoader<
       TFields,
       TID,
       TViewerContext,

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -76,7 +76,9 @@ export default class EntityAssociationLoader<
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
 
-    return (await loader.loadByIDAsync(associatedEntityID as unknown as TAssociatedID)) as Result<
+    return (await loader
+      .nonEnforcing()
+      .loadByIDAsync(associatedEntityID as unknown as TAssociatedID)) as Result<
       null extends TFields[TIdentifyingField] ? TAssociatedEntity | null : TAssociatedEntity
     >;
   }
@@ -129,10 +131,9 @@ export default class EntityAssociationLoader<
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
-    return await loader.loadManyByFieldEqualingAsync(
-      associatedEntityFieldContainingThisID,
-      thisID as any,
-    );
+    return await loader
+      .nonEnforcing()
+      .loadManyByFieldEqualingAsync(associatedEntityFieldContainingThisID, thisID as any);
   }
 
   /**
@@ -186,10 +187,9 @@ export default class EntityAssociationLoader<
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
-    return await loader.loadByFieldEqualingAsync(
-      associatedEntityLookupByField,
-      associatedFieldValue as any,
-    );
+    return await loader
+      .nonEnforcing()
+      .loadByFieldEqualingAsync(associatedEntityLookupByField, associatedFieldValue as any);
   }
 
   /**
@@ -244,10 +244,9 @@ export default class EntityAssociationLoader<
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
-    return await loader.loadManyByFieldEqualingAsync(
-      associatedEntityLookupByField,
-      associatedFieldValue as any,
-    );
+    return await loader
+      .nonEnforcing()
+      .loadManyByFieldEqualingAsync(associatedEntityLookupByField, associatedFieldValue as any);
   }
 
   /**

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -77,7 +77,7 @@ export default class EntityAssociationLoader<
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
 
     return (await loader
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByIDAsync(associatedEntityID as unknown as TAssociatedID)) as Result<
       null extends TFields[TIdentifyingField] ? TAssociatedEntity | null : TAssociatedEntity
     >;
@@ -132,7 +132,7 @@ export default class EntityAssociationLoader<
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
     return await loader
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadManyByFieldEqualingAsync(associatedEntityFieldContainingThisID, thisID as any);
   }
 
@@ -188,7 +188,7 @@ export default class EntityAssociationLoader<
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
     return await loader
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadByFieldEqualingAsync(associatedEntityLookupByField, associatedFieldValue as any);
   }
 
@@ -245,7 +245,7 @@ export default class EntityAssociationLoader<
       .getLoaderFactory()
       .forLoad(queryContext, { previousValue: null, cascadingDeleteCause: null });
     return await loader
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadManyByFieldEqualingAsync(associatedEntityLookupByField, associatedFieldValue as any);
   }
 

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -1,26 +1,13 @@
-import { Result, asyncResult, result } from '@expo/results';
-import invariant from 'invariant';
-import nullthrows from 'nullthrows';
-
 import EnforcingEntityLoader from './EnforcingEntityLoader';
 import { IEntityClass } from './Entity';
 import EntityConfiguration from './EntityConfiguration';
-import {
-  FieldEqualityCondition,
-  QuerySelectionModifiers,
-  isSingleValueFieldEqualityCondition,
-  QuerySelectionModifiersWithOrderByRaw,
-} from './EntityDatabaseAdapter';
 import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
+import NonEnforcingEntityLoader from './NonEnforcingEntityLoader';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
-import { pick } from './entityUtils';
-import EntityInvalidFieldValueError from './errors/EntityInvalidFieldValueError';
-import EntityNotFoundError from './errors/EntityNotFoundError';
 import EntityDataManager from './internal/EntityDataManager';
 import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
-import { mapMap, mapMapAsync } from './utils/collections/maps';
 
 /**
  * The primary interface for loading entities. All normal loads are batched,
@@ -66,7 +53,7 @@ export default class EntityLoader<
   ) {}
 
   /**
-   * Enforcing view on this entity loader. All loads through this view are
+   * Enforcing entity loader. All loads through this loader are
    * guaranteed to be the values of successful results (or null for some loader methods),
    * and will throw otherwise.
    */
@@ -78,317 +65,31 @@ export default class EntityLoader<
     TPrivacyPolicy,
     TSelectedFields
   > {
-    return new EnforcingEntityLoader(this);
+    return new EnforcingEntityLoader(this.nonEnforcing());
   }
 
   /**
-   * Load many entities where fieldName is one of fieldValues.
-   * @param fieldName - entity field being queried
-   * @param fieldValues - fieldName field values being queried
-   * @returns map from fieldValue to entity results that match the query for that fieldValue,
-   *          where result errors can be UnauthorizedError
+   * Non-enforcing entity loader. All loads through this loader are are results (or null for some loader methods),
+   * where an unsuccessful result means an authorization error. Other errors are thrown.
    */
-  async loadManyByFieldEqualingManyAsync<N extends keyof Pick<TFields, TSelectedFields>>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly Result<TEntity>[]>> {
-    this.validateFieldValues(fieldName, fieldValues);
-
-    const fieldValuesToFieldObjects = await this.dataManager.loadManyByFieldEqualingAsync(
+  nonEnforcing(): NonEnforcingEntityLoader<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new NonEnforcingEntityLoader(
+      this.viewerContext,
       this.queryContext,
-      fieldName,
-      fieldValues,
+      this.privacyPolicyEvaluationContext,
+      this.entityConfiguration,
+      this.entityClass,
+      this.entitySelectedFields,
+      this.privacyPolicy,
+      this.dataManager,
+      this.metricsAdapter,
     );
-
-    return await this.constructAndAuthorizeEntitiesAsync(fieldValuesToFieldObjects);
-  }
-
-  /**
-   * Load many entities where fieldName equals fieldValue.
-   * @param fieldName - entity field being queried
-   * @param fieldValue - fieldName field value being queried
-   * @returns array of entity results that match the query for fieldValue, where result error can be UnauthorizedError
-   */
-  async loadManyByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
-    fieldName: N,
-    fieldValue: NonNullable<TFields[N]>,
-  ): Promise<readonly Result<TEntity>[]> {
-    const entityResults = await this.loadManyByFieldEqualingManyAsync(fieldName, [fieldValue]);
-    const entityResultsForFieldValue = entityResults.get(fieldValue);
-    invariant(
-      entityResultsForFieldValue !== undefined,
-      `${fieldValue} should be guaranteed to be present in returned map of entities`,
-    );
-    return entityResultsForFieldValue!;
-  }
-
-  /**
-   * Load an entity where fieldName equals fieldValue, or null if no entity exists.
-   * @param uniqueFieldName - entity field being queried
-   * @param fieldValue - uniqueFieldName field value being queried
-   * @returns entity result where uniqueFieldName equals fieldValue, or null if no entity matches the condition.
-   * @throws when multiple entities match the condition
-   */
-  async loadByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
-    uniqueFieldName: N,
-    fieldValue: NonNullable<TFields[N]>,
-  ): Promise<Result<TEntity> | null> {
-    const entityResults = await this.loadManyByFieldEqualingAsync(uniqueFieldName, fieldValue);
-    invariant(
-      entityResults.length <= 1,
-      `loadByFieldEqualing: Multiple entities of type ${this.entityClass.name} found for ${String(
-        uniqueFieldName,
-      )}=${fieldValue}`,
-    );
-    return entityResults[0] ?? null;
-  }
-
-  /**
-   * Loads an entity by a specified ID.
-   * @param id - ID of the entity
-   * @returns entity result for matching ID, where result error can be UnauthorizedError or EntityNotFoundError.
-   */
-  async loadByIDAsync(id: TID): Promise<Result<TEntity>> {
-    const entityResults = await this.loadManyByIDsAsync([id]);
-    // loadManyByIDsAsync is always populated for each id supplied
-    return nullthrows(entityResults.get(id));
-  }
-
-  /**
-   * Load an entity by a specified ID, or return null if non-existent.
-   * @param id - ID of the entity
-   * @returns entity result for matching ID, or null if no entity exists for ID.
-   */
-  async loadByIDNullableAsync(id: TID): Promise<Result<TEntity> | null> {
-    return await this.loadByFieldEqualingAsync(
-      this.entityConfiguration.idField as TSelectedFields,
-      id,
-    );
-  }
-
-  /**
-   * Loads many entities for a list of IDs.
-   * @param ids - IDs of the entities to load
-   * @returns map from ID to corresponding entity result, where result error can be UnauthorizedError or EntityNotFoundError.
-   */
-  async loadManyByIDsAsync(ids: readonly TID[]): Promise<ReadonlyMap<TID, Result<TEntity>>> {
-    const entityResults = (await this.loadManyByFieldEqualingManyAsync(
-      this.entityConfiguration.idField as TSelectedFields,
-      ids,
-    )) as ReadonlyMap<TID, readonly Result<TEntity>[]>;
-    return mapMap(entityResults, (entityResultsForId, id) => {
-      const entityResult = entityResultsForId[0];
-      return (
-        entityResult ??
-        result(new EntityNotFoundError(this.entityClass, this.entityConfiguration.idField, id))
-      );
-    });
-  }
-
-  /**
-   * Loads many entities for a list of IDs, returning null for any IDs that are non-existent.
-   * @param ids - IDs of the entities to load
-   * @returns map from ID to nullable corresponding entity result, where result error can be UnauthorizedError or EntityNotFoundError.
-   */
-  async loadManyByIDsNullableAsync(
-    ids: readonly TID[],
-  ): Promise<ReadonlyMap<TID, Result<TEntity> | null>> {
-    const entityResults = (await this.loadManyByFieldEqualingManyAsync(
-      this.entityConfiguration.idField as TSelectedFields,
-      ids,
-    )) as ReadonlyMap<TID, readonly Result<TEntity>[]>;
-    return mapMap(entityResults, (entityResultsForId) => {
-      return entityResultsForId[0] ?? null;
-    });
-  }
-
-  /**
-   * Loads the first entity matching the selection constructed from the conjunction of specified
-   * operands, or null if no matching entity exists. Entities loaded using this method are not
-   * batched or cached.
-   *
-   * This is a convenience method for {@link loadManyByFieldEqualityConjunctionAsync}. However, the
-   * `orderBy` option must be specified to define what "first" means. If ordering doesn't matter,
-   * explicitly pass in an empty array.
-   *
-   * @param fieldEqualityOperands - list of field equality selection operand specifications
-   * @param querySelectionModifiers - orderBy and optional offset for the query
-   * @returns the first entity results that matches the query, where result error can be
-   *  UnauthorizedError
-   */
-  async loadFirstByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
-    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
-    querySelectionModifiers: Omit<QuerySelectionModifiers<TFields>, 'limit'> &
-      Required<Pick<QuerySelectionModifiers<TFields>, 'orderBy'>>,
-  ): Promise<Result<TEntity> | null> {
-    const results = await this.loadManyByFieldEqualityConjunctionAsync(fieldEqualityOperands, {
-      ...querySelectionModifiers,
-      limit: 1,
-    });
-    return results[0] ?? null;
-  }
-
-  /**
-   * Loads many entities matching the selection constructed from the conjunction of specified operands.
-   * Entities loaded using this method are not batched or cached.
-   *
-   * @example
-   * fieldEqualityOperands:
-   * `[{fieldName: 'hello', fieldValue: 1}, {fieldName: 'world', fieldValues: [2, 3]}]`
-   * Entities returned with a SQL EntityDatabaseAdapter:
-   * `WHERE hello = 1 AND world = ANY({2, 3})`
-   *
-   * @param fieldEqualityOperands - list of field equality selection operand specifications
-   * @param querySelectionModifiers - limit, offset, and orderBy for the query
-   * @returns array of entity results that match the query, where result error can be UnauthorizedError
-   */
-  async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
-    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
-    querySelectionModifiers: QuerySelectionModifiers<TFields> = {},
-  ): Promise<readonly Result<TEntity>[]> {
-    for (const fieldEqualityOperand of fieldEqualityOperands) {
-      const fieldValues = isSingleValueFieldEqualityCondition(fieldEqualityOperand)
-        ? [fieldEqualityOperand.fieldValue]
-        : fieldEqualityOperand.fieldValues;
-      this.validateFieldValues(fieldEqualityOperand.fieldName, fieldValues);
-    }
-
-    const fieldObjects = await this.dataManager.loadManyByFieldEqualityConjunctionAsync(
-      this.queryContext,
-      fieldEqualityOperands,
-      querySelectionModifiers,
-    );
-    return await this.constructAndAuthorizeEntitiesArrayAsync(fieldObjects);
-  }
-
-  /**
-   * Loads many entities matching the raw WHERE clause. Corresponds to the knex `whereRaw` argument format.
-   *
-   * @remarks
-   * Important notes:
-   * - Fields in clause are database column names instead of transformed entity field names.
-   * - Entities loaded using this method are not batched or cached.
-   * - Not all database adapters implement the ability to execute this method of fetching entities.
-   *
-   * @example
-   * rawWhereClause: `id = ?`
-   * bindings: `[1]`
-   * Entites returned `WHERE id = 1`
-   *
-   * http://knexjs.org/#Builder-whereRaw
-   * http://knexjs.org/#Raw-Bindings
-   *
-   * @param rawWhereClause - parameterized SQL WHERE clause with positional binding placeholders or named binding placeholders
-   * @param bindings - array of positional bindings or object of named bindings
-   * @param querySelectionModifiers - limit, offset, orderBy, and orderByRaw for the query
-   * @returns array of entity results that match the query, where result error can be UnauthorizedError
-   * @throws Error when rawWhereClause or bindings are invalid
-   */
-  async loadManyByRawWhereClauseAsync(
-    rawWhereClause: string,
-    bindings: any[] | object,
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByRaw<TFields> = {},
-  ): Promise<readonly Result<TEntity>[]> {
-    const fieldObjects = await this.dataManager.loadManyByRawWhereClauseAsync(
-      this.queryContext,
-      rawWhereClause,
-      bindings,
-      querySelectionModifiers,
-    );
-    return await this.constructAndAuthorizeEntitiesArrayAsync(fieldObjects);
-  }
-
-  /**
-   * Invalidate all caches for an entity's fields. Exposed primarily for internal use by EntityMutator.
-   * @param objectFields - entity data object to be invalidated
-   */
-  async invalidateFieldsAsync(objectFields: Readonly<TFields>): Promise<void> {
-    await this.dataManager.invalidateObjectFieldsAsync(objectFields);
-  }
-
-  /**
-   * Invalidate all caches for an entity. One potential use case would be to keep the entity
-   * framework in sync with changes made to data outside of the framework.
-   * @param entity - entity to be invalidated
-   */
-  async invalidateEntityAsync(entity: TEntity): Promise<void> {
-    await this.invalidateFieldsAsync(entity.getAllDatabaseFields());
-  }
-
-  private tryConstructEntities(fieldsObjects: readonly TFields[]): readonly Result<TEntity>[] {
-    return fieldsObjects.map((fieldsObject) => {
-      try {
-        return result(this.constructEntity(fieldsObject));
-      } catch (e) {
-        if (!(e instanceof Error)) {
-          throw e;
-        }
-        return result(e);
-      }
-    });
-  }
-
-  public constructEntity(fieldsObject: TFields): TEntity {
-    const idField = this.entityConfiguration.idField;
-    const id = nullthrows(fieldsObject[idField], 'must provide ID to create an entity');
-    const entitySelectedFields =
-      this.entitySelectedFields ?? Array.from(this.entityConfiguration.schema.keys());
-    const selectedFields = pick(fieldsObject, entitySelectedFields);
-    return new this.entityClass({
-      viewerContext: this.viewerContext,
-      id: id as TID,
-      databaseFields: fieldsObject,
-      selectedFields,
-    });
-  }
-
-  /**
-   * Construct and authorize entities from fields map, returning error results for entities that fail
-   * to construct or fail to authorize.
-   *
-   * @param map - map from an arbitrary key type to an array of entity field objects
-   */
-  public async constructAndAuthorizeEntitiesAsync<K>(
-    map: ReadonlyMap<K, readonly Readonly<TFields>[]>,
-  ): Promise<ReadonlyMap<K, readonly Result<TEntity>[]>> {
-    return await mapMapAsync(map, async (fieldObjects) => {
-      return await this.constructAndAuthorizeEntitiesArrayAsync(fieldObjects);
-    });
-  }
-
-  private async constructAndAuthorizeEntitiesArrayAsync(
-    fieldObjects: readonly Readonly<TFields>[],
-  ): Promise<readonly Result<TEntity>[]> {
-    const uncheckedEntityResults = this.tryConstructEntities(fieldObjects);
-    return await Promise.all(
-      uncheckedEntityResults.map(async (uncheckedEntityResult) => {
-        if (!uncheckedEntityResult.ok) {
-          return uncheckedEntityResult;
-        }
-        return await asyncResult(
-          this.privacyPolicy.authorizeReadAsync(
-            this.viewerContext,
-            this.queryContext,
-            this.privacyPolicyEvaluationContext,
-            uncheckedEntityResult.value,
-            this.metricsAdapter,
-          ),
-        );
-      }),
-    );
-  }
-
-  private validateFieldValues<N extends keyof Pick<TFields, TSelectedFields>>(
-    fieldName: N,
-    fieldValues: readonly TFields[N][],
-  ): void {
-    const fieldDefinition = this.entityConfiguration.schema.get(fieldName);
-    invariant(fieldDefinition, `must have field definition for field = ${String(fieldName)}`);
-    for (const fieldValue of fieldValues) {
-      const isInputValid = fieldDefinition.validateInputValue(fieldValue);
-      if (!isInputValid) {
-        throw new EntityInvalidFieldValueError(this.entityClass, fieldName, fieldValue);
-      }
-    }
   }
 }

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -1,9 +1,9 @@
+import AuthorizationResultBasedEntityLoader from './AuthorizationResultBasedEntityLoader';
 import EnforcingEntityLoader from './EnforcingEntityLoader';
 import { IEntityClass } from './Entity';
 import EntityConfiguration from './EntityConfiguration';
 import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
-import NonEnforcingEntityLoader from './NonEnforcingEntityLoader';
 import ReadonlyEntity from './ReadonlyEntity';
 import ViewerContext from './ViewerContext';
 import EntityDataManager from './internal/EntityDataManager';
@@ -65,14 +65,15 @@ export default class EntityLoader<
     TPrivacyPolicy,
     TSelectedFields
   > {
-    return new EnforcingEntityLoader(this.nonEnforcing());
+    return new EnforcingEntityLoader(this.withAuthorizationResults());
   }
 
   /**
-   * Non-enforcing entity loader. All loads through this loader are are results (or null for some loader methods),
-   * where an unsuccessful result means an authorization error. Other errors are thrown.
+   * Authorization-result-based entity loader. All loads through this
+   * loader are are results (or null for some loader methods), where an unsuccessful result
+   * means an authorization error or entity construction error occurred. Other errors are thrown.
    */
-  nonEnforcing(): NonEnforcingEntityLoader<
+  withAuthorizationResults(): AuthorizationResultBasedEntityLoader<
     TFields,
     TID,
     TViewerContext,
@@ -80,7 +81,7 @@ export default class EntityLoader<
     TPrivacyPolicy,
     TSelectedFields
   > {
-    return new NonEnforcingEntityLoader(
+    return new AuthorizationResultBasedEntityLoader(
       this.viewerContext,
       this.queryContext,
       this.privacyPolicyEvaluationContext,

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -216,7 +216,7 @@ export class CreateMutator<
       cascadingDeleteCause: null,
     });
 
-    const temporaryEntityForPrivacyCheck = entityLoader.nonEnforcing().constructEntity({
+    const temporaryEntityForPrivacyCheck = entityLoader.withAuthorizationResults().constructEntity({
       [this.entityConfiguration.idField]: '00000000-0000-0000-0000-000000000000', // zero UUID
       ...this.fieldsForEntity,
     } as unknown as TFields);
@@ -256,10 +256,14 @@ export class CreateMutator<
     const insertResult = await this.databaseAdapter.insertAsync(queryContext, this.fieldsForEntity);
 
     queryContext.appendPostCommitInvalidationCallback(
-      entityLoader.nonEnforcing().invalidateFieldsAsync.bind(entityLoader, insertResult),
+      entityLoader
+        .withAuthorizationResults()
+        .invalidateFieldsAsync.bind(entityLoader, insertResult),
     );
 
-    const unauthorizedEntityAfterInsert = entityLoader.nonEnforcing().constructEntity(insertResult);
+    const unauthorizedEntityAfterInsert = entityLoader
+      .withAuthorizationResults()
+      .constructEntity(insertResult);
     const newEntity = await entityLoader
       .enforcing()
       .loadByIDAsync(unauthorizedEntityAfterInsert.getID());
@@ -430,7 +434,7 @@ export class UpdateMutator<
     });
 
     const entityAboutToBeUpdated = entityLoader
-      .nonEnforcing()
+      .withAuthorizationResults()
       .constructEntity(this.fieldsForEntity);
     const authorizeUpdateResult = await asyncResult(
       this.privacyPolicy.authorizeUpdateAsync(
@@ -476,11 +480,13 @@ export class UpdateMutator<
 
     queryContext.appendPostCommitInvalidationCallback(
       entityLoader
-        .nonEnforcing()
+        .withAuthorizationResults()
         .invalidateFieldsAsync.bind(entityLoader, this.originalEntity.getAllDatabaseFields()),
     );
     queryContext.appendPostCommitInvalidationCallback(
-      entityLoader.nonEnforcing().invalidateFieldsAsync.bind(entityLoader, this.fieldsForEntity),
+      entityLoader
+        .withAuthorizationResults()
+        .invalidateFieldsAsync.bind(entityLoader, this.fieldsForEntity),
     );
 
     const updatedEntity = await entityLoader
@@ -684,7 +690,7 @@ export class DeleteMutator<
     });
     queryContext.appendPostCommitInvalidationCallback(
       entityLoader
-        .nonEnforcing()
+        .withAuthorizationResults()
         .invalidateFieldsAsync.bind(entityLoader, this.entity.getAllDatabaseFields()),
     );
 

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -84,9 +84,11 @@ export default abstract class EntitySecondaryCacheLoader<
     );
 
     // convert value to and from array to reuse complex code
-    const entitiesMap = await this.entityLoader.constructAndAuthorizeEntitiesAsync(
-      mapMap(loadParamsToFieldObjects, (fieldObject) => (fieldObject ? [fieldObject] : [])),
-    );
+    const entitiesMap = await this.entityLoader
+      .nonEnforcing()
+      .constructAndAuthorizeEntitiesAsync(
+        mapMap(loadParamsToFieldObjects, (fieldObject) => (fieldObject ? [fieldObject] : [])),
+      );
     return mapMap(entitiesMap, (fieldObjects) => fieldObjects[0] ?? null);
   }
 

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -85,7 +85,7 @@ export default abstract class EntitySecondaryCacheLoader<
 
     // convert value to and from array to reuse complex code
     const entitiesMap = await this.entityLoader
-      .nonEnforcing()
+      .withAuthorizationResults()
       .constructAndAuthorizeEntitiesAsync(
         mapMap(loadParamsToFieldObjects, (fieldObject) => (fieldObject ? [fieldObject] : [])),
       );

--- a/packages/entity/src/NonEnforcingEntityLoader.ts
+++ b/packages/entity/src/NonEnforcingEntityLoader.ts
@@ -1,0 +1,379 @@
+import { Result, asyncResult, result } from '@expo/results';
+import invariant from 'invariant';
+import nullthrows from 'nullthrows';
+
+import { IEntityClass } from './Entity';
+import EntityConfiguration from './EntityConfiguration';
+import {
+  FieldEqualityCondition,
+  QuerySelectionModifiers,
+  isSingleValueFieldEqualityCondition,
+  QuerySelectionModifiersWithOrderByRaw,
+} from './EntityDatabaseAdapter';
+import EntityPrivacyPolicy, { EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
+import { EntityQueryContext } from './EntityQueryContext';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+import { pick } from './entityUtils';
+import EntityInvalidFieldValueError from './errors/EntityInvalidFieldValueError';
+import EntityNotFoundError from './errors/EntityNotFoundError';
+import EntityDataManager from './internal/EntityDataManager';
+import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
+import { mapMap, mapMapAsync } from './utils/collections/maps';
+
+/**
+ * Non-enforcing entity loader. All normal loads are batched,
+ * cached, and authorized against the entity's EntityPrivacyPolicy. All loads through this
+ * loader are are results (or null for some loader methods), where an unsuccessful result
+ * means an authorization error occurred. Other errors are thrown.
+ */
+export default class NonEnforcingEntityLoader<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly viewerContext: TViewerContext,
+    private readonly queryContext: EntityQueryContext,
+    private readonly privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+    private readonly entitySelectedFields: TSelectedFields[] | undefined,
+    private readonly privacyPolicy: TPrivacyPolicy,
+    private readonly dataManager: EntityDataManager<TFields>,
+    protected readonly metricsAdapter: IEntityMetricsAdapter,
+  ) {}
+
+  /**
+   * Load many entities where fieldName is one of fieldValues.
+   * @param fieldName - entity field being queried
+   * @param fieldValues - fieldName field values being queried
+   * @returns map from fieldValue to entity results that match the query for that fieldValue,
+   *          where result errors can be UnauthorizedError
+   */
+  async loadManyByFieldEqualingManyAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldName: N,
+    fieldValues: readonly NonNullable<TFields[N]>[],
+  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly Result<TEntity>[]>> {
+    this.validateFieldValues(fieldName, fieldValues);
+
+    const fieldValuesToFieldObjects = await this.dataManager.loadManyByFieldEqualingAsync(
+      this.queryContext,
+      fieldName,
+      fieldValues,
+    );
+
+    return await this.constructAndAuthorizeEntitiesAsync(fieldValuesToFieldObjects);
+  }
+
+  /**
+   * Load many entities where fieldName equals fieldValue.
+   * @param fieldName - entity field being queried
+   * @param fieldValue - fieldName field value being queried
+   * @returns array of entity results that match the query for fieldValue, where result error can be UnauthorizedError
+   */
+  async loadManyByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>,
+  ): Promise<readonly Result<TEntity>[]> {
+    const entityResults = await this.loadManyByFieldEqualingManyAsync(fieldName, [fieldValue]);
+    const entityResultsForFieldValue = entityResults.get(fieldValue);
+    invariant(
+      entityResultsForFieldValue !== undefined,
+      `${fieldValue} should be guaranteed to be present in returned map of entities`,
+    );
+    return entityResultsForFieldValue!;
+  }
+
+  /**
+   * Load an entity where fieldName equals fieldValue, or null if no entity exists.
+   * @param uniqueFieldName - entity field being queried
+   * @param fieldValue - uniqueFieldName field value being queried
+   * @returns entity result where uniqueFieldName equals fieldValue, or null if no entity matches the condition.
+   * @throws when multiple entities match the condition
+   */
+  async loadByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    uniqueFieldName: N,
+    fieldValue: NonNullable<TFields[N]>,
+  ): Promise<Result<TEntity> | null> {
+    const entityResults = await this.loadManyByFieldEqualingAsync(uniqueFieldName, fieldValue);
+    invariant(
+      entityResults.length <= 1,
+      `loadByFieldEqualing: Multiple entities of type ${this.entityClass.name} found for ${String(
+        uniqueFieldName,
+      )}=${fieldValue}`,
+    );
+    return entityResults[0] ?? null;
+  }
+
+  /**
+   * Loads an entity by a specified ID.
+   * @param id - ID of the entity
+   * @returns entity result for matching ID, where result error can be UnauthorizedError or EntityNotFoundError.
+   */
+  async loadByIDAsync(id: TID): Promise<Result<TEntity>> {
+    const entityResults = await this.loadManyByIDsAsync([id]);
+    // loadManyByIDsAsync is always populated for each id supplied
+    return nullthrows(entityResults.get(id));
+  }
+
+  /**
+   * Load an entity by a specified ID, or return null if non-existent.
+   * @param id - ID of the entity
+   * @returns entity result for matching ID, or null if no entity exists for ID.
+   */
+  async loadByIDNullableAsync(id: TID): Promise<Result<TEntity> | null> {
+    return await this.loadByFieldEqualingAsync(
+      this.entityConfiguration.idField as TSelectedFields,
+      id,
+    );
+  }
+
+  /**
+   * Loads many entities for a list of IDs.
+   * @param ids - IDs of the entities to load
+   * @returns map from ID to corresponding entity result, where result error can be UnauthorizedError or EntityNotFoundError.
+   */
+  async loadManyByIDsAsync(ids: readonly TID[]): Promise<ReadonlyMap<TID, Result<TEntity>>> {
+    const entityResults = (await this.loadManyByFieldEqualingManyAsync(
+      this.entityConfiguration.idField as TSelectedFields,
+      ids,
+    )) as ReadonlyMap<TID, readonly Result<TEntity>[]>;
+    return mapMap(entityResults, (entityResultsForId, id) => {
+      const entityResult = entityResultsForId[0];
+      return (
+        entityResult ??
+        result(new EntityNotFoundError(this.entityClass, this.entityConfiguration.idField, id))
+      );
+    });
+  }
+
+  /**
+   * Loads many entities for a list of IDs, returning null for any IDs that are non-existent.
+   * @param ids - IDs of the entities to load
+   * @returns map from ID to nullable corresponding entity result, where result error can be UnauthorizedError or EntityNotFoundError.
+   */
+  async loadManyByIDsNullableAsync(
+    ids: readonly TID[],
+  ): Promise<ReadonlyMap<TID, Result<TEntity> | null>> {
+    const entityResults = (await this.loadManyByFieldEqualingManyAsync(
+      this.entityConfiguration.idField as TSelectedFields,
+      ids,
+    )) as ReadonlyMap<TID, readonly Result<TEntity>[]>;
+    return mapMap(entityResults, (entityResultsForId) => {
+      return entityResultsForId[0] ?? null;
+    });
+  }
+
+  /**
+   * Loads the first entity matching the selection constructed from the conjunction of specified
+   * operands, or null if no matching entity exists. Entities loaded using this method are not
+   * batched or cached.
+   *
+   * This is a convenience method for {@link loadManyByFieldEqualityConjunctionAsync}. However, the
+   * `orderBy` option must be specified to define what "first" means. If ordering doesn't matter,
+   * explicitly pass in an empty array.
+   *
+   * @param fieldEqualityOperands - list of field equality selection operand specifications
+   * @param querySelectionModifiers - orderBy and optional offset for the query
+   * @returns the first entity results that matches the query, where result error can be
+   *  UnauthorizedError
+   */
+  async loadFirstByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
+    querySelectionModifiers: Omit<QuerySelectionModifiers<TFields>, 'limit'> &
+      Required<Pick<QuerySelectionModifiers<TFields>, 'orderBy'>>,
+  ): Promise<Result<TEntity> | null> {
+    const results = await this.loadManyByFieldEqualityConjunctionAsync(fieldEqualityOperands, {
+      ...querySelectionModifiers,
+      limit: 1,
+    });
+    return results[0] ?? null;
+  }
+
+  /**
+   * Loads many entities matching the selection constructed from the conjunction of specified operands.
+   * Entities loaded using this method are not batched or cached.
+   *
+   * @example
+   * fieldEqualityOperands:
+   * `[{fieldName: 'hello', fieldValue: 1}, {fieldName: 'world', fieldValues: [2, 3]}]`
+   * Entities returned with a SQL EntityDatabaseAdapter:
+   * `WHERE hello = 1 AND world = ANY({2, 3})`
+   *
+   * @param fieldEqualityOperands - list of field equality selection operand specifications
+   * @param querySelectionModifiers - limit, offset, and orderBy for the query
+   * @returns array of entity results that match the query, where result error can be UnauthorizedError
+   */
+  async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
+    querySelectionModifiers: QuerySelectionModifiers<TFields> = {},
+  ): Promise<readonly Result<TEntity>[]> {
+    for (const fieldEqualityOperand of fieldEqualityOperands) {
+      const fieldValues = isSingleValueFieldEqualityCondition(fieldEqualityOperand)
+        ? [fieldEqualityOperand.fieldValue]
+        : fieldEqualityOperand.fieldValues;
+      this.validateFieldValues(fieldEqualityOperand.fieldName, fieldValues);
+    }
+
+    const fieldObjects = await this.dataManager.loadManyByFieldEqualityConjunctionAsync(
+      this.queryContext,
+      fieldEqualityOperands,
+      querySelectionModifiers,
+    );
+    return await this.constructAndAuthorizeEntitiesArrayAsync(fieldObjects);
+  }
+
+  /**
+   * Loads many entities matching the raw WHERE clause. Corresponds to the knex `whereRaw` argument format.
+   *
+   * @remarks
+   * Important notes:
+   * - Fields in clause are database column names instead of transformed entity field names.
+   * - Entities loaded using this method are not batched or cached.
+   * - Not all database adapters implement the ability to execute this method of fetching entities.
+   *
+   * @example
+   * rawWhereClause: `id = ?`
+   * bindings: `[1]`
+   * Entites returned `WHERE id = 1`
+   *
+   * http://knexjs.org/#Builder-whereRaw
+   * http://knexjs.org/#Raw-Bindings
+   *
+   * @param rawWhereClause - parameterized SQL WHERE clause with positional binding placeholders or named binding placeholders
+   * @param bindings - array of positional bindings or object of named bindings
+   * @param querySelectionModifiers - limit, offset, orderBy, and orderByRaw for the query
+   * @returns array of entity results that match the query, where result error can be UnauthorizedError
+   * @throws Error when rawWhereClause or bindings are invalid
+   */
+  async loadManyByRawWhereClauseAsync(
+    rawWhereClause: string,
+    bindings: any[] | object,
+    querySelectionModifiers: QuerySelectionModifiersWithOrderByRaw<TFields> = {},
+  ): Promise<readonly Result<TEntity>[]> {
+    const fieldObjects = await this.dataManager.loadManyByRawWhereClauseAsync(
+      this.queryContext,
+      rawWhereClause,
+      bindings,
+      querySelectionModifiers,
+    );
+    return await this.constructAndAuthorizeEntitiesArrayAsync(fieldObjects);
+  }
+
+  /**
+   * Invalidate all caches for an entity's fields. Exposed primarily for internal use by EntityMutator.
+   * @param objectFields - entity data object to be invalidated
+   */
+  async invalidateFieldsAsync(objectFields: Readonly<TFields>): Promise<void> {
+    await this.dataManager.invalidateObjectFieldsAsync(objectFields);
+  }
+
+  /**
+   * Invalidate all caches for an entity. One potential use case would be to keep the entity
+   * framework in sync with changes made to data outside of the framework.
+   * @param entity - entity to be invalidated
+   */
+  async invalidateEntityAsync(entity: TEntity): Promise<void> {
+    await this.invalidateFieldsAsync(entity.getAllDatabaseFields());
+  }
+
+  private tryConstructEntities(fieldsObjects: readonly TFields[]): readonly Result<TEntity>[] {
+    return fieldsObjects.map((fieldsObject) => {
+      try {
+        return result(this.constructEntity(fieldsObject));
+      } catch (e) {
+        if (!(e instanceof Error)) {
+          throw e;
+        }
+        return result(e);
+      }
+    });
+  }
+
+  public constructEntity(fieldsObject: TFields): TEntity {
+    const idField = this.entityConfiguration.idField;
+    const id = nullthrows(fieldsObject[idField], 'must provide ID to create an entity');
+    const entitySelectedFields =
+      this.entitySelectedFields ?? Array.from(this.entityConfiguration.schema.keys());
+    const selectedFields = pick(fieldsObject, entitySelectedFields);
+    return new this.entityClass({
+      viewerContext: this.viewerContext,
+      id: id as TID,
+      databaseFields: fieldsObject,
+      selectedFields,
+    });
+  }
+
+  /**
+   * Construct and authorize entities from fields map, returning error results for entities that fail
+   * to construct or fail to authorize.
+   *
+   * @param map - map from an arbitrary key type to an array of entity field objects
+   */
+  public async constructAndAuthorizeEntitiesAsync<K>(
+    map: ReadonlyMap<K, readonly Readonly<TFields>[]>,
+  ): Promise<ReadonlyMap<K, readonly Result<TEntity>[]>> {
+    return await mapMapAsync(map, async (fieldObjects) => {
+      return await this.constructAndAuthorizeEntitiesArrayAsync(fieldObjects);
+    });
+  }
+
+  private async constructAndAuthorizeEntitiesArrayAsync(
+    fieldObjects: readonly Readonly<TFields>[],
+  ): Promise<readonly Result<TEntity>[]> {
+    const uncheckedEntityResults = this.tryConstructEntities(fieldObjects);
+    return await Promise.all(
+      uncheckedEntityResults.map(async (uncheckedEntityResult) => {
+        if (!uncheckedEntityResult.ok) {
+          return uncheckedEntityResult;
+        }
+        return await asyncResult(
+          this.privacyPolicy.authorizeReadAsync(
+            this.viewerContext,
+            this.queryContext,
+            this.privacyPolicyEvaluationContext,
+            uncheckedEntityResult.value,
+            this.metricsAdapter,
+          ),
+        );
+      }),
+    );
+  }
+
+  private validateFieldValues<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldName: N,
+    fieldValues: readonly TFields[N][],
+  ): void {
+    const fieldDefinition = this.entityConfiguration.schema.get(fieldName);
+    invariant(fieldDefinition, `must have field definition for field = ${String(fieldName)}`);
+    for (const fieldValue of fieldValues) {
+      const isInputValid = fieldDefinition.validateInputValue(fieldValue);
+      if (!isInputValid) {
+        throw new EntityInvalidFieldValueError(this.entityClass, fieldName, fieldValue);
+      }
+    }
+  }
+}

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -2,39 +2,45 @@ import { result } from '@expo/results';
 import { mock, instance, when, anything } from 'ts-mockito';
 
 import EnforcingEntityLoader from '../EnforcingEntityLoader';
-import EntityLoader from '../EntityLoader';
+import NonEnforcingEntityLoader from '../NonEnforcingEntityLoader';
 
 describe(EnforcingEntityLoader, () => {
   describe('loadManyByFieldEqualingManyAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything())).thenResolve(
+      when(
+        nonEnforcingEntityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything()),
+      ).thenResolve(
         new Map(
           Object.entries({
             hello: [result(rejection)],
           }),
         ),
       );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByFieldEqualingManyAsync(anything(), anything()),
       ).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything())).thenResolve(
+      when(
+        nonEnforcingEntityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything()),
+      ).thenResolve(
         new Map(
           Object.entries({
             hello: [result(resolved)],
           }),
         ),
       );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByFieldEqualingManyAsync(anything(), anything()),
       ).resolves.toEqual(
@@ -49,26 +55,28 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByFieldEqualingAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything())).thenResolve([
-        result(rejection),
-      ]);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve([result(rejection)]);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByFieldEqualingAsync(anything(), anything()),
       ).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything())).thenResolve([
-        result(resolved),
-      ]);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve([result(resolved)]);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByFieldEqualingAsync(anything(), anything()),
       ).resolves.toEqual([resolved]);
@@ -77,52 +85,56 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByFieldEqualingAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenResolve(
-        result(rejection),
-      );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve(result(rejection));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadByFieldEqualingAsync(anything(), anything()),
       ).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenResolve(
-        result(resolved),
-      );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve(result(resolved));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadByFieldEqualingAsync(anything(), anything()),
       ).resolves.toEqual(resolved);
     });
 
     it('returns null when result is successful and no entity is found', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = null;
-      when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenResolve(
-        result(resolved),
-      );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve(result(resolved));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadByFieldEqualingAsync(anything(), anything()),
       ).resolves.toEqual(resolved);
     });
 
     it('throws when multiple matching entities are found', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const multipleEntitiesError = new Error();
-      when(entityLoaderMock.loadByFieldEqualingAsync(anything(), anything())).thenReject(
-        multipleEntitiesError,
-      );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
+      ).thenReject(multipleEntitiesError);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadByFieldEqualingAsync(anything(), anything()),
       ).rejects.toEqual(multipleEntitiesError);
@@ -131,53 +143,64 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByIDAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadByIDAsync(anything())).thenResolve(result(rejection));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(nonEnforcingEntityLoaderMock.loadByIDAsync(anything())).thenResolve(result(rejection));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadByIDAsync(anything())).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadByIDAsync(anything())).thenResolve(result(resolved));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(nonEnforcingEntityLoaderMock.loadByIDAsync(anything())).thenResolve(result(resolved));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadByIDAsync(anything())).resolves.toEqual(resolved);
     });
   });
 
   describe('loadByIDNullableAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(rejection));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(nonEnforcingEntityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(
+        result(rejection),
+      );
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadByIDNullableAsync(anything())).rejects.toThrow(
         rejection,
       );
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(resolved));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(nonEnforcingEntityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(
+        result(resolved),
+      );
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadByIDNullableAsync(anything())).resolves.toEqual(
         resolved,
       );
     });
 
     it('returns null when non-existent object', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = null;
-      when(entityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(result(resolved));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      when(nonEnforcingEntityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(
+        result(resolved),
+      );
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadByIDNullableAsync(anything())).resolves.toEqual(
         resolved,
       );
@@ -186,32 +209,34 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByIDsAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
+      when(nonEnforcingEntityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
         new Map(
           Object.entries({
             hello: result(rejection),
           }),
         ),
       );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadManyByIDsAsync(anything())).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
+      when(nonEnforcingEntityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
         new Map(
           Object.entries({
             hello: result(resolved),
           }),
         ),
       );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadManyByIDsAsync(anything())).resolves.toEqual(
         new Map(
           Object.entries({
@@ -224,9 +249,10 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByIDsNullableAsync', () => {
     it('throws when result is unsuccessful even when there is a null result', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
-      when(entityLoaderMock.loadManyByIDsNullableAsync(anything())).thenResolve(
+      when(nonEnforcingEntityLoaderMock.loadManyByIDsNullableAsync(anything())).thenResolve(
         new Map(
           Object.entries({
             hello: result(rejection),
@@ -234,17 +260,18 @@ describe(EnforcingEntityLoader, () => {
           }),
         ),
       );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadManyByIDsNullableAsync(anything())).rejects.toThrow(
         rejection,
       );
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
-      when(entityLoaderMock.loadManyByIDsNullableAsync(anything())).thenResolve(
+      when(nonEnforcingEntityLoaderMock.loadManyByIDsNullableAsync(anything())).thenResolve(
         new Map(
           Object.entries({
             hello: result(resolved),
@@ -252,8 +279,8 @@ describe(EnforcingEntityLoader, () => {
           }),
         ),
       );
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(enforcingEntityLoader.loadManyByIDsNullableAsync(anything())).resolves.toEqual(
         new Map(
           Object.entries({
@@ -267,38 +294,50 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadFirstByFieldEqualityConjunction', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
       when(
-        entityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(
+          anything(),
+          anything(),
+        ),
       ).thenResolve(result(rejection));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
       ).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
       when(
-        entityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(
+          anything(),
+          anything(),
+        ),
       ).thenResolve(result(resolved));
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
       ).resolves.toEqual(resolved);
     });
 
     it('returns null when the query is successful but no rows match', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       when(
-        entityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(
+          anything(),
+          anything(),
+        ),
       ).thenResolve(null);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
       ).resolves.toBeNull();
@@ -307,26 +346,34 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByFieldEqualityConjunction', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
       when(
-        entityLoaderMock.loadManyByFieldEqualityConjunctionAsync(anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadManyByFieldEqualityConjunctionAsync(
+          anything(),
+          anything(),
+        ),
       ).thenResolve([result(rejection)]);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByFieldEqualityConjunctionAsync(anything(), anything()),
       ).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
       when(
-        entityLoaderMock.loadManyByFieldEqualityConjunctionAsync(anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadManyByFieldEqualityConjunctionAsync(
+          anything(),
+          anything(),
+        ),
       ).thenResolve([result(resolved)]);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByFieldEqualityConjunctionAsync(anything(), anything()),
       ).resolves.toEqual([resolved]);
@@ -335,26 +382,36 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByRawWhereClause', () => {
     it('throws when result is unsuccessful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const rejection = new Error();
       when(
-        entityLoaderMock.loadManyByRawWhereClauseAsync(anything(), anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadManyByRawWhereClauseAsync(
+          anything(),
+          anything(),
+          anything(),
+        ),
       ).thenResolve([result(rejection)]);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByRawWhereClauseAsync(anything(), anything(), anything()),
       ).rejects.toThrow(rejection);
     });
 
     it('returns value when result is successful', async () => {
-      const entityLoaderMock = mock<EntityLoader<any, any, any, any, any, any>>(EntityLoader);
+      const nonEnforcingEntityLoaderMock =
+        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
       const resolved = {};
       when(
-        entityLoaderMock.loadManyByRawWhereClauseAsync(anything(), anything(), anything()),
+        nonEnforcingEntityLoaderMock.loadManyByRawWhereClauseAsync(
+          anything(),
+          anything(),
+          anything(),
+        ),
       ).thenResolve([result(resolved)]);
-      const entityLoader = instance(entityLoaderMock);
-      const enforcingEntityLoader = new EnforcingEntityLoader(entityLoader);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadManyByRawWhereClauseAsync(anything(), anything(), anything()),
       ).resolves.toEqual([resolved]);
@@ -363,11 +420,12 @@ describe(EnforcingEntityLoader, () => {
 
   it('has the same method names as EntityLoader', () => {
     const enforcingLoaderProperties = Object.getOwnPropertyNames(EnforcingEntityLoader.prototype);
-    const loaderProperties = Object.getOwnPropertyNames(EntityLoader.prototype);
+    const nonEnforcingLoaderProperties = Object.getOwnPropertyNames(
+      NonEnforcingEntityLoader.prototype,
+    );
 
     // ensure known differences still exist for sanity check
     const knownLoaderOnlyDifferences = [
-      'enforcing',
       'invalidateFieldsAsync',
       'invalidateEntityAsync',
       'tryConstructEntities',
@@ -376,9 +434,11 @@ describe(EnforcingEntityLoader, () => {
       'constructAndAuthorizeEntitiesArrayAsync',
       'constructEntity',
     ];
-    expect(loaderProperties).toEqual(expect.arrayContaining(knownLoaderOnlyDifferences));
+    expect(nonEnforcingLoaderProperties).toEqual(
+      expect.arrayContaining(knownLoaderOnlyDifferences),
+    );
 
-    const loaderPropertiesWithoutKnownDifferences = loaderProperties.filter(
+    const loaderPropertiesWithoutKnownDifferences = nonEnforcingLoaderProperties.filter(
       (p) => !knownLoaderOnlyDifferences.includes(p),
     );
 

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -1,14 +1,15 @@
 import { result } from '@expo/results';
 import { mock, instance, when, anything } from 'ts-mockito';
 
+import AuthorizationResultBasedEntityLoader from '../AuthorizationResultBasedEntityLoader';
 import EnforcingEntityLoader from '../EnforcingEntityLoader';
-import NonEnforcingEntityLoader from '../NonEnforcingEntityLoader';
 
 describe(EnforcingEntityLoader, () => {
   describe('loadManyByFieldEqualingManyAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything()),
@@ -27,8 +28,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(
         nonEnforcingEntityLoaderMock.loadManyByFieldEqualingManyAsync(anything(), anything()),
@@ -55,8 +57,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByFieldEqualingAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything()),
@@ -69,8 +72,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(
         nonEnforcingEntityLoaderMock.loadManyByFieldEqualingAsync(anything(), anything()),
@@ -85,8 +89,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByFieldEqualingAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
@@ -99,8 +104,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(
         nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
@@ -113,8 +119,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns null when result is successful and no entity is found', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = null;
       when(
         nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
@@ -127,8 +134,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('throws when multiple matching entities are found', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const multipleEntitiesError = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadByFieldEqualingAsync(anything(), anything()),
@@ -143,8 +151,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByIDAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(nonEnforcingEntityLoaderMock.loadByIDAsync(anything())).thenResolve(result(rejection));
       const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
@@ -153,8 +162,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(nonEnforcingEntityLoaderMock.loadByIDAsync(anything())).thenResolve(result(resolved));
       const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
@@ -165,8 +175,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadByIDNullableAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(nonEnforcingEntityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(
         result(rejection),
@@ -179,8 +190,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(nonEnforcingEntityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(
         result(resolved),
@@ -193,8 +205,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns null when non-existent object', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = null;
       when(nonEnforcingEntityLoaderMock.loadByIDNullableAsync(anything())).thenResolve(
         result(resolved),
@@ -209,8 +222,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByIDsAsync', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(nonEnforcingEntityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
         new Map(
@@ -225,8 +239,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(nonEnforcingEntityLoaderMock.loadManyByIDsAsync(anything())).thenResolve(
         new Map(
@@ -249,8 +264,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByIDsNullableAsync', () => {
     it('throws when result is unsuccessful even when there is a null result', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(nonEnforcingEntityLoaderMock.loadManyByIDsNullableAsync(anything())).thenResolve(
         new Map(
@@ -268,8 +284,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(nonEnforcingEntityLoaderMock.loadManyByIDsNullableAsync(anything())).thenResolve(
         new Map(
@@ -294,8 +311,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadFirstByFieldEqualityConjunction', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(
@@ -311,8 +329,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(
         nonEnforcingEntityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(
@@ -328,8 +347,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns null when the query is successful but no rows match', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       when(
         nonEnforcingEntityLoaderMock.loadFirstByFieldEqualityConjunctionAsync(
           anything(),
@@ -346,8 +366,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByFieldEqualityConjunction', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadManyByFieldEqualityConjunctionAsync(
@@ -363,8 +384,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(
         nonEnforcingEntityLoaderMock.loadManyByFieldEqualityConjunctionAsync(
@@ -382,8 +404,9 @@ describe(EnforcingEntityLoader, () => {
 
   describe('loadManyByRawWhereClause', () => {
     it('throws when result is unsuccessful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const rejection = new Error();
       when(
         nonEnforcingEntityLoaderMock.loadManyByRawWhereClauseAsync(
@@ -400,8 +423,9 @@ describe(EnforcingEntityLoader, () => {
     });
 
     it('returns value when result is successful', async () => {
-      const nonEnforcingEntityLoaderMock =
-        mock<NonEnforcingEntityLoader<any, any, any, any, any, any>>(NonEnforcingEntityLoader);
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
       const resolved = {};
       when(
         nonEnforcingEntityLoaderMock.loadManyByRawWhereClauseAsync(
@@ -421,7 +445,7 @@ describe(EnforcingEntityLoader, () => {
   it('has the same method names as EntityLoader', () => {
     const enforcingLoaderProperties = Object.getOwnPropertyNames(EnforcingEntityLoader.prototype);
     const nonEnforcingLoaderProperties = Object.getOwnPropertyNames(
-      NonEnforcingEntityLoader.prototype,
+      AuthorizationResultBasedEntityLoader.prototype,
     );
 
     // ensure known differences still exist for sanity check

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -135,15 +135,15 @@ it('runs through a common workflow', async () => {
 
   // check that two people can't read each others data
   await expect(
-    enforceAsyncResult(BlahEntity.loader(vc1).loadByIDAsync(blahOwner2.getID())),
+    enforceAsyncResult(BlahEntity.loader(vc1).nonEnforcing().loadByIDAsync(blahOwner2.getID())),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
   await expect(
-    enforceAsyncResult(BlahEntity.loader(vc2).loadByIDAsync(blahOwner1.getID())),
+    enforceAsyncResult(BlahEntity.loader(vc2).nonEnforcing().loadByIDAsync(blahOwner1.getID())),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
   // check that all of owner 1's objects can be loaded
   const results = await enforceResultsAsync(
-    BlahEntity.loader(vc1).loadManyByFieldEqualingAsync('ownerID', vc1.getUserID()!),
+    BlahEntity.loader(vc1).nonEnforcing().loadManyByFieldEqualingAsync('ownerID', vc1.getUserID()!),
   );
   expect(results).toHaveLength(2);
 
@@ -155,7 +155,9 @@ it('runs through a common workflow', async () => {
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
   // check that empty load many returns nothing
-  const results2 = await BlahEntity.loader(vc1).loadManyByFieldEqualingManyAsync('ownerID', []);
+  const results2 = await BlahEntity.loader(vc1)
+    .nonEnforcing()
+    .loadManyByFieldEqualingManyAsync('ownerID', []);
   for (const value in results2.values) {
     expect(value).toHaveLength(0);
   }

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -135,15 +135,21 @@ it('runs through a common workflow', async () => {
 
   // check that two people can't read each others data
   await expect(
-    enforceAsyncResult(BlahEntity.loader(vc1).nonEnforcing().loadByIDAsync(blahOwner2.getID())),
+    enforceAsyncResult(
+      BlahEntity.loader(vc1).withAuthorizationResults().loadByIDAsync(blahOwner2.getID()),
+    ),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
   await expect(
-    enforceAsyncResult(BlahEntity.loader(vc2).nonEnforcing().loadByIDAsync(blahOwner1.getID())),
+    enforceAsyncResult(
+      BlahEntity.loader(vc2).withAuthorizationResults().loadByIDAsync(blahOwner1.getID()),
+    ),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
   // check that all of owner 1's objects can be loaded
   const results = await enforceResultsAsync(
-    BlahEntity.loader(vc1).nonEnforcing().loadManyByFieldEqualingAsync('ownerID', vc1.getUserID()!),
+    BlahEntity.loader(vc1)
+      .withAuthorizationResults()
+      .loadManyByFieldEqualingAsync('ownerID', vc1.getUserID()!),
   );
   expect(results).toHaveLength(2);
 
@@ -156,7 +162,7 @@ it('runs through a common workflow', async () => {
 
   // check that empty load many returns nothing
   const results2 = await BlahEntity.loader(vc1)
-    .nonEnforcing()
+    .withAuthorizationResults()
     .loadManyByFieldEqualingManyAsync('ownerID', []);
   for (const value in results2.values) {
     expect(value).toHaveLength(0);

--- a/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
@@ -180,14 +180,16 @@ describe(EntityLoader, () => {
 
     let capturedThrownThing1: any;
     try {
-      await entityLoader.nonEnforcing().loadByIDAsync(ID_SENTINEL_THROW_LITERAL);
+      await entityLoader.withAuthorizationResults().loadByIDAsync(ID_SENTINEL_THROW_LITERAL);
     } catch (e) {
       capturedThrownThing1 = e;
     }
     expect(capturedThrownThing1).not.toBeInstanceOf(Error);
     expect(capturedThrownThing1).toEqual('hello');
 
-    const result = await entityLoader.nonEnforcing().loadByIDAsync(ID_SENTINEL_THROW_ERROR);
+    const result = await entityLoader
+      .withAuthorizationResults()
+      .loadByIDAsync(ID_SENTINEL_THROW_ERROR);
     expect(result.ok).toBe(false);
     expect(result.enforceError().message).toEqual('world');
   });

--- a/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-constructor-test.ts
@@ -180,14 +180,14 @@ describe(EntityLoader, () => {
 
     let capturedThrownThing1: any;
     try {
-      await entityLoader.loadByIDAsync(ID_SENTINEL_THROW_LITERAL);
+      await entityLoader.nonEnforcing().loadByIDAsync(ID_SENTINEL_THROW_LITERAL);
     } catch (e) {
       capturedThrownThing1 = e;
     }
     expect(capturedThrownThing1).not.toBeInstanceOf(Error);
     expect(capturedThrownThing1).toEqual('hello');
 
-    const result = await entityLoader.loadByIDAsync(ID_SENTINEL_THROW_ERROR);
+    const result = await entityLoader.nonEnforcing().loadByIDAsync(ID_SENTINEL_THROW_ERROR);
     expect(result.ok).toBe(false);
     expect(result.enforceError().message).toEqual('world');
   });

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -84,20 +84,24 @@ describe(EntityLoader, () => {
       dataManager,
       metricsAdapter,
     );
-    const entity = await enforceAsyncResult(entityLoader.loadByIDAsync(id1));
+    const entity = await enforceAsyncResult(entityLoader.nonEnforcing().loadByIDAsync(id1));
     expect(entity.getID()).toEqual(id1);
     expect(entity.getField('dateField')).toEqual(dateToInsert);
 
     const entities = await enforceResultsAsync(
-      entityLoader.loadManyByFieldEqualingAsync('stringField', 'huh'),
+      entityLoader.nonEnforcing().loadManyByFieldEqualingAsync('stringField', 'huh'),
     );
     expect(entities.map((m) => m.getID())).toEqual([id1, id2]);
 
-    const entityResultNumber3 = await entityLoader.loadByFieldEqualingAsync('intField', 3);
+    const entityResultNumber3 = await entityLoader
+      .nonEnforcing()
+      .loadByFieldEqualingAsync('intField', 3);
     expect(entityResultNumber3).not.toBeNull();
     expect(entityResultNumber3!.enforceValue().getID()).toEqual(id2);
 
-    const entityResultNumber4 = await entityLoader.loadByFieldEqualingAsync('intField', 4);
+    const entityResultNumber4 = await entityLoader
+      .nonEnforcing()
+      .loadByFieldEqualingAsync('intField', 4);
     expect(entityResultNumber4).toBeNull();
 
     const entityResultDuplicateValues = await entityLoader
@@ -106,23 +110,27 @@ describe(EntityLoader, () => {
     expect(entityResultDuplicateValues.size).toBe(1);
     expect(entityResultDuplicateValues.get('huh')?.map((m) => m.getID())).toEqual([id1, id2]);
 
-    await expect(entityLoader.loadByFieldEqualingAsync('stringField', 'huh')).rejects.toThrowError(
+    await expect(
+      entityLoader.nonEnforcing().loadByFieldEqualingAsync('stringField', 'huh'),
+    ).rejects.toThrowError(
       'loadByFieldEqualing: Multiple entities of type TestEntity found for stringField=huh',
     );
 
-    await expect(entityLoader.loadByIDNullableAsync(uuidv4())).resolves.toBeNull();
-    await expect(entityLoader.loadByIDNullableAsync(id1)).resolves.not.toBeNull();
+    await expect(entityLoader.nonEnforcing().loadByIDNullableAsync(uuidv4())).resolves.toBeNull();
+    await expect(entityLoader.nonEnforcing().loadByIDNullableAsync(id1)).resolves.not.toBeNull();
 
     const nonExistentId = uuidv4();
-    const manyIdResults = await entityLoader.loadManyByIDsNullableAsync([nonExistentId, id1]);
+    const manyIdResults = await entityLoader
+      .nonEnforcing()
+      .loadManyByIDsNullableAsync([nonExistentId, id1]);
     expect(manyIdResults.get(nonExistentId)).toBeNull();
     expect(manyIdResults.get(id1)).not.toBeNull();
 
-    await expect(enforceAsyncResult(entityLoader.loadByIDAsync(nonExistentId))).rejects.toThrow(
-      EntityNotFoundError,
-    );
+    await expect(
+      enforceAsyncResult(entityLoader.nonEnforcing().loadByIDAsync(nonExistentId)),
+    ).rejects.toThrow(EntityNotFoundError);
 
-    await expect(entityLoader.loadByIDAsync('not-a-uuid')).rejects.toThrowError(
+    await expect(entityLoader.nonEnforcing().loadByIDAsync('not-a-uuid')).rejects.toThrowError(
       'Entity field not valid: TestEntity (customIdField = not-a-uuid)',
     );
   });
@@ -200,7 +208,7 @@ describe(EntityLoader, () => {
       metricsAdapter,
     );
     const entities = await enforceResultsAsync(
-      entityLoader.loadManyByFieldEqualityConjunctionAsync([
+      entityLoader.nonEnforcing().loadManyByFieldEqualityConjunctionAsync([
         {
           fieldName: 'stringField',
           fieldValue: 'huh',
@@ -223,9 +231,11 @@ describe(EntityLoader, () => {
     ).twice();
 
     await expect(
-      entityLoader.loadManyByFieldEqualityConjunctionAsync([
-        { fieldName: 'customIdField', fieldValue: 'not-a-uuid' },
-      ]),
+      entityLoader
+        .nonEnforcing()
+        .loadManyByFieldEqualityConjunctionAsync([
+          { fieldName: 'customIdField', fieldValue: 'not-a-uuid' },
+        ]),
     ).rejects.toThrowError('Entity field not valid: TestEntity (customIdField = not-a-uuid)');
   });
 
@@ -301,7 +311,7 @@ describe(EntityLoader, () => {
       dataManager,
       metricsAdapter,
     );
-    const result = await entityLoader.loadFirstByFieldEqualityConjunctionAsync(
+    const result = await entityLoader.nonEnforcing().loadFirstByFieldEqualityConjunctionAsync(
       [
         {
           fieldName: 'stringField',
@@ -369,7 +379,7 @@ describe(EntityLoader, () => {
       dataManager,
       metricsAdapter,
     );
-    const result = await entityLoader.loadManyByRawWhereClauseAsync('id = ?', [1], {
+    const result = await entityLoader.nonEnforcing().loadManyByRawWhereClauseAsync('id = ?', [1], {
       orderBy: [{ fieldName: 'testIndexedField', order: OrderByOrdering.DESCENDING }],
     });
     expect(result).toHaveLength(1);
@@ -442,7 +452,7 @@ describe(EntityLoader, () => {
       dataManager,
       metricsAdapter,
     );
-    const entity = await enforceAsyncResult(entityLoader.loadByIDAsync(id1));
+    const entity = await enforceAsyncResult(entityLoader.nonEnforcing().loadByIDAsync(id1));
     verify(
       spiedPrivacyPolicy.authorizeReadAsync(
         viewerContext,
@@ -478,7 +488,7 @@ describe(EntityLoader, () => {
       dataManagerInstance,
       metricsAdapter,
     );
-    await entityLoader.invalidateFieldsAsync({ customIdField: id1 } as any);
+    await entityLoader.nonEnforcing().invalidateFieldsAsync({ customIdField: id1 } as any);
 
     verify(
       dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: id1 } as any)),
@@ -509,7 +519,7 @@ describe(EntityLoader, () => {
       dataManagerInstance,
       metricsAdapter,
     );
-    await entityLoader.invalidateFieldsAsync({ customIdField: id1 } as any);
+    await entityLoader.nonEnforcing().invalidateFieldsAsync({ customIdField: id1 } as any);
     verify(
       dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: id1 } as any)),
     ).once();
@@ -543,7 +553,7 @@ describe(EntityLoader, () => {
       dataManagerInstance,
       metricsAdapter,
     );
-    await entityLoader.invalidateEntityAsync(entityInstance);
+    await entityLoader.nonEnforcing().invalidateEntityAsync(entityInstance);
     verify(
       dataManagerMock.invalidateObjectFieldsAsync(deepEqual({ customIdField: id1 } as any)),
     ).once();
@@ -592,7 +602,7 @@ describe(EntityLoader, () => {
       metricsAdapter,
     );
 
-    const entityResult = await entityLoader.loadByIDAsync(id1);
+    const entityResult = await entityLoader.nonEnforcing().loadByIDAsync(id1);
     expect(entityResult.ok).toBe(false);
     expect(entityResult.reason).toEqual(rejectionError);
     expect(entityResult.value).toBe(undefined);
@@ -631,22 +641,26 @@ describe(EntityLoader, () => {
 
     const loadByValue = uuidv4();
 
-    await expect(entityLoader.loadByIDAsync(loadByValue)).rejects.toEqual(error);
+    await expect(entityLoader.nonEnforcing().loadByIDAsync(loadByValue)).rejects.toEqual(error);
     await expect(entityLoader.enforcing().loadByIDAsync(loadByValue)).rejects.toEqual(error);
-    await expect(entityLoader.loadManyByIDsAsync([loadByValue])).rejects.toEqual(error);
+    await expect(entityLoader.nonEnforcing().loadManyByIDsAsync([loadByValue])).rejects.toEqual(
+      error,
+    );
     await expect(entityLoader.enforcing().loadManyByIDsAsync([loadByValue])).rejects.toEqual(error);
-    await expect(entityLoader.loadManyByIDsNullableAsync([loadByValue])).rejects.toEqual(error);
+    await expect(
+      entityLoader.nonEnforcing().loadManyByIDsNullableAsync([loadByValue]),
+    ).rejects.toEqual(error);
     await expect(
       entityLoader.enforcing().loadManyByIDsNullableAsync([loadByValue]),
     ).rejects.toEqual(error);
     await expect(
-      entityLoader.loadManyByFieldEqualingAsync('customIdField', loadByValue),
+      entityLoader.nonEnforcing().loadManyByFieldEqualingAsync('customIdField', loadByValue),
     ).rejects.toEqual(error);
     await expect(
       entityLoader.enforcing().loadManyByFieldEqualingAsync('customIdField', loadByValue),
     ).rejects.toEqual(error);
     await expect(
-      entityLoader.loadManyByFieldEqualingManyAsync('customIdField', [loadByValue]),
+      entityLoader.nonEnforcing().loadManyByFieldEqualingManyAsync('customIdField', [loadByValue]),
     ).rejects.toEqual(error);
     await expect(
       entityLoader.enforcing().loadManyByFieldEqualingManyAsync('customIdField', [loadByValue]),

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -31,6 +31,7 @@ import EntityMutatorFactory from '../EntityMutatorFactory';
 import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityTransactionalQueryContext, EntityQueryContext } from '../EntityQueryContext';
 import IEntityDatabaseAdapterProvider from '../IEntityDatabaseAdapterProvider';
+import NonEnforcingEntityLoader from '../NonEnforcingEntityLoader';
 import ViewerContext from '../ViewerContext';
 import { enforceResultsAsync } from '../entityUtils';
 import EntityDataManager from '../internal/EntityDataManager';
@@ -568,6 +569,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id2),
       );
 
@@ -583,6 +585,7 @@ describe(EntityMutatorFactory, () => {
       const reloadedEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id2),
       );
       expect(reloadedEntity.getAllFields()).toMatchObject(updatedEntity.getAllFields());
@@ -619,6 +622,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, { previousValue: null, cascadingDeleteCause: null })
+          .nonEnforcing()
           .loadByIDAsync(id2),
       );
 
@@ -691,6 +695,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id2),
       );
 
@@ -761,6 +766,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id2),
       );
 
@@ -807,6 +813,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id1),
       );
 
@@ -820,6 +827,7 @@ describe(EntityMutatorFactory, () => {
       const reloadedEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id1),
       );
       expect(reloadedEntity.getAllFields()).toMatchObject(existingEntity.getAllFields());
@@ -858,6 +866,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id1),
       );
       expect(existingEntity).toBeTruthy();
@@ -868,6 +877,7 @@ describe(EntityMutatorFactory, () => {
         enforceAsyncResult(
           entityLoaderFactory
             .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+            .nonEnforcing()
             .loadByIDAsync(id1),
         ),
       ).rejects.toBeInstanceOf(Error);
@@ -907,6 +917,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id1),
       );
 
@@ -957,6 +968,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id1),
       );
 
@@ -1011,6 +1023,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .nonEnforcing()
           .loadByIDAsync(id1),
       );
 
@@ -1053,6 +1066,7 @@ describe(EntityMutatorFactory, () => {
     const entites1 = await enforceResultsAsync(
       entityLoaderFactory
         .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+        .nonEnforcing()
         .loadManyByFieldEqualingAsync('stringField', 'huh'),
     );
     expect(entites1).toHaveLength(1);
@@ -1067,6 +1081,7 @@ describe(EntityMutatorFactory, () => {
     const entities2 = await enforceResultsAsync(
       entityLoaderFactory
         .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+        .nonEnforcing()
         .loadManyByFieldEqualingAsync('stringField', 'huh'),
     );
     expect(entities2).toHaveLength(2);
@@ -1138,7 +1153,19 @@ describe(EntityMutatorFactory, () => {
           keyof SimpleTestFields
         >
       >(EntityLoader);
-    when(entityLoaderMock.constructEntity(anything())).thenReturn(fakeEntity);
+    const nonEnforcingEntityLoaderMock =
+      mock<
+        NonEnforcingEntityLoader<
+          SimpleTestFields,
+          string,
+          ViewerContext,
+          SimpleTestEntity,
+          SimpleTestEntityPrivacyPolicy,
+          keyof SimpleTestFields
+        >
+      >(NonEnforcingEntityLoader);
+    when(nonEnforcingEntityLoaderMock.constructEntity(anything())).thenReturn(fakeEntity);
+    when(entityLoaderMock.nonEnforcing()).thenReturn(instance(nonEnforcingEntityLoaderMock));
     const entityLoader = instance(entityLoaderMock);
 
     const entityLoaderFactoryMock =
@@ -1262,7 +1289,19 @@ describe(EntityMutatorFactory, () => {
           keyof SimpleTestFields
         >
       >(EntityLoader);
-    when(entityLoaderMock.constructEntity(anything())).thenReturn(fakeEntity);
+    const nonEnforcingEntityLoaderMock =
+      mock<
+        NonEnforcingEntityLoader<
+          SimpleTestFields,
+          string,
+          ViewerContext,
+          SimpleTestEntity,
+          SimpleTestEntityPrivacyPolicy,
+          keyof SimpleTestFields
+        >
+      >(NonEnforcingEntityLoader);
+    when(nonEnforcingEntityLoaderMock.constructEntity(anything())).thenReturn(fakeEntity);
+    when(entityLoaderMock.nonEnforcing()).thenReturn(instance(nonEnforcingEntityLoaderMock));
     const entityLoader = instance(entityLoaderMock);
 
     const entityLoaderFactoryMock =

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -12,6 +12,7 @@ import {
 } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
+import AuthorizationResultBasedEntityLoader from '../AuthorizationResultBasedEntityLoader';
 import EntityCompanionProvider from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
 import EntityDatabaseAdapter from '../EntityDatabaseAdapter';
@@ -31,7 +32,6 @@ import EntityMutatorFactory from '../EntityMutatorFactory';
 import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityTransactionalQueryContext, EntityQueryContext } from '../EntityQueryContext';
 import IEntityDatabaseAdapterProvider from '../IEntityDatabaseAdapterProvider';
-import NonEnforcingEntityLoader from '../NonEnforcingEntityLoader';
 import ViewerContext from '../ViewerContext';
 import { enforceResultsAsync } from '../entityUtils';
 import EntityDataManager from '../internal/EntityDataManager';
@@ -569,7 +569,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id2),
       );
 
@@ -585,7 +585,7 @@ describe(EntityMutatorFactory, () => {
       const reloadedEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id2),
       );
       expect(reloadedEntity.getAllFields()).toMatchObject(updatedEntity.getAllFields());
@@ -622,7 +622,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, { previousValue: null, cascadingDeleteCause: null })
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id2),
       );
 
@@ -695,7 +695,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id2),
       );
 
@@ -766,7 +766,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id2),
       );
 
@@ -813,7 +813,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id1),
       );
 
@@ -827,7 +827,7 @@ describe(EntityMutatorFactory, () => {
       const reloadedEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id1),
       );
       expect(reloadedEntity.getAllFields()).toMatchObject(existingEntity.getAllFields());
@@ -866,7 +866,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id1),
       );
       expect(existingEntity).toBeTruthy();
@@ -877,7 +877,7 @@ describe(EntityMutatorFactory, () => {
         enforceAsyncResult(
           entityLoaderFactory
             .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-            .nonEnforcing()
+            .withAuthorizationResults()
             .loadByIDAsync(id1),
         ),
       ).rejects.toBeInstanceOf(Error);
@@ -917,7 +917,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id1),
       );
 
@@ -968,7 +968,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id1),
       );
 
@@ -1023,7 +1023,7 @@ describe(EntityMutatorFactory, () => {
       const existingEntity = await enforceAsyncResult(
         entityLoaderFactory
           .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-          .nonEnforcing()
+          .withAuthorizationResults()
           .loadByIDAsync(id1),
       );
 
@@ -1066,7 +1066,7 @@ describe(EntityMutatorFactory, () => {
     const entites1 = await enforceResultsAsync(
       entityLoaderFactory
         .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-        .nonEnforcing()
+        .withAuthorizationResults()
         .loadManyByFieldEqualingAsync('stringField', 'huh'),
     );
     expect(entites1).toHaveLength(1);
@@ -1081,7 +1081,7 @@ describe(EntityMutatorFactory, () => {
     const entities2 = await enforceResultsAsync(
       entityLoaderFactory
         .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
-        .nonEnforcing()
+        .withAuthorizationResults()
         .loadManyByFieldEqualingAsync('stringField', 'huh'),
     );
     expect(entities2).toHaveLength(2);
@@ -1153,19 +1153,20 @@ describe(EntityMutatorFactory, () => {
           keyof SimpleTestFields
         >
       >(EntityLoader);
-    const nonEnforcingEntityLoaderMock =
-      mock<
-        NonEnforcingEntityLoader<
-          SimpleTestFields,
-          string,
-          ViewerContext,
-          SimpleTestEntity,
-          SimpleTestEntityPrivacyPolicy,
-          keyof SimpleTestFields
-        >
-      >(NonEnforcingEntityLoader);
+    const nonEnforcingEntityLoaderMock = mock<
+      AuthorizationResultBasedEntityLoader<
+        SimpleTestFields,
+        string,
+        ViewerContext,
+        SimpleTestEntity,
+        SimpleTestEntityPrivacyPolicy,
+        keyof SimpleTestFields
+      >
+    >(AuthorizationResultBasedEntityLoader);
     when(nonEnforcingEntityLoaderMock.constructEntity(anything())).thenReturn(fakeEntity);
-    when(entityLoaderMock.nonEnforcing()).thenReturn(instance(nonEnforcingEntityLoaderMock));
+    when(entityLoaderMock.withAuthorizationResults()).thenReturn(
+      instance(nonEnforcingEntityLoaderMock),
+    );
     const entityLoader = instance(entityLoaderMock);
 
     const entityLoaderFactoryMock =
@@ -1289,19 +1290,20 @@ describe(EntityMutatorFactory, () => {
           keyof SimpleTestFields
         >
       >(EntityLoader);
-    const nonEnforcingEntityLoaderMock =
-      mock<
-        NonEnforcingEntityLoader<
-          SimpleTestFields,
-          string,
-          ViewerContext,
-          SimpleTestEntity,
-          SimpleTestEntityPrivacyPolicy,
-          keyof SimpleTestFields
-        >
-      >(NonEnforcingEntityLoader);
+    const nonEnforcingEntityLoaderMock = mock<
+      AuthorizationResultBasedEntityLoader<
+        SimpleTestFields,
+        string,
+        ViewerContext,
+        SimpleTestEntity,
+        SimpleTestEntityPrivacyPolicy,
+        keyof SimpleTestFields
+      >
+    >(AuthorizationResultBasedEntityLoader);
     when(nonEnforcingEntityLoaderMock.constructEntity(anything())).thenReturn(fakeEntity);
-    when(entityLoaderMock.nonEnforcing()).thenReturn(instance(nonEnforcingEntityLoaderMock));
+    when(entityLoaderMock.withAuthorizationResults()).thenReturn(
+      instance(nonEnforcingEntityLoaderMock),
+    );
     const entityLoader = instance(entityLoaderMock);
 
     const entityLoaderFactoryMock =

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -35,10 +35,9 @@ describe('Two entities backed by the same table', () => {
       OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID()),
     ).rejects.toThrowError('OneTestEntity must be instantiated with one data');
 
-    const manyResults = await OneTestEntity.loader(viewerContext).loadManyByFieldEqualingAsync(
-      'common_other_field',
-      'wat',
-    );
+    const manyResults = await OneTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadManyByFieldEqualingAsync('common_other_field', 'wat');
     const successfulManyResults = successfulResults(manyResults);
     const failedManyResults = failedResults(manyResults);
 
@@ -50,14 +49,14 @@ describe('Two entities backed by the same table', () => {
       'OneTestEntity must be instantiated with one data',
     );
 
-    const fieldEqualityConjunctionResults = await OneTestEntity.loader(
-      viewerContext,
-    ).loadManyByFieldEqualityConjunctionAsync([
-      {
-        fieldName: 'common_other_field',
-        fieldValue: 'wat',
-      },
-    ]);
+    const fieldEqualityConjunctionResults = await OneTestEntity.loader(viewerContext)
+      .nonEnforcing()
+      .loadManyByFieldEqualityConjunctionAsync([
+        {
+          fieldName: 'common_other_field',
+          fieldValue: 'wat',
+        },
+      ]);
     const successfulfieldEqualityConjunctionResultsResults = successfulResults(
       fieldEqualityConjunctionResults,
     );

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -36,7 +36,7 @@ describe('Two entities backed by the same table', () => {
     ).rejects.toThrowError('OneTestEntity must be instantiated with one data');
 
     const manyResults = await OneTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadManyByFieldEqualingAsync('common_other_field', 'wat');
     const successfulManyResults = successfulResults(manyResults);
     const failedManyResults = failedResults(manyResults);
@@ -50,7 +50,7 @@ describe('Two entities backed by the same table', () => {
     );
 
     const fieldEqualityConjunctionResults = await OneTestEntity.loader(viewerContext)
-      .nonEnforcing()
+      .withAuthorizationResults()
       .loadManyByFieldEqualityConjunctionAsync([
         {
           fieldName: 'common_other_field',

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -254,12 +254,14 @@ async function canViewerDeleteInternalAsync<
         continue;
       }
 
-      const entityResultsForInboundEdge = await loader.loadManyByFieldEqualingAsync(
-        fieldName,
-        association.associatedEntityLookupByField
-          ? sourceEntity.getField(association.associatedEntityLookupByField as any)
-          : sourceEntity.getID(),
-      );
+      const entityResultsForInboundEdge = await loader
+        .nonEnforcing()
+        .loadManyByFieldEqualingAsync(
+          fieldName,
+          association.associatedEntityLookupByField
+            ? sourceEntity.getField(association.associatedEntityLookupByField as any)
+            : sourceEntity.getID(),
+        );
 
       const failedEntityLoadResults = failedResults(entityResultsForInboundEdge);
       for (const failedResult of failedEntityLoadResults) {

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -255,7 +255,7 @@ async function canViewerDeleteInternalAsync<
       }
 
       const entityResultsForInboundEdge = await loader
-        .nonEnforcing()
+        .withAuthorizationResults()
         .loadManyByFieldEqualingAsync(
           fieldName,
           association.associatedEntityLookupByField


### PR DESCRIPTION
# Why

This has been discussed many many times and it's long overdue: it's time to make non-enforcing loads not the default. Whether we make enforcing loads the default is another discussion to be had, but is out of the scope of this PR.

This PR introduces a new required intermediate call to loaders to explicitly specify either enforcing or non-enforcing load behavior.

```diff
-    const entityResult = await TestEntity.loader(viewerContext).loadByIDAsync(id);
+    const entityResult = await TestEntity.loader(viewerContext)
+      .withAuthorizationResults()
+      .loadByIDAsync(id);
```

Note that `.enforcing` calls remain unchanged.

The reasoning behind this change is that it's too easy to misinterpret a Failure result to also be the result of the call when a database error is thrown from a non-enforcing method, when in fact it's only a Failure when the privacy policy evaluation fails.

In Expo's use of Entity, we almost exclusively use `.enforcing()`, to the point where we want to add a lint rule to discourage non-enforcing. Rather than go down this path, we figure it's better to just make the non-enforcing explicit. And then maybe in the future make enforcing default, though that's a ways in the future to avoid implicit breakage.

# How reviewers can help

~~- Help decide on the name for `.nonEnforcing`. Note that the `.enforcing` method is considered the opposite. Other names I considered are `.resultWrapped()`, `.asyncResult()`, but I'm sure there are others. I went with `.nonEnforcing` since it seemed the clearest.~~

# How

Add `.withAuthorizationResults` method to `EntityLoader`, add new `AuthorizationResultBasedEntityLoader` class, move methods there.

In a follow-up, I'll look into moving the common methods (the ones in `knownLoaderOnlyDifferences`) to a different utils class since it no longer makes sense for them not to be on the loader class. But to limit the scope of this PR, they are kept in the `AuthorizationResultBasedEntityLoader` class for now.

# Test Plan

Run all tests.
