### PR TITLE
chore: upgrade typescript to 5.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ts-jest": "^29.1.5",
     "ts-mockito": "^2.6.1",
     "typedoc": "^0.26.2",
-    "typescript": "^5.5.2",
+    "typescript": "^5.5.4",
     "uuid": "^8.3.0"
   },
   "dependencies": {

--- a/resources/run-with-docker
+++ b/resources/run-with-docker
@@ -9,14 +9,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$DIR/test-env.sh"
 
 compose_down() {
-  docker-compose -f "$DIR/docker-compose.yml" down -v
+  docker compose -f "$DIR/docker-compose.yml" down -v
 }
 
-docker-compose -f "$DIR/docker-compose.yml" up -d
+docker compose -f "$DIR/docker-compose.yml" up -d
 
 trap compose_down EXIT SIGTERM
 
-docker-compose -f "$DIR/docker-compose.yml" logs --follow --timestamps &
+docker compose -f "$DIR/docker-compose.yml" logs --follow --timestamps &
 
 sleep 5
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9456,10 +9456,10 @@ typedoc@^0.26.2:
     shiki "^1.9.0"
     yaml "^2.4.5"
 
-typescript@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
-  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+typescript@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Why

This upgrades typescript to the latest.

# How

Look at changes on https://github.com/microsoft/TypeScript/releases between prev and this version, see nothing alarming.

# Test Plan

Run tsc and full test suite.