### PR TITLE
feat: add function to get authorization results for canViewerUpdateAsync/canViewerDeleteAsync

### DIFF
--- a/packages/entity/src/__tests__/entityUtils-test.ts
+++ b/packages/entity/src/__tests__/entityUtils-test.ts
@@ -7,6 +7,7 @@ import {
   successfulResultsFilterMap,
   failedResultsFilterMap,
   pick,
+  partitionArray,
 } from '../entityUtils';
 
 describe(enforceResultsAsync, () => {
@@ -95,5 +96,16 @@ describe(pick, () => {
       a: 1,
       b: 2,
     });
+  });
+});
+
+describe(partitionArray, () => {
+  it('partitions array', () => {
+    type A = true;
+    type B = false;
+    const arr: (A | B)[] = [true, false, true, true, false];
+    const [as, bs] = partitionArray<A, B>(arr, (val: A | B): val is A => val === true);
+    expect(as).toMatchObject([true, true, true]);
+    expect(bs).toMatchObject([false, false]);
   });
 });

--- a/packages/entity/src/entityUtils.ts
+++ b/packages/entity/src/entityUtils.ts
@@ -71,22 +71,37 @@ export const failedResultsFilterMap = <K, T>(
   return ret;
 };
 
+export type PartitionArrayPredicate<T, U> = (val: T | U) => val is T;
+
+/**
+ * Partition an array of values into two arrays based on evaluation of a binary predicate.
+ * @param values - array of values to partition
+ * @param predicate - binary predicate to evaluate partition group of each value
+ */
+export const partitionArray = <T, U>(
+  values: (T | U)[],
+  predicate: PartitionArrayPredicate<T, U>,
+): [T[], U[]] => {
+  const ts: T[] = [];
+  const us: U[] = [];
+
+  for (const value of values) {
+    if (predicate(value)) {
+      ts.push(value);
+    } else {
+      us.push(value);
+    }
+  }
+
+  return [ts, us];
+};
+
 /**
  * Partition array of values and errors into an array of values and an array of errors.
  * @param valuesAndErrors - array of values and errors
  */
 export const partitionErrors = <T>(valuesAndErrors: (T | Error)[]): [T[], Error[]] => {
-  const values: T[] = [];
-  const errors: Error[] = [];
-
-  for (const valueOrError of valuesAndErrors) {
-    if (isError(valueOrError)) {
-      errors.push(valueOrError);
-    } else {
-      values.push(valueOrError);
-    }
-  }
-
+  const [errors, values] = partitionArray<Error, T>(valuesAndErrors, isError);
   return [values, errors];
 };
 


### PR DESCRIPTION
# Why

There's a need to debug authorization failures at the callsites of `canViewerDeleteAsync` in Expo's server code. Making this return the authorization failure should help to debug.

# How

Add new set of functions that returns the result of the authorization check.

# Test Plan

Add full test coverage for this new set of functions and run the tests.
