### PR TITLE
feat: allow cascadingDeleteCause to be passed in via public deletion mutator methods

### DIFF
--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -153,7 +153,7 @@ export default abstract class Entity<
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
       .forDelete(existingEntity, queryContext)
-      .deleteAsync();
+      .deleteAsync(null);
   }
 
   /**
@@ -195,7 +195,7 @@ export default abstract class Entity<
       .getViewerScopedEntityCompanionForClass(this)
       .getMutatorFactory()
       .forDelete(existingEntity, queryContext)
-      .enforceDeleteAsync();
+      .enforceDeleteAsync(null);
   }
 }
 

--- a/packages/entity/src/EntityMutator.ts
+++ b/packages/entity/src/EntityMutator.ts
@@ -599,19 +599,23 @@ export class DeleteMutator<
    * Delete the entity after authorizing against delete privacy rules. The entity is invalidated in all caches.
    * @returns void result, where result error can be UnauthorizedError
    */
-  async deleteAsync(): Promise<Result<void>> {
+  async deleteAsync(
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null,
+  ): Promise<Result<void>> {
     return await timeAndLogMutationEventAsync(
       this.metricsAdapter,
       EntityMetricsMutationType.DELETE,
       this.entityClass.name,
-    )(this.deleteInTransactionAsync(new Set(), false, null));
+    )(this.deleteInTransactionAsync(new Set(), false, cascadingDeleteCause));
   }
 
   /**
    * Convenience method that throws upon delete failure.
    */
-  async enforceDeleteAsync(): Promise<void> {
-    return await enforceAsyncResult(this.deleteAsync());
+  async enforceDeleteAsync(
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null,
+  ): Promise<void> {
+    return await enforceAsyncResult(this.deleteAsync(cascadingDeleteCause));
   }
 
   private async deleteInTransactionAsync(

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -871,7 +871,7 @@ describe(EntityMutatorFactory, () => {
       );
       expect(existingEntity).toBeTruthy();
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync(null);
 
       await expect(
         enforceAsyncResult(
@@ -921,7 +921,7 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id1),
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync(null);
 
       verify(
         spiedPrivacyPolicy.authorizeDeleteAsync(
@@ -972,7 +972,7 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id1),
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync(null);
 
       verifyTriggerCounts(
         viewerContext,
@@ -1027,7 +1027,7 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id1),
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync(null);
 
       verifyValidatorCounts(viewerContext, validatorSpies, 0, {
         type: EntityMutationType.DELETE as any,
@@ -1246,7 +1246,7 @@ describe(EntityMutatorFactory, () => {
 
     const entityDeleteResult = await entityMutatorFactory
       .forDelete(fakeEntity, queryContext)
-      .deleteAsync();
+      .deleteAsync(null);
     expect(entityDeleteResult.ok).toBe(false);
     expect(entityDeleteResult.reason).toEqual(rejectionError);
     expect(entityDeleteResult.value).toBe(undefined);
@@ -1364,7 +1364,7 @@ describe(EntityMutatorFactory, () => {
       entityMutatorFactory.forUpdate(fakeEntity, queryContext).updateAsync(),
     ).rejects.toEqual(rejectionError);
     await expect(
-      entityMutatorFactory.forDelete(fakeEntity, queryContext).deleteAsync(),
+      entityMutatorFactory.forDelete(fakeEntity, queryContext).deleteAsync(null),
     ).rejects.toEqual(rejectionError);
   });
 
@@ -1388,7 +1388,9 @@ describe(EntityMutatorFactory, () => {
         .updateAsync(),
     );
 
-    await enforceAsyncResult(entityMutatorFactory.forDelete(newEntity, queryContext).deleteAsync());
+    await enforceAsyncResult(
+      entityMutatorFactory.forDelete(newEntity, queryContext).deleteAsync(null),
+    );
 
     verify(
       spiedMetricsAdapter.logMutatorMutationEvent(


### PR DESCRIPTION
# Why

When doing large batch deletions like the ones specified in https://github.com/expo/entity/pull/243, the case is usually to serially do a bunch of deletions ahead of a cascade in order to decrease memory usage.

This has one issue: these become normal deletions. Even though they're somewhat "part" of this cascade deletion.

Some privacy policies make use of the `cascadingDeleteCause` in order to determine delete-ability. Because of this, these "cascading" deletes should have the cause.

# How

Add the ability to manually specify it.

# Test Plan

N/A
