### PR TITLE
feat: add convenience method for loading first of many by simple field equality

### DIFF
--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -212,6 +212,31 @@ export default class AuthorizationResultBasedEntityLoader<
   }
 
   /**
+   * Load a single of potentially many entities where fieldName equals fieldValue, or null if no matching entity exists.
+   * Entities loaded using this method are not batched or cached.
+   *
+   * This is a convenience method for a case of {@link loadFirstByFieldEqualityConjunctionAsync} where ordering doesn't matter.
+   *
+   * @param fieldName - entity field being queried
+   * @param fieldValue - fieldName field value being queried
+   * @returns single entity result that matches the query for fieldValue, where result error can be UnauthorizedError, or null
+   *  if no matching entity exists.
+   */
+  async loadFirstByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>,
+  ): Promise<Result<TEntity> | null> {
+    const results = await this.loadManyByFieldEqualityConjunctionAsync(
+      [{ fieldName, fieldValue }],
+      {
+        orderBy: [],
+        limit: 1,
+      },
+    );
+    return results[0] ?? null;
+  }
+
+  /**
    * Loads many entities matching the selection constructed from the conjunction of specified operands.
    * Entities loaded using this method are not batched or cached.
    *

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -142,6 +142,21 @@ export default class EnforcingEntityLoader<
 
   /**
    * Enforcing version of entity loader method by the same name.
+   * @throws EntityNotAuthorizedError when viewer is not authorized to view the returned entity
+   */
+  async loadFirstByFieldEqualingAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldName: N,
+    fieldValue: NonNullable<TFields[N]>,
+  ): Promise<TEntity | null> {
+    const entityResult = await this.entityLoader.loadFirstByFieldEqualingAsync(
+      fieldName,
+      fieldValue,
+    );
+    return entityResult ? entityResult.enforceValue() : null;
+  }
+
+  /**
+   * Enforcing version of entity loader method by the same name.
    * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
    */
   async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -309,7 +309,7 @@ describe(EnforcingEntityLoader, () => {
     });
   });
 
-  describe('loadFirstByFieldEqualityConjunction', () => {
+  describe('loadFirstByFieldEqualityConjunctionAsync', () => {
     it('throws when result is unsuccessful', async () => {
       const nonEnforcingEntityLoaderMock = mock<
         AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
@@ -360,6 +360,52 @@ describe(EnforcingEntityLoader, () => {
       const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
       await expect(
         enforcingEntityLoader.loadFirstByFieldEqualityConjunctionAsync(anything(), anything()),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe('loadFirstByFieldEqualingAsync', () => {
+    it('throws when result is unsuccessful', async () => {
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
+      const rejection = new Error();
+      when(
+        nonEnforcingEntityLoaderMock.loadFirstByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve(result(rejection));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
+      await expect(
+        enforcingEntityLoader.loadFirstByFieldEqualingAsync(anything(), anything()),
+      ).rejects.toThrow(rejection);
+    });
+
+    it('returns value when result is successful', async () => {
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
+      const resolved = {};
+      when(
+        nonEnforcingEntityLoaderMock.loadFirstByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve(result(resolved));
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
+      await expect(
+        enforcingEntityLoader.loadFirstByFieldEqualingAsync(anything(), anything()),
+      ).resolves.toEqual(resolved);
+    });
+
+    it('returns null when the query is successful but no rows match', async () => {
+      const nonEnforcingEntityLoaderMock = mock<
+        AuthorizationResultBasedEntityLoader<any, any, any, any, any, any>
+      >(AuthorizationResultBasedEntityLoader);
+      when(
+        nonEnforcingEntityLoaderMock.loadFirstByFieldEqualingAsync(anything(), anything()),
+      ).thenResolve(null);
+      const nonEnforcingEntityLoader = instance(nonEnforcingEntityLoaderMock);
+      const enforcingEntityLoader = new EnforcingEntityLoader(nonEnforcingEntityLoader);
+      await expect(
+        enforcingEntityLoader.loadFirstByFieldEqualingAsync(anything(), anything()),
       ).resolves.toBeNull();
     });
   });


### PR DESCRIPTION
# Why

In some cases it is helpful to be able to load a single entity of many matching a field equality (see the PR stacked on top of this one for example). 

We already provide `loadFirstByFieldEqualityConjunctionAsync` but this adds another convenience method for the case where order is undefined.

# How

Add method and tests.

# Test Plan

Run tests.
