### PR TITLE
feat!: Make load/create/update/delete entity authorization result interfaces consistent

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -26,9 +26,10 @@ describe(GenericLocalMemoryCacher, () => {
 
     const date = new Date();
     const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
-      .enforceCreateAsync();
+      .createAsync();
 
     // loading an entity should put it in cache
     const entity1 = await LocalMemoryTestEntity.loader(viewerContext)
@@ -103,9 +104,10 @@ describe(GenericLocalMemoryCacher, () => {
 
     const date = new Date();
     const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
-      .enforceCreateAsync();
+      .createAsync();
 
     // loading an entity will try to put it in cache but it's a noop cache, so it should be a miss
     const entity1 = await LocalMemoryTestEntity.loader(viewerContext)

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -104,8 +104,9 @@ describe(GenericRedisCacher, () => {
     const cacheKeyMaker = genericCacher['makeCacheKey'].bind(genericCacher);
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'blah')
-      .enforceCreateAsync();
+      .createAsync();
 
     // loading an entity should put it in cache. load by multiple requests and multiple fields in same tick to ensure batch works
     mgetSpy.mockClear();

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -47,8 +47,9 @@ describe(GenericRedisCacher, () => {
     const cacheKeyMaker = genericCacher['makeCacheKey'].bind(genericCacher);
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'blah')
-      .enforceCreateAsync();
+      .createAsync();
 
     // loading an entity should put it in cache
     const entity1 = await RedisTestEntity.loader(viewerContext)
@@ -99,7 +100,10 @@ describe(GenericRedisCacher, () => {
     );
     const date = new Date();
     const entity1 = await enforceAsyncResult(
-      RedisTestEntity.creator(viewerContext).setField('dateField', date).createAsync(),
+      RedisTestEntity.creator(viewerContext)
+        .withAuthorizationResults()
+        .setField('dateField', date)
+        .createAsync(),
     );
     expect(entity1.getField('dateField')).toEqual(date);
 
@@ -121,7 +125,10 @@ describe(GenericRedisCacher, () => {
       createRedisIntegrationTestEntityCompanionProvider(genericRedisCacheContext),
     );
     const entity1 = await enforceAsyncResult(
-      RedisTestEntity.creator(viewerContext).setField('name', '').createAsync(),
+      RedisTestEntity.creator(viewerContext)
+        .withAuthorizationResults()
+        .setField('name', '')
+        .createAsync(),
     );
     const entity2 = await RedisTestEntity.loader(viewerContext)
       .enforcing()

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -47,9 +47,10 @@ describe(GenericRedisCacher, () => {
     );
     const date = new Date();
     const entity1Created = await RedisTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
-      .enforceCreateAsync();
+      .createAsync();
     const testKey = `test-id-key-${entity1Created.getID()}`;
     const objectMap = new Map<string, Readonly<RedisTestEntityFields>>([
       [testKey, entity1Created.getAllFields()],
@@ -93,9 +94,10 @@ describe(GenericRedisCacher, () => {
     );
     const date = new Date();
     const entity1Created = await RedisTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
-      .enforceCreateAsync();
+      .createAsync();
     const testKey = `test-id-key-${entity1Created.getID()}`;
     const objectMap = new Map<string, Readonly<RedisTestEntityFields>>([
       [testKey, entity1Created.getAllFields()],

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -40,7 +40,7 @@ describe(GenericRedisCacher, () => {
     );
 
     await expect(
-      RedisTestEntity.creator(vc1).setField('name', 'blah').enforceCreateAsync(),
+      RedisTestEntity.creator(vc1).enforcing().setField('name', 'blah').createAsync(),
     ).rejects.toThrow(EntityCacheAdapterTransientError);
   });
 });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -34,10 +34,13 @@ describe(PostgresEntityQueryContextProvider, () => {
   it('supports nested transactions', async () => {
     const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 
-    await PostgresUniqueTestEntity.creator(vc1).setField('name', 'unique').enforceCreateAsync();
+    await PostgresUniqueTestEntity.creator(vc1)
+      .enforcing()
+      .setField('name', 'unique')
+      .createAsync();
 
     const id = (
-      await PostgresUniqueTestEntity.creator(vc1).setField('name', 'wat').enforceCreateAsync()
+      await PostgresUniqueTestEntity.creator(vc1).enforcing().setField('name', 'wat').createAsync()
     ).getID();
 
     await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
@@ -45,8 +48,9 @@ describe(PostgresEntityQueryContextProvider, () => {
         .enforcing()
         .loadByIDAsync(id);
       await PostgresUniqueTestEntity.updater(entity, queryContext)
+        .enforcing()
         .setField('name', 'wat2')
-        .enforceUpdateAsync();
+        .updateAsync();
 
       // ensure the outer transaction is not aborted due to postgres error in inner transaction,
       // in this case the error triggered is a unique constraint violation
@@ -56,8 +60,9 @@ describe(PostgresEntityQueryContextProvider, () => {
             .enforcing()
             .loadByIDAsync(id);
           await PostgresUniqueTestEntity.updater(entity, innerQueryContext)
+            .enforcing()
             .setField('name', 'unique')
-            .enforceUpdateAsync();
+            .updateAsync();
         });
       } catch {}
 
@@ -65,8 +70,9 @@ describe(PostgresEntityQueryContextProvider, () => {
         .enforcing()
         .loadByIDAsync(id);
       await PostgresUniqueTestEntity.updater(entity2, queryContext)
+        .enforcing()
         .setField('name', 'wat3')
-        .enforceUpdateAsync();
+        .updateAsync();
     });
 
     const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).enforcing().loadByIDAsync(id);
@@ -77,7 +83,7 @@ describe(PostgresEntityQueryContextProvider, () => {
     const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 
     const id = (
-      await PostgresUniqueTestEntity.creator(vc1).setField('name', 'wat').enforceCreateAsync()
+      await PostgresUniqueTestEntity.creator(vc1).enforcing().setField('name', 'wat').createAsync()
     ).getID();
 
     await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
@@ -88,8 +94,9 @@ describe(PostgresEntityQueryContextProvider, () => {
               .enforcing()
               .loadByIDAsync(id);
             await PostgresUniqueTestEntity.updater(entity, innerQueryContex3)
+              .enforcing()
               .setField('name', 'wat3')
-              .enforceUpdateAsync();
+              .updateAsync();
           });
         });
       });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -35,40 +35,60 @@ describe('postgres entity integration', () => {
     it('throws after deletion of multiple rows or no rows', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
       const entity1 = await enforceAsyncResult(
-        InvalidTestEntity.creator(vc).setField('id', 1).setField('name', 'hello').createAsync(),
+        InvalidTestEntity.creator(vc)
+          .withAuthorizationResults()
+          .setField('id', 1)
+          .setField('name', 'hello')
+          .createAsync(),
       );
       await enforceAsyncResult(
-        InvalidTestEntity.creator(vc).setField('id', 1).setField('name', 'world').createAsync(),
+        InvalidTestEntity.creator(vc)
+          .withAuthorizationResults()
+          .setField('id', 1)
+          .setField('name', 'world')
+          .createAsync(),
       );
 
-      await expect(InvalidTestEntity.deleteAsync(entity1)).rejects.toThrowError(
-        'Excessive deletions from database adapter delete',
-      );
+      await expect(
+        InvalidTestEntity.deleter(entity1).enforcing().deleteAsync(),
+      ).rejects.toThrowError('Excessive deletions from database adapter delete');
     });
 
     it('throws after update of multiple rows', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
       const entity1 = await enforceAsyncResult(
-        InvalidTestEntity.creator(vc).setField('id', 1).setField('name', 'hello').createAsync(),
+        InvalidTestEntity.creator(vc)
+          .withAuthorizationResults()
+          .setField('id', 1)
+          .setField('name', 'hello')
+          .createAsync(),
       );
       await enforceAsyncResult(
-        InvalidTestEntity.creator(vc).setField('id', 1).setField('name', 'world').createAsync(),
+        InvalidTestEntity.creator(vc)
+          .withAuthorizationResults()
+          .setField('id', 1)
+          .setField('name', 'world')
+          .createAsync(),
       );
 
       await expect(
-        InvalidTestEntity.updater(entity1).setField('name', 'blah').enforceUpdateAsync(),
+        InvalidTestEntity.updater(entity1).enforcing().setField('name', 'blah').updateAsync(),
       ).rejects.toThrowError('Excessive results from database adapter update');
     });
 
     it('throws after update of no rows', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
       const entity1 = await enforceAsyncResult(
-        InvalidTestEntity.creator(vc).setField('id', 1).setField('name', 'hello').createAsync(),
+        InvalidTestEntity.creator(vc)
+          .withAuthorizationResults()
+          .setField('id', 1)
+          .setField('name', 'hello')
+          .createAsync(),
       );
-      await InvalidTestEntity.deleteAsync(entity1);
+      await InvalidTestEntity.deleter(entity1).enforcing().deleteAsync();
 
       await expect(
-        InvalidTestEntity.updater(entity1).setField('name', 'blah').enforceUpdateAsync(),
+        InvalidTestEntity.updater(entity1).enforcing().setField('name', 'blah').updateAsync(),
       ).rejects.toThrowError('Empty results from database adapter update');
     });
   });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -42,9 +42,10 @@ describe('postgres errors', () => {
   it('throws EntityDatabaseAdapterTransientError on Knex timeout', async () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await ErrorsTestEntity.creator(vc)
+      .enforcing()
       .setField('id', 1)
       .setField('fieldNonNull', 'hello')
-      .enforceCreateAsync();
+      .createAsync();
 
     const shortTimeoutKnexInstance = knex({
       client: 'pg',
@@ -70,9 +71,10 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', null as any)
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterNotNullConstraintError);
   });
 
@@ -80,10 +82,11 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('fieldForeignKey', 2)
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterForeignKeyConstraintError);
   });
 
@@ -91,32 +94,36 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 
     await ErrorsTestEntity.creator(vc)
+      .enforcing()
       .setField('id', 1)
       .setField('fieldNonNull', 'hello')
-      .enforceCreateAsync();
+      .createAsync();
 
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterUniqueConstraintError);
   });
 
   it('throws EntityDatabaseAdapterUniqueConstraintError when unique constraint is violated', async () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await ErrorsTestEntity.creator(vc)
+      .enforcing()
       .setField('id', 2)
       .setField('fieldNonNull', 'hello')
       .setField('fieldUnique', 'hello')
-      .enforceCreateAsync();
+      .createAsync();
 
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('fieldUnique', 'hello')
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterUniqueConstraintError);
   });
 
@@ -124,18 +131,20 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('checkLessThan5', 2)
-        .enforceCreateAsync(),
+        .createAsync(),
     ).resolves.toBeTruthy();
 
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 2)
         .setField('fieldNonNull', 'hello')
         .setField('checkLessThan5', 10)
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterCheckConstraintError);
   });
 
@@ -143,18 +152,20 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('fieldExclusion', 'what')
-        .enforceCreateAsync(),
+        .createAsync(),
     ).resolves.toBeTruthy();
 
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 2)
         .setField('fieldNonNull', 'hello')
         .setField('fieldExclusion', 'what')
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterExclusionConstraintError);
   });
 
@@ -162,10 +173,11 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
+        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('nonExistentColumn', 'what')
-        .enforceCreateAsync(),
+        .createAsync(),
     ).rejects.toThrow(EntityDatabaseAdapterUnknownError);
   });
 });

--- a/packages/entity-example/src/__tests__/NoteEntity-test.ts
+++ b/packages/entity-example/src/__tests__/NoteEntity-test.ts
@@ -11,6 +11,7 @@ describe(NoteEntity, () => {
     const viewerContext = new UserViewerContext(companionProvider, userId);
 
     const createdEntityResult = await NoteEntity.creator(viewerContext)
+      .withAuthorizationResults()
       .setField('userID', userId)
       .setField('body', 'image')
       .setField('title', 'page')
@@ -18,6 +19,7 @@ describe(NoteEntity, () => {
     expect(createdEntityResult.ok).toBe(true);
 
     const createdEntityResultImpersonate = await NoteEntity.creator(viewerContext)
+      .withAuthorizationResults()
       .setField('userID', uuidv4()) // a different user
       .setField('body', 'image')
       .setField('title', 'page')

--- a/packages/entity-example/src/routers/notesRouter.ts
+++ b/packages/entity-example/src/routers/notesRouter.ts
@@ -56,6 +56,7 @@ router.post('/', async (ctx) => {
   const { title, body } = ctx.request.body as any;
 
   const createResult = await NoteEntity.creator(viewerContext)
+    .withAuthorizationResults()
     .setField('userID', viewerContext.userID)
     .setField('title', title)
     .setField('body', body)
@@ -83,6 +84,7 @@ router.put('/:id', async (ctx) => {
   }
 
   const noteUpdateResult = await NoteEntity.updater(noteLoadResult.value)
+    .withAuthorizationResults()
     .setField('title', title)
     .setField('body', body)
     .updateAsync();
@@ -107,7 +109,9 @@ router.delete('/:id', async (ctx) => {
     return;
   }
 
-  const noteDeleteResult = await NoteEntity.deleteAsync(noteLoadResult.value);
+  const noteDeleteResult = await NoteEntity.deleter(noteLoadResult.value)
+    .withAuthorizationResults()
+    .deleteAsync();
   if (!noteDeleteResult.ok) {
     ctx.throw(403, noteDeleteResult.reason);
     return;

--- a/packages/entity-example/src/schema.ts
+++ b/packages/entity-example/src/schema.ts
@@ -73,25 +73,27 @@ export const resolvers: IResolvers<any, GraphqlContext> = {
       }
 
       return await NoteEntity.creator(viewerContext)
+        .enforcing()
         .setField('userID', viewerContext.userID)
         .setField('title', args.note.title)
         .setField('body', args.note.body)
-        .enforceCreateAsync();
+        .createAsync();
     },
     async updateNote(_root, args, { viewerContext }) {
       const existingNote = await NoteEntity.loader(viewerContext)
         .enforcing()
         .loadByIDAsync(args.id);
       return await NoteEntity.updater(existingNote)
+        .enforcing()
         .setField('title', args.note.title)
         .setField('body', args.note.body)
-        .enforceUpdateAsync();
+        .updateAsync();
     },
     async deleteNote(_root, args, { viewerContext }) {
       const existingNote = await NoteEntity.loader(viewerContext)
         .enforcing()
         .loadByIDAsync(args.id);
-      await NoteEntity.enforceDeleteAsync(existingNote);
+      await NoteEntity.deleter(existingNote).enforcing().deleteAsync();
       return existingNote;
     },
   } as IObjectTypeResolver<any, GraphqlContext>,

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -141,9 +141,10 @@ describe('Entity cache inconsistency', () => {
     );
 
     const entity1 = await TestEntity.creator(viewerContext)
+      .enforcing()
       .setField('other_string', 'hello')
       .setField('third_string', 'initial')
-      .enforceCreateAsync();
+      .createAsync();
 
     // put entities in cache and dataloader
     await TestEntity.loader(viewerContext).enforcing().loadByIDAsync(entity1.getID());
@@ -180,8 +181,9 @@ describe('Entity cache inconsistency', () => {
         'postgres',
         async (queryContext) => {
           await TestEntity.updater(entity1, queryContext)
+            .enforcing()
             .setField('third_string', 'updated')
-            .enforceUpdateAsync();
+            .updateAsync();
 
           openBarrier1();
 

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -79,10 +79,11 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
       );
 
-      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
       const child = await ChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', parent.getID())
-        .enforceCreateAsync();
+        .createAsync();
 
       await expect(
         ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
@@ -93,7 +94,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
           .loadByFieldEqualingAsync('parent_id', parent.getID()),
       ).resolves.not.toBeNull();
 
-      await ParentEntity.enforceDeleteAsync(parent);
+      await ParentEntity.deleter(parent).enforcing().deleteAsync();
 
       await expect(
         ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -129,10 +129,10 @@ describe('Entity integrity', () => {
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
 
-    const entity1 = await TestEntity.creator(viewerContext).enforceCreateAsync();
+    const entity1 = await TestEntity.creator(viewerContext).enforcing().createAsync();
 
     await expect(
-      TestEntity.updater(entity1).setField('id', uuidv4()).enforceUpdateAsync(),
+      TestEntity.updater(entity1).enforcing().setField('id', uuidv4()).updateAsync(),
     ).rejects.toThrow('id field updates not supported: (entityClass = TestEntity)');
 
     // ensure cache consistency

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -221,15 +221,17 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
 
-    const category1 = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const category1 = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const other1 = await OtherEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', category1.getID())
-      .enforceCreateAsync();
+      .createAsync();
     await CategoryEntity.updater(category1)
+      .enforcing()
       .setField('parent_other_id', other1.getID())
-      .enforceUpdateAsync();
+      .updateAsync();
 
-    await CategoryEntity.enforceDeleteAsync(category1);
+    await CategoryEntity.deleter(category1).enforcing().deleteAsync();
 
     if (edgeDeletionBehavior === EntityEdgeDeletionBehavior.SET_NULL) {
       await expect(

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -173,8 +173,9 @@ describe(LocalMemorySecondaryEntityCache, () => {
     const viewerContext = new TestViewerContext(createTestEntityCompanionProvider());
 
     const createdEntity = await LocalMemoryTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'wat')
-      .enforceCreateAsync();
+      .createAsync();
 
     const secondaryCacheLoader = new TestSecondaryLocalMemoryCacheLoader(
       new LocalMemorySecondaryEntityCache(

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -80,8 +80,9 @@ describe(RedisSecondaryEntityCache, () => {
     );
 
     const createdEntity = await RedisTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('name', 'wat')
-      .enforceCreateAsync();
+      .createAsync();
 
     const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
       new RedisSecondaryEntityCache(

--- a/packages/entity/src/EnforcingEntityCreator.ts
+++ b/packages/entity/src/EnforcingEntityCreator.ts
@@ -1,0 +1,55 @@
+import { enforceAsyncResult } from '@expo/results';
+
+import { AuthorizationResultBasedCreateMutator } from './AuthorizationResultBasedEntityMutator';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * Enforcing entity creator. All updates
+ * through this creator will throw if authorization is not successful.
+ */
+export default class EnforcingEntityCreator<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly entityCreator: AuthorizationResultBasedCreateMutator<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+  ) {}
+
+  /**
+   * Set the value for entity field.
+   * @param fieldName - entity field being updated
+   * @param value - value for entity field
+   */
+  setField<K extends keyof Pick<TFields, TSelectedFields>>(fieldName: K, value: TFields[K]): this {
+    this.entityCreator.setField(fieldName, value);
+    return this;
+  }
+
+  /**
+   * Commit the new entity after authorizing against creation privacy rules. Invalidates all caches for
+   * queries that would return new entity.
+   * @returns authorized, cached, newly-created entity, throwing if unsuccessful
+   */
+  async createAsync(): Promise<TEntity> {
+    return await enforceAsyncResult(this.entityCreator.createAsync());
+  }
+}

--- a/packages/entity/src/EnforcingEntityDeleter.ts
+++ b/packages/entity/src/EnforcingEntityDeleter.ts
@@ -1,0 +1,44 @@
+import { enforceAsyncResult } from '@expo/results';
+
+import { AuthorizationResultBasedDeleteMutator } from './AuthorizationResultBasedEntityMutator';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * Enforcing entity deleter. All deletes
+ * through this deleter will throw if authorization is not successful.
+ */
+export default class EnforcingEntityDeleter<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly entityDeleter: AuthorizationResultBasedDeleteMutator<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+  ) {}
+
+  /**
+   * Delete the entity after authorizing against delete privacy rules. The entity is invalidated in all caches.
+   * Throws when delete is not successful.
+   */
+  async deleteAsync(): Promise<void> {
+    await enforceAsyncResult(this.entityDeleter.deleteAsync());
+  }
+}

--- a/packages/entity/src/EnforcingEntityUpdater.ts
+++ b/packages/entity/src/EnforcingEntityUpdater.ts
@@ -1,0 +1,55 @@
+import { enforceAsyncResult } from '@expo/results';
+
+import { AuthorizationResultBasedUpdateMutator } from './AuthorizationResultBasedEntityMutator';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * Enforcing entity updater. All updates
+ * through this updater will throw if authorization is not successful.
+ */
+export default class EnforcingEntityUpdater<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly entityUpdater: AuthorizationResultBasedUpdateMutator<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+  ) {}
+
+  /**
+   * Set the value for entity field.
+   * @param fieldName - entity field being updated
+   * @param value - value for entity field
+   */
+  setField<K extends keyof Pick<TFields, TSelectedFields>>(fieldName: K, value: TFields[K]): this {
+    this.entityUpdater.setField(fieldName, value);
+    return this;
+  }
+
+  /**
+   * Commit the changes to the entity after authorizing against update privacy rules.
+   * Invalidates all caches for pre-update entity.
+   * @returns authorized updated entity, throws upon update failure
+   */
+  async updateAsync(): Promise<TEntity> {
+    return await enforceAsyncResult(this.entityUpdater.updateAsync());
+  }
+}

--- a/packages/entity/src/EntityCreator.ts
+++ b/packages/entity/src/EntityCreator.ts
@@ -1,0 +1,73 @@
+import { AuthorizationResultBasedCreateMutator } from './AuthorizationResultBasedEntityMutator';
+import EnforcingEntityCreator from './EnforcingEntityCreator';
+import { IEntityClass } from './Entity';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import { EntityQueryContext } from './EntityQueryContext';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * The primary interface for creating entities.
+ */
+export default class EntityCreator<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TViewerContext2 extends TViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly viewerContext: TViewerContext2,
+    private readonly queryContext: EntityQueryContext,
+    private readonly entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+  ) {}
+
+  /**
+   * Enforcing entity creator. All creates through this creator are
+   * guaranteed to be successful and will throw otherwise.
+   */
+  enforcing(): EnforcingEntityCreator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new EnforcingEntityCreator(this.withAuthorizationResults());
+  }
+
+  /**
+   * Authorization-result-based entity creator. All creates through this
+   * creator are results, where an unsuccessful result means an authorization
+   * error or entity construction error occurred. Other errors are thrown.
+   */
+  withAuthorizationResults(): AuthorizationResultBasedCreateMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return this.viewerContext
+      .getViewerScopedEntityCompanionForClass(this.entityClass)
+      .getMutatorFactory()
+      .forCreate(this.queryContext);
+  }
+}

--- a/packages/entity/src/EntityDeleter.ts
+++ b/packages/entity/src/EntityDeleter.ts
@@ -1,0 +1,73 @@
+import { AuthorizationResultBasedDeleteMutator } from './AuthorizationResultBasedEntityMutator';
+import EnforcingEntityDeleter from './EnforcingEntityDeleter';
+import { IEntityClass } from './Entity';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import { EntityQueryContext } from './EntityQueryContext';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * The primary interface for deleting entities.
+ */
+export default class EntityDeleter<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly existingEntity: TEntity,
+    private readonly queryContext: EntityQueryContext,
+    private readonly entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+  ) {}
+
+  /**
+   * Enforcing entity deleter. All deletes through this deleter are
+   * guaranteed to be successful and will throw otherwise.
+   */
+  enforcing(): EnforcingEntityDeleter<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new EnforcingEntityDeleter(this.withAuthorizationResults());
+  }
+
+  /**
+   * Authorization-result-based entity deleter. All deletes through this
+   * deleter are results, where an unsuccessful result means an authorization
+   * error or entity construction error occurred. Other errors are thrown.
+   */
+  withAuthorizationResults(): AuthorizationResultBasedDeleteMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return this.existingEntity
+      .getViewerContext()
+      .getViewerScopedEntityCompanionForClass(this.entityClass)
+      .getMutatorFactory()
+      .forDelete(this.existingEntity, this.queryContext);
+  }
+}

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -92,7 +92,7 @@ export default class EntityLoader<
 
   /**
    * Authorization-result-based entity loader. All loads through this
-   * loader are are results (or null for some loader methods), where an unsuccessful result
+   * loader are results (or null for some loader methods), where an unsuccessful result
    * means an authorization error or entity construction error occurred. Other errors are thrown.
    */
   withAuthorizationResults(): AuthorizationResultBasedEntityLoader<

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -1,3 +1,8 @@
+import {
+  AuthorizationResultBasedCreateMutator,
+  AuthorizationResultBasedUpdateMutator,
+  AuthorizationResultBasedDeleteMutator,
+} from './AuthorizationResultBasedEntityMutator';
 import Entity, { IEntityClass } from './Entity';
 import EntityCompanionProvider from './EntityCompanionProvider';
 import EntityConfiguration from './EntityConfiguration';
@@ -5,7 +10,6 @@ import EntityDatabaseAdapter from './EntityDatabaseAdapter';
 import EntityLoaderFactory from './EntityLoaderFactory';
 import EntityMutationTriggerConfiguration from './EntityMutationTriggerConfiguration';
 import EntityMutationValidator from './EntityMutationValidator';
-import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import ViewerContext from './ViewerContext';
@@ -75,8 +79,15 @@ export default class EntityMutatorFactory<
   forCreate(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-  ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return new CreateMutator(
+  ): AuthorizationResultBasedCreateMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new AuthorizationResultBasedCreateMutator(
       this.entityCompanionProvider,
       viewerContext,
       queryContext,
@@ -100,8 +111,15 @@ export default class EntityMutatorFactory<
   forUpdate(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
-  ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return new UpdateMutator(
+  ): AuthorizationResultBasedUpdateMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new AuthorizationResultBasedUpdateMutator(
       this.entityCompanionProvider,
       existingEntity.getViewerContext(),
       queryContext,
@@ -125,8 +143,15 @@ export default class EntityMutatorFactory<
   forDelete(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
-  ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
-    return new DeleteMutator(
+  ): AuthorizationResultBasedDeleteMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new AuthorizationResultBasedDeleteMutator(
       this.entityCompanionProvider,
       existingEntity.getViewerContext(),
       queryContext,

--- a/packages/entity/src/EntityUpdater.ts
+++ b/packages/entity/src/EntityUpdater.ts
@@ -1,0 +1,73 @@
+import { AuthorizationResultBasedUpdateMutator } from './AuthorizationResultBasedEntityMutator';
+import EnforcingEntityUpdater from './EnforcingEntityUpdater';
+import { IEntityClass } from './Entity';
+import EntityPrivacyPolicy from './EntityPrivacyPolicy';
+import { EntityQueryContext } from './EntityQueryContext';
+import ReadonlyEntity from './ReadonlyEntity';
+import ViewerContext from './ViewerContext';
+
+/**
+ * The primary interface for updating entities.
+ */
+export default class EntityUpdater<
+  TFields extends object,
+  TID extends NonNullable<TFields[TSelectedFields]>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TSelectedFields extends keyof TFields,
+> {
+  constructor(
+    private readonly existingEntity: TEntity,
+    private readonly queryContext: EntityQueryContext,
+    private readonly entityClass: IEntityClass<
+      TFields,
+      TID,
+      TViewerContext,
+      TEntity,
+      TPrivacyPolicy,
+      TSelectedFields
+    >,
+  ) {}
+
+  /**
+   * Enforcing entity updater. All updates through this updater are
+   * guaranteed to be successful and will throw otherwise.
+   */
+  enforcing(): EnforcingEntityUpdater<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new EnforcingEntityUpdater(this.withAuthorizationResults());
+  }
+
+  /**
+   * Authorization-result-based entity updater. All updates through this
+   * updater are results, where an unsuccessful result means an authorization
+   * error or entity construction error occurred. Other errors are thrown.
+   */
+  withAuthorizationResults(): AuthorizationResultBasedUpdateMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return this.existingEntity
+      .getViewerContext()
+      .getViewerScopedEntityCompanionForClass(this.entityClass)
+      .getMutatorFactory()
+      .forUpdate(this.existingEntity, this.queryContext);
+  }
+}

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -1,4 +1,8 @@
-import { CreateMutator, UpdateMutator, DeleteMutator } from './EntityMutator';
+import {
+  AuthorizationResultBasedCreateMutator,
+  AuthorizationResultBasedUpdateMutator,
+  AuthorizationResultBasedDeleteMutator,
+} from './AuthorizationResultBasedEntityMutator';
 import EntityMutatorFactory from './EntityMutatorFactory';
 import EntityPrivacyPolicy from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -36,21 +40,42 @@ export default class ViewerScopedEntityMutatorFactory<
 
   forCreate(
     queryContext: EntityQueryContext,
-  ): CreateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
+  ): AuthorizationResultBasedCreateMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return this.entityMutatorFactory.forCreate(this.viewerContext, queryContext);
   }
 
   forUpdate(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
-  ): UpdateMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
+  ): AuthorizationResultBasedUpdateMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return this.entityMutatorFactory.forUpdate(existingEntity, queryContext);
   }
 
   forDelete(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
-  ): DeleteMutator<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
+  ): AuthorizationResultBasedDeleteMutator<
+    TFields,
+    TID,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
     return this.entityMutatorFactory.forDelete(existingEntity, queryContext);
   }
 }

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -1,20 +1,22 @@
 import Entity from '../Entity';
-import { CreateMutator, UpdateMutator } from '../EntityMutator';
+import EntityCreator from '../EntityCreator';
+import EntityDeleter from '../EntityDeleter';
+import EntityUpdater from '../EntityUpdater';
 import ViewerContext from '../ViewerContext';
 import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
 import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
 
 describe(Entity, () => {
   describe('creator', () => {
-    it('creates a new CreateMutator', () => {
+    it('creates a new EntityCreator', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.creator(viewerContext)).toBeInstanceOf(CreateMutator);
+      expect(SimpleTestEntity.creator(viewerContext)).toBeInstanceOf(EntityCreator);
     });
   });
 
   describe('updater', () => {
-    it('creates a new UpdateMutator', () => {
+    it('creates a new EntityUpdater', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
       const data = {
@@ -26,7 +28,24 @@ describe(Entity, () => {
         databaseFields: data,
         selectedFields: data,
       });
-      expect(SimpleTestEntity.updater(testEntity)).toBeInstanceOf(UpdateMutator);
+      expect(SimpleTestEntity.updater(testEntity)).toBeInstanceOf(EntityUpdater);
+    });
+  });
+
+  describe('deleter', () => {
+    it('creates a new EntityDeleter', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
+      expect(SimpleTestEntity.deleter(testEntity)).toBeInstanceOf(EntityDeleter);
     });
   });
 });

--- a/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
@@ -14,10 +14,11 @@ describe(EntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testOtherEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).createAsync(),
+        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
       );
       const testEntity = await enforceAsyncResult(
         TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
           .setField('stringField', testOtherEntity.getID())
           .createAsync(),
       );
@@ -37,12 +38,20 @@ describe(EntityAssociationLoader, () => {
     it('loads many associated entities referencing this entity', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
-      const testEntity = await enforceAsyncResult(TestEntity.creator(viewerContext).createAsync());
+      const testEntity = await enforceAsyncResult(
+        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+      );
       const testOtherEntity1 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', testEntity.getID()).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', testEntity.getID())
+          .createAsync(),
       );
       const testOtherEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', testEntity.getID()).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', testEntity.getID())
+          .createAsync(),
       );
       const loaded = await enforceResultsAsync(
         testEntity.associationLoader().loadManyAssociatedEntitiesAsync(TestEntity, 'stringField'),
@@ -58,10 +67,11 @@ describe(EntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testOtherEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).createAsync(),
+        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
       );
       const testEntity = await enforceAsyncResult(
         TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
           .setField('stringField', testOtherEntity.getID())
           .createAsync(),
       );
@@ -75,7 +85,10 @@ describe(EntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', uuidv4()).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', uuidv4())
+          .createAsync(),
       );
       const loadedOtherResult = await testEntity
         .associationLoader()
@@ -87,7 +100,10 @@ describe(EntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', 'blah').createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', 'blah')
+          .createAsync(),
       );
       const loadedOtherResult = await testEntity
         .associationLoader()
@@ -100,12 +116,20 @@ describe(EntityAssociationLoader, () => {
     it('loads many associated entities by field equaling', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
-      const testEntity = await enforceAsyncResult(TestEntity.creator(viewerContext).createAsync());
+      const testEntity = await enforceAsyncResult(
+        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+      );
       const testOtherEntity1 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', testEntity.getID()).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', testEntity.getID())
+          .createAsync(),
       );
       const testOtherEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', testEntity.getID()).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', testEntity.getID())
+          .createAsync(),
       );
       const loaded = await enforceResultsAsync(
         testEntity
@@ -124,7 +148,9 @@ describe(EntityAssociationLoader, () => {
     it('returns empty results when field being queried by is null', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
-      const testEntity = await enforceAsyncResult(TestEntity.creator(viewerContext).createAsync());
+      const testEntity = await enforceAsyncResult(
+        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+      );
       const loaded = await enforceResultsAsync(
         testEntity
           .associationLoader()
@@ -142,19 +168,24 @@ describe(EntityAssociationLoader, () => {
     it('chain loads associated entities', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
-      const testEntity4 = await enforceAsyncResult(TestEntity.creator(viewerContext).createAsync());
+      const testEntity4 = await enforceAsyncResult(
+        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+      );
       const testEntity3 = await enforceAsyncResult(
         TestEntity2.creator(viewerContext)
+          .withAuthorizationResults()
           .setField('foreignKey', testEntity4.getID())
           .createAsync(),
       );
       const testEntity2 = await enforceAsyncResult(
         TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
           .setField('testIndexedField', testEntity3.getID())
           .createAsync(),
       );
       const testEntity = await enforceAsyncResult(
         TestEntity2.creator(viewerContext)
+          .withAuthorizationResults()
           .setField('foreignKey', testEntity2.getID())
           .createAsync(),
       );
@@ -201,7 +232,10 @@ describe(EntityAssociationLoader, () => {
       const viewerContext = new TestViewerContext(companionProvider);
 
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext).setField('foreignKey', uuidv4()).createAsync(),
+        TestEntity2.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('foreignKey', uuidv4())
+          .createAsync(),
       );
 
       const loadResult = await testEntity.associationLoader().loadAssociatedEntityThroughAsync([
@@ -219,10 +253,16 @@ describe(EntityAssociationLoader, () => {
 
       const fieldValue = uuidv4();
       const testEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('stringField', fieldValue).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('stringField', fieldValue)
+          .createAsync(),
       );
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext).setField('foreignKey', fieldValue).createAsync(),
+        TestEntity2.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('foreignKey', fieldValue)
+          .createAsync(),
       );
 
       const loaded2Result = await testEntity.associationLoader().loadAssociatedEntityThroughAsync([
@@ -240,7 +280,10 @@ describe(EntityAssociationLoader, () => {
       const viewerContext = new TestViewerContext(companionProvider);
 
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext).setField('foreignKey', uuidv4()).createAsync(),
+        TestEntity2.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('foreignKey', uuidv4())
+          .createAsync(),
       );
 
       const loaded2Result = await testEntity.associationLoader().loadAssociatedEntityThroughAsync([
@@ -258,7 +301,10 @@ describe(EntityAssociationLoader, () => {
       const viewerContext = new TestViewerContext(companionProvider);
 
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).setField('nullableField', null).createAsync(),
+        TestEntity.creator(viewerContext)
+          .withAuthorizationResults()
+          .setField('nullableField', null)
+          .createAsync(),
       );
 
       const loadedResult = await testEntity.associationLoader().loadAssociatedEntityThroughAsync([

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -118,15 +118,24 @@ it('runs through a common workflow', async () => {
   const vc2 = new TestUserViewerContext(entityCompanionProvider, uuidv4());
 
   const blahOwner1 = await enforceAsyncResult(
-    BlahEntity.creator(vc1).setField('ownerID', vc1.getUserID()).createAsync(),
+    BlahEntity.creator(vc1)
+      .withAuthorizationResults()
+      .setField('ownerID', vc1.getUserID())
+      .createAsync(),
   );
 
   await enforceAsyncResult(
-    BlahEntity.creator(vc1).setField('ownerID', vc1.getUserID()).createAsync(),
+    BlahEntity.creator(vc1)
+      .withAuthorizationResults()
+      .setField('ownerID', vc1.getUserID())
+      .createAsync(),
   );
 
   const blahOwner2 = await enforceAsyncResult(
-    BlahEntity.creator(vc2).setField('ownerID', vc2.getUserID()).createAsync(),
+    BlahEntity.creator(vc2)
+      .withAuthorizationResults()
+      .setField('ownerID', vc2.getUserID())
+      .createAsync(),
   );
 
   // sanity check created objects
@@ -156,7 +165,10 @@ it('runs through a common workflow', async () => {
   // check that two people can't create objects owned by others
   await expect(
     enforceAsyncResult(
-      BlahEntity.creator(vc2).setField('ownerID', blahOwner1.getID()).createAsync(),
+      BlahEntity.creator(vc2)
+        .withAuthorizationResults()
+        .setField('ownerID', blahOwner1.getID())
+        .createAsync(),
     ),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
@@ -169,7 +181,7 @@ it('runs through a common workflow', async () => {
   }
 
   // check that the user can't delete their own data (as specified by privacy rules)
-  await expect(enforceAsyncResult(BlahEntity.deleteAsync(blahOwner2))).rejects.toBeInstanceOf(
-    EntityNotAuthorizedError,
-  );
+  await expect(
+    enforceAsyncResult(BlahEntity.deleter(blahOwner2).withAuthorizationResults().deleteAsync()),
+  ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 });

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -527,13 +527,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
       const child = await ChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', parent.getID())
-        .enforceCreateAsync();
+        .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', child.getID())
-        .enforceCreateAsync();
+        .createAsync();
 
       await expect(
         ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
@@ -548,7 +550,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       ).resolves.not.toBeNull();
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.enforceDeleteAsync(parent);
+      await ParentEntity.deleter(parent).enforcing().deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       await expect(
@@ -649,13 +651,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
       const child = await ChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', parent.getID())
-        .enforceCreateAsync();
+        .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', child.getID())
-        .enforceCreateAsync();
+        .createAsync();
 
       await expect(
         ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
@@ -670,7 +674,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       ).resolves.not.toBeNull();
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.enforceDeleteAsync(parent);
+      await ParentEntity.deleter(parent).enforcing().deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       await expect(
@@ -762,13 +766,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
       const child = await ChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', parent.getID())
-        .enforceCreateAsync();
+        .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', child.getID())
-        .enforceCreateAsync();
+        .createAsync();
 
       await expect(
         ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
@@ -803,7 +809,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       expect(grandChildCachedBefore.get(child.getID())?.status).toEqual(CacheStatus.HIT);
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.enforceDeleteAsync(parent);
+      await ParentEntity.deleter(parent).enforcing().deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       const childCachedAfter = await childCacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
@@ -901,13 +907,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforceCreateAsync();
+      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
       const child = await ChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', parent.getID())
-        .enforceCreateAsync();
+        .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
+        .enforcing()
         .setField('parent_id', child.getID())
-        .enforceCreateAsync();
+        .createAsync();
 
       await expect(
         ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
@@ -942,7 +950,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       expect(grandChildCachedBefore.get(child.getID())?.status).toEqual(CacheStatus.HIT);
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.enforceDeleteAsync(parent);
+      await ParentEntity.deleter(parent).enforcing().deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       const childCachedAfter = await childCacheAdapter.loadManyAsync('parent_id', [parent.getID()]);

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -93,11 +93,11 @@ describe('EntityMutator', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     // put it in cache
-    const entity = await BlahEntity.creator(viewerContext).enforceCreateAsync();
+    const entity = await BlahEntity.creator(viewerContext).enforcing().createAsync();
     const entityLoaded = await BlahEntity.loader(viewerContext)
       .enforcing()
       .loadByIDAsync(entity.getID());
 
-    await BlahEntity.enforceDeleteAsync(entityLoaded);
+    await BlahEntity.deleter(entityLoaded).enforcing().deleteAsync();
   });
 });

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -395,10 +395,12 @@ describe(EntityMutatorFactory, () => {
           nullableField: null,
         },
       ]);
-      const newEntity = await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
-        .setField('stringField', 'huh')
-        .enforceCreateAsync();
+      const newEntity = await enforceAsyncResult(
+        entityMutatorFactory
+          .forCreate(viewerContext, queryContext)
+          .setField('stringField', 'huh')
+          .createAsync(),
+      );
       expect(newEntity).toBeTruthy();
     });
 
@@ -429,10 +431,12 @@ describe(EntityMutatorFactory, () => {
 
       const spiedPrivacyPolicy = spy(privacyPolicy);
 
-      await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
-        .setField('stringField', 'huh')
-        .enforceCreateAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory
+          .forCreate(viewerContext, queryContext)
+          .setField('stringField', 'huh')
+          .createAsync(),
+      );
 
       verify(
         spiedPrivacyPolicy.authorizeCreateAsync(
@@ -472,10 +476,12 @@ describe(EntityMutatorFactory, () => {
 
       const triggerSpies = setUpMutationTriggerSpies(mutationTriggers);
 
-      await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
-        .setField('stringField', 'huh')
-        .enforceCreateAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory
+          .forCreate(viewerContext, queryContext)
+          .setField('stringField', 'huh')
+          .createAsync(),
+      );
 
       verifyTriggerCounts(
         viewerContext,
@@ -519,10 +525,12 @@ describe(EntityMutatorFactory, () => {
 
       const validatorSpies = setUpMutationValidatorSpies(mutationValidators);
 
-      await entityMutatorFactory
-        .forCreate(viewerContext, queryContext)
-        .setField('stringField', 'huh')
-        .enforceCreateAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory
+          .forCreate(viewerContext, queryContext)
+          .setField('stringField', 'huh')
+          .createAsync(),
+      );
 
       verifyValidatorCounts(viewerContext, validatorSpies, 1, { type: EntityMutationType.CREATE });
     });
@@ -573,10 +581,12 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id2),
       );
 
-      const updatedEntity = await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
-        .setField('stringField', 'huh2')
-        .enforceUpdateAsync();
+      const updatedEntity = await enforceAsyncResult(
+        entityMutatorFactory
+          .forUpdate(existingEntity, queryContext)
+          .setField('stringField', 'huh2')
+          .updateAsync(),
+      );
 
       expect(updatedEntity).toBeTruthy();
       expect(updatedEntity.getAllFields()).not.toMatchObject(existingEntity.getAllFields());
@@ -626,10 +636,12 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id2),
       );
 
-      await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
-        .setField('stringField', 'huh2')
-        .enforceUpdateAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory
+          .forUpdate(existingEntity, queryContext)
+          .setField('stringField', 'huh2')
+          .updateAsync(),
+      );
 
       verify(
         spiedPrivacyPolicy.authorizeUpdateAsync(
@@ -699,10 +711,12 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id2),
       );
 
-      await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
-        .setField('stringField', 'huh2')
-        .enforceUpdateAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory
+          .forUpdate(existingEntity, queryContext)
+          .setField('stringField', 'huh2')
+          .updateAsync(),
+      );
 
       verifyTriggerCounts(
         viewerContext,
@@ -770,10 +784,12 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id2),
       );
 
-      await entityMutatorFactory
-        .forUpdate(existingEntity, queryContext)
-        .setField('stringField', 'huh2')
-        .enforceUpdateAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory
+          .forUpdate(existingEntity, queryContext)
+          .setField('stringField', 'huh2')
+          .updateAsync(),
+      );
 
       verifyValidatorCounts(viewerContext, validatorSpies, 1, {
         type: EntityMutationType.UPDATE,
@@ -818,10 +834,12 @@ describe(EntityMutatorFactory, () => {
       );
 
       await expect(
-        entityMutatorFactory
-          .forUpdate(existingEntity, queryContext)
-          .setField('customIdField', uuidv4())
-          .enforceUpdateAsync(),
+        enforceAsyncResult(
+          entityMutatorFactory
+            .forUpdate(existingEntity, queryContext)
+            .setField('customIdField', uuidv4())
+            .updateAsync(),
+        ),
       ).rejects.toThrow('id field updates not supported: (entityClass = TestEntity)');
 
       const reloadedEntity = await enforceAsyncResult(
@@ -871,7 +889,9 @@ describe(EntityMutatorFactory, () => {
       );
       expect(existingEntity).toBeTruthy();
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory.forDelete(existingEntity, queryContext).deleteAsync(),
+      );
 
       await expect(
         enforceAsyncResult(
@@ -921,7 +941,9 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id1),
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory.forDelete(existingEntity, queryContext).deleteAsync(),
+      );
 
       verify(
         spiedPrivacyPolicy.authorizeDeleteAsync(
@@ -972,7 +994,9 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id1),
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory.forDelete(existingEntity, queryContext).deleteAsync(),
+      );
 
       verifyTriggerCounts(
         viewerContext,
@@ -1027,7 +1051,9 @@ describe(EntityMutatorFactory, () => {
           .loadByIDAsync(id1),
       );
 
-      await entityMutatorFactory.forDelete(existingEntity, queryContext).enforceDeleteAsync();
+      await enforceAsyncResult(
+        entityMutatorFactory.forDelete(existingEntity, queryContext).deleteAsync(),
+      );
 
       verifyValidatorCounts(viewerContext, validatorSpies, 0, {
         type: EntityMutationType.DELETE as any,
@@ -1109,10 +1135,12 @@ describe(EntityMutatorFactory, () => {
         .createAsync(),
     ).rejects.toThrowError('Entity field not valid: TestEntity (stringField = 10)');
 
-    const createdEntity = await entityMutatorFactory
-      .forCreate(viewerContext, queryContext)
-      .setField('stringField', 'hello')
-      .enforceCreateAsync();
+    const createdEntity = await enforceAsyncResult(
+      entityMutatorFactory
+        .forCreate(viewerContext, queryContext)
+        .setField('stringField', 'hello')
+        .createAsync(),
+    );
 
     await expect(
       entityMutatorFactory

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -32,7 +32,7 @@ describe(EntitySecondaryCacheLoader, () => {
     it('calls into secondary cache with correct params', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
-      const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();
+      const createdEntity = await SimpleTestEntity.creator(vc1).enforcing().createAsync();
       const loadParams = { id: createdEntity.getID() };
 
       const secondaryEntityCacheMock =
@@ -57,7 +57,7 @@ describe(EntitySecondaryCacheLoader, () => {
     it('constructs and authorizes entities', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
-      const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();
+      const createdEntity = await SimpleTestEntity.creator(vc1).enforcing().createAsync();
       const loadParams = { id: createdEntity.getID() };
 
       const secondaryEntityCacheMock =
@@ -90,7 +90,7 @@ describe(EntitySecondaryCacheLoader, () => {
     it('calls invalidate on the secondary cache', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
-      const createdEntity = await SimpleTestEntity.creator(vc1).enforceCreateAsync();
+      const createdEntity = await SimpleTestEntity.creator(vc1).enforcing().createAsync();
       const loadParams = { id: createdEntity.getID() };
 
       const secondaryEntityCacheMock =

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -87,13 +87,15 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const parentCategory = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const parentCategory = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const subCategory = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', parentCategory.getID())
-      .enforceCreateAsync();
+      .createAsync();
     const subSubCategory = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', subCategory.getID())
-      .enforceCreateAsync();
+      .createAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext)
@@ -109,7 +111,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
         .loadByIDNullableAsync(subSubCategory.getID()),
     ).resolves.not.toBeNull();
 
-    await CategoryEntity.enforceDeleteAsync(parentCategory);
+    await CategoryEntity.deleter(parentCategory).enforcing().deleteAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext)
@@ -132,15 +134,17 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const categoryA = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', categoryA.getID())
-      .enforceCreateAsync();
+      .createAsync();
     await CategoryEntity.updater(categoryA)
+      .enforcing()
       .setField('parent_category_id', categoryB.getID())
-      .enforceUpdateAsync();
+      .updateAsync();
 
-    await CategoryEntity.enforceDeleteAsync(categoryA);
+    await CategoryEntity.deleter(categoryA).enforcing().deleteAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(categoryA.getID()),
@@ -158,13 +162,15 @@ describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const parentCategory = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const parentCategory = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const subCategory = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', parentCategory.getID())
-      .enforceCreateAsync();
+      .createAsync();
     const subSubCategory = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', subCategory.getID())
-      .enforceCreateAsync();
+      .createAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext)
@@ -180,7 +186,7 @@ describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
         .loadByIDNullableAsync(subSubCategory.getID()),
     ).resolves.not.toBeNull();
 
-    await CategoryEntity.enforceDeleteAsync(parentCategory);
+    await CategoryEntity.deleter(parentCategory).enforcing().deleteAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext)
@@ -205,15 +211,17 @@ describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const categoryA = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', categoryA.getID())
-      .enforceCreateAsync();
+      .createAsync();
     await CategoryEntity.updater(categoryA)
+      .enforcing()
       .setField('parent_category_id', categoryB.getID())
-      .enforceUpdateAsync();
+      .updateAsync();
 
-    await CategoryEntity.enforceDeleteAsync(categoryA);
+    await CategoryEntity.deleter(categoryA).enforcing().deleteAsync();
 
     const loadedCategoryB = await CategoryEntity.loader(viewerContext)
       .enforcing()
@@ -231,13 +239,15 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const parentCategory = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const parentCategory = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const subCategory = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', parentCategory.getID())
-      .enforceCreateAsync();
+      .createAsync();
     const subSubCategory = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', subCategory.getID())
-      .enforceCreateAsync();
+      .createAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext)
@@ -271,7 +281,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     );
     expect(subSubCategoryCachedBefore.get(subCategory.getID())?.status).toEqual(CacheStatus.HIT);
 
-    await CategoryEntity.enforceDeleteAsync(parentCategory);
+    await CategoryEntity.deleter(parentCategory).enforcing().deleteAsync();
 
     const subCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
       parentCategory.getID(),
@@ -307,13 +317,15 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).enforceCreateAsync();
+    const categoryA = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
+      .enforcing()
       .setField('parent_category_id', categoryA.getID())
-      .enforceCreateAsync();
+      .createAsync();
     await CategoryEntity.updater(categoryA)
+      .enforcing()
       .setField('parent_category_id', categoryB.getID())
-      .enforceUpdateAsync();
+      .updateAsync();
 
     await expect(
       CategoryEntity.loader(viewerContext)
@@ -338,7 +350,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     expect(categoriesCachedBefore.get(categoryA.getID())?.status).toEqual(CacheStatus.HIT);
     expect(categoriesCachedBefore.get(categoryB.getID())?.status).toEqual(CacheStatus.HIT);
 
-    await CategoryEntity.enforceDeleteAsync(categoryA);
+    await CategoryEntity.deleter(categoryA).enforcing().deleteAsync();
 
     const categoriesCachedAfter = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
       categoryA.getID(),

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -14,15 +14,17 @@ describe('Two entities backed by the same table', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     const one = await OneTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('entity_type', EntityType.ONE)
       .setField('common_other_field', 'wat')
-      .enforceCreateAsync();
+      .createAsync();
 
     const two = await TwoTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('entity_type', EntityType.TWO)
       .setField('other_field', 'blah')
       .setField('common_other_field', 'wat')
-      .enforceCreateAsync();
+      .createAsync();
 
     expect(one).toBeInstanceOf(OneTestEntity);
     expect(two).toBeInstanceOf(TwoTestEntity);

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -13,8 +13,9 @@ describe('Two entities backed by the same table', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     const entity1 = await OneTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('fake_field', 'hello')
-      .enforceCreateAsync();
+      .createAsync();
     expect(entity1).toBeInstanceOf(OneTestEntity);
 
     const entity2 = await TwoTestEntity.loader(viewerContext)
@@ -23,9 +24,10 @@ describe('Two entities backed by the same table', () => {
     expect(entity2).toBeInstanceOf(TwoTestEntity);
 
     const updated2 = await TwoTestEntity.updater(entity2)
+      .enforcing()
       .setField('fake_field', 'world')
       .setField('other_field', 'wat')
-      .enforceUpdateAsync();
+      .updateAsync();
     expect(updated2.getAllFields()).toMatchObject({
       id: updated2.getID(),
       other_field: 'wat',
@@ -46,9 +48,10 @@ describe('Two entities backed by the same table', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     const entity = await TwoTestEntity.creator(viewerContext)
+      .enforcing()
       .setField('fake_field', 'hello')
       .setField('other_field', 'huh')
-      .enforceCreateAsync();
+      .createAsync();
 
     const loadedEntity = await TwoTestEntity.loader(viewerContext)
       .enforcing()
@@ -62,7 +65,7 @@ describe('Two entities backed by the same table', () => {
     const loaded1 = await OneTestEntity.loader(viewerContext)
       .enforcing()
       .loadByIDAsync(entity.getID());
-    await OneTestEntity.updater(loaded1).setField('fake_field', 'world').enforceUpdateAsync();
+    await OneTestEntity.updater(loaded1).enforcing().setField('fake_field', 'world').updateAsync();
 
     const loaded2 = await TwoTestEntity.loader(viewerContext)
       .enforcing()

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -28,7 +28,7 @@ export * from './EntityMutationInfo';
 export { default as EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration';
 export * from './EntityMutationTriggerConfiguration';
 export { default as EntityMutationValidator } from './EntityMutationValidator';
-export * from './EntityMutator';
+export * from './AuthorizationResultBasedEntityMutator';
 export { default as EntityMutatorFactory } from './EntityMutatorFactory';
 export { default as EntityPrivacyPolicy } from './EntityPrivacyPolicy';
 export * from './EntityPrivacyPolicy';

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -50,7 +50,9 @@ describe(canViewerUpdateAsync, () => {
   it('appropriately executes update privacy policy', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     const canViewerUpdate = await canViewerUpdateAsync(SimpleTestDenyDeleteEntity, testEntity);
     expect(canViewerUpdate).toBe(true);
     const canViewerUpdateResult = await getCanViewerUpdateResultAsync(
@@ -63,7 +65,9 @@ describe(canViewerUpdateAsync, () => {
   it('denies when policy denies', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     const canViewerUpdate = await canViewerUpdateAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerUpdate).toBe(false);
     const canViewerUpdateResult = await getCanViewerUpdateResultAsync(
@@ -79,8 +83,9 @@ describe(canViewerUpdateAsync, () => {
   it('rethrows non-authorization errors', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity =
-      await SimpleTestThrowOtherErrorEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     await expect(canViewerUpdateAsync(SimpleTestThrowOtherErrorEntity, testEntity)).rejects.toThrow(
       'update error',
     );
@@ -94,7 +99,9 @@ describe(canViewerDeleteAsync, () => {
   it('appropriately executes update privacy policy', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerDelete).toBe(true);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -107,7 +114,9 @@ describe(canViewerDeleteAsync, () => {
   it('denies when policy denies', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyDeleteEntity, testEntity);
     expect(canViewerDelete).toBe(false);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -123,11 +132,14 @@ describe(canViewerDeleteAsync, () => {
   it('denies when recursive policy denies for CASCADE_DELETE', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     // add another entity referencing testEntity that would cascade deletion to itself when testEntity is deleted
     const leafEntity = await LeafDenyDeleteEntity.creator(viewerContext)
+      .enforcing()
       .setField('simple_test_deny_update_cascade_delete_id', testEntity.getID())
-      .enforceCreateAsync();
+      .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerDelete).toBe(false);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -143,11 +155,14 @@ describe(canViewerDeleteAsync, () => {
   it('denies when recursive policy denies for SET_NULL', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     // add another entity referencing testEntity that would set null to its column when testEntity is deleted
     const leafEntity = await LeafDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
       .setField('simple_test_deny_update_set_null_id', testEntity.getID())
-      .enforceCreateAsync();
+      .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerDelete).toBe(false);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -163,15 +178,19 @@ describe(canViewerDeleteAsync, () => {
   it('allows when recursive policy allows for CASCADE_DELETE and SET_NULL', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     // add another entity referencing testEntity that would cascade deletion to itself when testEntity is deleted
     await LeafDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
       .setField('simple_test_deny_update_cascade_delete_id', testEntity.getID())
-      .enforceCreateAsync();
+      .createAsync();
     // add another entity referencing testEntity that would set null to its column when testEntity is deleted
     await LeafDenyDeleteEntity.creator(viewerContext)
+      .enforcing()
       .setField('simple_test_deny_update_set_null_id', testEntity.getID())
-      .enforceCreateAsync();
+      .createAsync();
 
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerDelete).toBe(true);
@@ -185,8 +204,9 @@ describe(canViewerDeleteAsync, () => {
   it('rethrows non-authorization errors', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity =
-      await SimpleTestThrowOtherErrorEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     await expect(
       canViewerDeleteAsync(SimpleTestThrowOtherErrorEntity, testEntity),
     ).rejects.toThrowError('delete error');
@@ -198,10 +218,13 @@ describe(canViewerDeleteAsync, () => {
   it('returns false when edge cannot be read', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     const leafEntity = await LeafDenyReadEntity.creator(viewerContext)
+      .enforcing()
       .setField('simple_test_id', testEntity.getID())
-      .enforceCreateAsync();
+      .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerDelete).toBe(false);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -217,10 +240,13 @@ describe(canViewerDeleteAsync, () => {
   it('rethrows non-authorization edge read errors', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).enforceCreateAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
+      .enforcing()
+      .createAsync();
     await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
+      .enforcing()
       .setField('simple_test_id', testEntity.getID())
-      .enforceCreateAsync();
+      .createAsync();
     await expect(canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity)).rejects.toThrowError(
       'read in cascading delete error',
     );
@@ -235,13 +261,13 @@ describe(canViewerDeleteAsync, () => {
     const canViewerDelete = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
       'postgres',
       async (queryContext) => {
-        const testEntity = await SimpleTestDenyUpdateEntity.creator(
-          viewerContext,
-          queryContext,
-        ).enforceCreateAsync();
+        const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext, queryContext)
+          .enforcing()
+          .createAsync();
         await LeafDenyReadEntity.creator(viewerContext, queryContext)
+          .enforcing()
           .setField('simple_test_id', testEntity.getID())
-          .enforceCreateAsync();
+          .createAsync();
         // this would fail if transactions weren't supported or correctly passed through
         return await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity, queryContext);
       },
@@ -251,13 +277,13 @@ describe(canViewerDeleteAsync, () => {
     const canViewerDeleteResult = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
       'postgres',
       async (queryContext) => {
-        const testEntity = await SimpleTestDenyUpdateEntity.creator(
-          viewerContext,
-          queryContext,
-        ).enforceCreateAsync();
+        const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext, queryContext)
+          .enforcing()
+          .createAsync();
         await LeafDenyReadEntity.creator(viewerContext, queryContext)
+          .enforcing()
           .setField('simple_test_id', testEntity.getID())
-          .enforceCreateAsync();
+          .createAsync();
         // this would fail if transactions weren't supported or correctly passed through
         return await getCanViewerDeleteResultAsync(
           SimpleTestDenyUpdateEntity,

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -21,20 +21,22 @@ describe(canViewerDeleteAsync, () => {
       const viewerContext = new ViewerContext(companionProvider);
 
       // create root
-      const testEntity = await TestEntity.creator(viewerContext).enforceCreateAsync();
+      const testEntity = await TestEntity.creator(viewerContext).enforcing().createAsync();
 
       // create a bunch of leaves referencing root with
       // edgeDeletionPermissionInferenceBehavior = EntityEdgeDeletionPermissionInferenceBehavior.ONE_IMPLIES_ALL
       for (let i = 0; i < 10; i++) {
         await TestLeafEntity.creator(viewerContext)
+          .enforcing()
           .setField('test_entity_id', testEntity.getID())
-          .enforceCreateAsync();
+          .createAsync();
       }
 
       for (let i = 0; i < 10; i++) {
         await TestLeafLookupByFieldEntity.creator(viewerContext)
+          .enforcing()
           .setField('test_entity_id', testEntity.getID())
-          .enforceCreateAsync();
+          .createAsync();
       }
 
       const testLeafEntityCompanion =
@@ -63,13 +65,14 @@ describe(canViewerDeleteAsync, () => {
       const viewerContext = new ViewerContext(companionProvider);
 
       // create root
-      const testEntity = await TestEntity.creator(viewerContext).enforceCreateAsync();
+      const testEntity = await TestEntity.creator(viewerContext).enforcing().createAsync();
 
       // create a bunch of leaves with no edgeDeletionPermissionInferenceBehavior
       for (let i = 0; i < 10; i++) {
         await TestLeafNoInferenceEntity.creator(viewerContext)
+          .enforcing()
           .setField('test_entity_id', testEntity.getID())
-          .enforceCreateAsync();
+          .createAsync();
       }
 
       const companion =


### PR DESCRIPTION
# Why

The idea here is to unify the pattern that we use for loading across mutations as well.

Currently, loading looks like:
```
await TestEntity.loader(vc).enforcing().loadByIdAsync();
await TestEntity.loader(vc).withAuthorizationResults().loadByIdAsync();
```
But mutations still look like:
```
await TestEntity.creator(vc).setField(...).enforceCreateAsync();
await TestEntity.creator(vc).setField(...).createAsync();

await TestEntity.updater(entity).setField(...).enforceUpdateAsync();
await TestEntity.updater(entity).setField(...).updateAsync();

await TestEntity.enforceDeleteAsync(entity);
await TestEntity.deleteAsync(entity);
```

This is proving to be too error-prone. Mostly with the `deleteAsync`/`enforceDeleteAsync` distinction not being explicit enough since the returned result from `deleteAsync` is rarely used in application code.

This PR proposes changing the mutations to be more like the loading:
```
await TestEntity.creator(vc).enforcing().setField(...).createAsync();
await TestEntity.creator(vc).withAuthorizationResults().setField(...).createAsync();

await TestEntity.updater(entity).enforcing().setField(...).updateAsync();
await TestEntity.updater(entity).withAuthorizationResults().setField(...).updateAsync();

await TestEntity.deleter(entity).enforcing().deleteAsync();
await TestEntity.deleter(entity).withAuthorizationResults().deleteAsync();
```

Closes ENG-15049.

# How

Add layer in-between entity methods and mutator factories that requires dictating `enforcing` or `withAuthorizationResults` to vend a mutator.

Note that this will likely require a codemod in any application that uses it. But the codemod is pretty straightforward.

# Test Plan

This has full test coverage.
