### PR TITLE
feat!: Default all loaders and mutators to enforcing

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -26,15 +26,14 @@ describe(GenericLocalMemoryCacher, () => {
 
     const date = new Date();
     const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
       .createAsync();
 
     // loading an entity should put it in cache
-    const entity1 = await LocalMemoryTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(entity1Created.getID());
+    const entity1 = await LocalMemoryTestEntity.loader(viewerContext).loadByIDAsync(
+      entity1Created.getID(),
+    );
 
     const localMemoryCacheAdapterProvider = (
       entityCompanionProvider['cacheAdapterFlavors'] as ReadonlyMap<
@@ -64,9 +63,10 @@ describe(GenericLocalMemoryCacher, () => {
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
 
-    const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadByIDAsync(nonExistentId);
+    const entityNonExistentResult =
+      await LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync(
+        nonExistentId,
+      );
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([
@@ -77,15 +77,16 @@ describe(GenericLocalMemoryCacher, () => {
     });
 
     // load again through entities framework to ensure it reads negative result
-    const entityNonExistentResult2 = await LocalMemoryTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadByIDAsync(nonExistentId);
+    const entityNonExistentResult2 =
+      await LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync(
+        nonExistentId,
+      );
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly
-    await LocalMemoryTestEntity.loader(viewerContext)
-      .utils()
-      .invalidateFieldsAsync(entity1.getAllFields());
+    await LocalMemoryTestEntity.loaderUtils(viewerContext).invalidateFieldsAsync(
+      entity1.getAllFields(),
+    );
     const cachedResultMiss = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker('id', entity1.getID()),
     ]);
@@ -104,15 +105,14 @@ describe(GenericLocalMemoryCacher, () => {
 
     const date = new Date();
     const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
       .createAsync();
 
     // loading an entity will try to put it in cache but it's a noop cache, so it should be a miss
-    const entity1 = await LocalMemoryTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(entity1Created.getID());
+    const entity1 = await LocalMemoryTestEntity.loader(viewerContext).loadByIDAsync(
+      entity1Created.getID(),
+    );
 
     const localMemoryCacheAdapterProvider = (
       entityCompanionProvider['cacheAdapterFlavors'] as ReadonlyMap<
@@ -137,9 +137,10 @@ describe(GenericLocalMemoryCacher, () => {
     // a non existent db fetch should try to write negative result ('') but it's a noop cache, so it should be a miss
     const nonExistentId = uuidv4();
 
-    const entityNonExistentResult = await LocalMemoryTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadByIDAsync(nonExistentId);
+    const entityNonExistentResult =
+      await LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync(
+        nonExistentId,
+      );
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -104,7 +104,6 @@ describe(GenericRedisCacher, () => {
     const cacheKeyMaker = genericCacher['makeCacheKey'].bind(genericCacher);
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'blah')
       .createAsync();
 
@@ -120,11 +119,12 @@ describe(GenericRedisCacher, () => {
       createRedisIntegrationTestEntityCompanionProvider(genericRedisCacheContext),
     );
     const [entity1, entity2, entity3] = await Promise.all([
-      RedisTestEntity.loader(viewerContext1).enforcing().loadByIDAsync(entity1Created.getID()),
-      RedisTestEntity.loader(viewerContext2).enforcing().loadByIDAsync(entity1Created.getID()),
-      RedisTestEntity.loader(viewerContext3)
-        .enforcing()
-        .loadByFieldEqualingAsync('name', entity1Created.getField('name')),
+      RedisTestEntity.loader(viewerContext1).loadByIDAsync(entity1Created.getID()),
+      RedisTestEntity.loader(viewerContext2).loadByIDAsync(entity1Created.getID()),
+      RedisTestEntity.loader(viewerContext3).loadByFieldEqualingAsync(
+        'name',
+        entity1Created.getField('name'),
+      ),
     ]);
 
     expect(mgetSpy).toHaveBeenCalledTimes(1);
@@ -141,30 +141,31 @@ describe(GenericRedisCacher, () => {
     });
 
     const cacheKeyEntity1NameField = cacheKeyMaker('name', entity1Created.getField('name'));
-    await RedisTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByFieldEqualingAsync('name', entity1Created.getField('name'));
+    await RedisTestEntity.loader(viewerContext).loadByFieldEqualingAsync(
+      'name',
+      entity1Created.getField('name'),
+    );
     await expect(redis.get(cacheKeyEntity1NameField)).resolves.toEqual(cachedJSON);
 
     // simulate non existent db fetch, should write negative result ('') to cache
     const nonExistentId = uuidv4();
-    const entityNonExistentResult = await RedisTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadByIDAsync(nonExistentId);
+    const entityNonExistentResult =
+      await RedisTestEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync(
+        nonExistentId,
+      );
     expect(entityNonExistentResult.ok).toBe(false);
     const cacheKeyNonExistent = cacheKeyMaker('id', nonExistentId);
     const nonExistentCachedValue = await redis.get(cacheKeyNonExistent);
     expect(nonExistentCachedValue).toEqual('');
     // load again through entities framework to ensure it reads negative result
-    const entityNonExistentResult2 = await RedisTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadByIDAsync(nonExistentId);
+    const entityNonExistentResult2 =
+      await RedisTestEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync(
+        nonExistentId,
+      );
     expect(entityNonExistentResult2.ok).toBe(false);
 
     // invalidate from cache to ensure it invalidates correctly in both caches
-    await RedisTestEntity.loader(viewerContext)
-      .utils()
-      .invalidateFieldsAsync(entity1.getAllFields());
+    await RedisTestEntity.loaderUtils(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
     await expect(redis.get(cacheKeyEntity1)).resolves.toBeNull();
     await expect(redis.get(cacheKeyEntity1NameField)).resolves.toBeNull();
   });

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -47,7 +47,6 @@ describe(GenericRedisCacher, () => {
     );
     const date = new Date();
     const entity1Created = await RedisTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
       .createAsync();
@@ -94,7 +93,6 @@ describe(GenericRedisCacher, () => {
     );
     const date = new Date();
     const entity1Created = await RedisTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'blah')
       .setField('dateField', date)
       .createAsync();

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -40,7 +40,7 @@ describe(GenericRedisCacher, () => {
     );
 
     await expect(
-      RedisTestEntity.creator(vc1).enforcing().setField('name', 'blah').createAsync(),
+      RedisTestEntity.creator(vc1).setField('name', 'blah').createAsync(),
     ).rejects.toThrow(EntityCacheAdapterTransientError);
   });
 });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -35,60 +35,55 @@ describe('postgres entity integration', () => {
     it('throws after deletion of multiple rows or no rows', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
       const entity1 = await enforceAsyncResult(
-        InvalidTestEntity.creator(vc)
-          .withAuthorizationResults()
+        InvalidTestEntity.creatorWithAuthorizationResults(vc)
           .setField('id', 1)
           .setField('name', 'hello')
           .createAsync(),
       );
       await enforceAsyncResult(
-        InvalidTestEntity.creator(vc)
-          .withAuthorizationResults()
+        InvalidTestEntity.creatorWithAuthorizationResults(vc)
           .setField('id', 1)
           .setField('name', 'world')
           .createAsync(),
       );
 
-      await expect(
-        InvalidTestEntity.deleter(entity1).enforcing().deleteAsync(),
-      ).rejects.toThrowError('Excessive deletions from database adapter delete');
+      await expect(InvalidTestEntity.deleter(entity1).deleteAsync()).rejects.toThrowError(
+        'Excessive deletions from database adapter delete',
+      );
     });
 
     it('throws after update of multiple rows', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
       const entity1 = await enforceAsyncResult(
-        InvalidTestEntity.creator(vc)
-          .withAuthorizationResults()
+        InvalidTestEntity.creatorWithAuthorizationResults(vc)
           .setField('id', 1)
           .setField('name', 'hello')
           .createAsync(),
       );
       await enforceAsyncResult(
-        InvalidTestEntity.creator(vc)
-          .withAuthorizationResults()
+        InvalidTestEntity.creatorWithAuthorizationResults(vc)
           .setField('id', 1)
           .setField('name', 'world')
           .createAsync(),
       );
 
       await expect(
-        InvalidTestEntity.updater(entity1).enforcing().setField('name', 'blah').updateAsync(),
+        InvalidTestEntity.updater(entity1).setField('name', 'blah').updateAsync(),
       ).rejects.toThrowError('Excessive results from database adapter update');
     });
 
     it('throws after update of no rows', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
       const entity1 = await enforceAsyncResult(
-        InvalidTestEntity.creator(vc)
-          .withAuthorizationResults()
+        InvalidTestEntity.creatorWithAuthorizationResults(vc)
           .setField('id', 1)
           .setField('name', 'hello')
           .createAsync(),
       );
-      await InvalidTestEntity.deleter(entity1).enforcing().deleteAsync();
+      await InvalidTestEntity.deleter(entity1).deleteAsync();
 
       await expect(
-        InvalidTestEntity.updater(entity1).enforcing().setField('name', 'blah').updateAsync(),
+        InvalidTestEntity.updater(entity1).setField('name', 'blah').updateAsync(),
       ).rejects.toThrowError('Empty results from database adapter update');
     });
   });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -42,7 +42,6 @@ describe('postgres errors', () => {
   it('throws EntityDatabaseAdapterTransientError on Knex timeout', async () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await ErrorsTestEntity.creator(vc)
-      .enforcing()
       .setField('id', 1)
       .setField('fieldNonNull', 'hello')
       .createAsync();
@@ -61,7 +60,7 @@ describe('postgres errors', () => {
     const vc2 = new ViewerContext(
       createKnexIntegrationTestEntityCompanionProvider(shortTimeoutKnexInstance),
     );
-    await expect(ErrorsTestEntity.loader(vc2).enforcing().loadByIDAsync(1)).rejects.toThrow(
+    await expect(ErrorsTestEntity.loader(vc2).loadByIDAsync(1)).rejects.toThrow(
       EntityDatabaseAdapterTransientError,
     );
     await shortTimeoutKnexInstance.destroy();
@@ -71,7 +70,6 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', null as any)
         .createAsync(),
@@ -82,7 +80,6 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('fieldForeignKey', 2)
@@ -94,14 +91,12 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 
     await ErrorsTestEntity.creator(vc)
-      .enforcing()
       .setField('id', 1)
       .setField('fieldNonNull', 'hello')
       .createAsync();
 
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .createAsync(),
@@ -111,7 +106,6 @@ describe('postgres errors', () => {
   it('throws EntityDatabaseAdapterUniqueConstraintError when unique constraint is violated', async () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await ErrorsTestEntity.creator(vc)
-      .enforcing()
       .setField('id', 2)
       .setField('fieldNonNull', 'hello')
       .setField('fieldUnique', 'hello')
@@ -119,7 +113,6 @@ describe('postgres errors', () => {
 
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('fieldUnique', 'hello')
@@ -131,7 +124,6 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('checkLessThan5', 2)
@@ -140,7 +132,6 @@ describe('postgres errors', () => {
 
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 2)
         .setField('fieldNonNull', 'hello')
         .setField('checkLessThan5', 10)
@@ -152,7 +143,6 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('fieldExclusion', 'what')
@@ -161,7 +151,6 @@ describe('postgres errors', () => {
 
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 2)
         .setField('fieldNonNull', 'hello')
         .setField('fieldExclusion', 'what')
@@ -173,7 +162,6 @@ describe('postgres errors', () => {
     const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
     await expect(
       ErrorsTestEntity.creator(vc)
-        .enforcing()
         .setField('id', 1)
         .setField('fieldNonNull', 'hello')
         .setField('nonExistentColumn', 'what')

--- a/packages/entity-example/src/__tests__/NoteEntity-test.ts
+++ b/packages/entity-example/src/__tests__/NoteEntity-test.ts
@@ -10,16 +10,16 @@ describe(NoteEntity, () => {
     const userId = uuidv4();
     const viewerContext = new UserViewerContext(companionProvider, userId);
 
-    const createdEntityResult = await NoteEntity.creator(viewerContext)
-      .withAuthorizationResults()
+    const createdEntityResult = await NoteEntity.creatorWithAuthorizationResults(viewerContext)
       .setField('userID', userId)
       .setField('body', 'image')
       .setField('title', 'page')
       .createAsync();
     expect(createdEntityResult.ok).toBe(true);
 
-    const createdEntityResultImpersonate = await NoteEntity.creator(viewerContext)
-      .withAuthorizationResults()
+    const createdEntityResultImpersonate = await NoteEntity.creatorWithAuthorizationResults(
+      viewerContext,
+    )
       .setField('userID', uuidv4()) // a different user
       .setField('body', 'image')
       .setField('title', 'page')

--- a/packages/entity-example/src/routers/notesRouter.ts
+++ b/packages/entity-example/src/routers/notesRouter.ts
@@ -19,9 +19,10 @@ router.get('/', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
   let notes: readonly NoteEntity[] = [];
   if (viewerContext.isUserViewerContext()) {
-    notes = await NoteEntity.loader(viewerContext)
-      .enforcing()
-      .loadManyByFieldEqualingAsync('userID', viewerContext.userID);
+    notes = await NoteEntity.loader(viewerContext).loadManyByFieldEqualingAsync(
+      'userID',
+      viewerContext.userID,
+    );
   }
   ctx.body = {
     notes: notes.map((note) => note.getAllFields()),
@@ -30,9 +31,9 @@ router.get('/', async (ctx) => {
 
 router.get('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
-  const noteResult = await NoteEntity.loader(viewerContext)
-    .withAuthorizationResults()
-    .loadByIDAsync(ctx.params['id']!);
+  const noteResult = await NoteEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync(
+    ctx.params['id']!,
+  );
   if (!noteResult.ok) {
     ctx.throw(403, noteResult.reason);
     return;
@@ -55,8 +56,7 @@ router.post('/', async (ctx) => {
 
   const { title, body } = ctx.request.body as any;
 
-  const createResult = await NoteEntity.creator(viewerContext)
-    .withAuthorizationResults()
+  const createResult = await NoteEntity.creatorWithAuthorizationResults(viewerContext)
     .setField('userID', viewerContext.userID)
     .setField('title', title)
     .setField('body', body)
@@ -75,16 +75,15 @@ router.put('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
   const { title, body } = ctx.request.body as any;
 
-  const noteLoadResult = await NoteEntity.loader(viewerContext)
-    .withAuthorizationResults()
-    .loadByIDAsync(ctx.params['id']!);
+  const noteLoadResult = await NoteEntity.loaderWithAuthorizationResults(
+    viewerContext,
+  ).loadByIDAsync(ctx.params['id']!);
   if (!noteLoadResult.ok) {
     ctx.throw(403, noteLoadResult.reason);
     return;
   }
 
-  const noteUpdateResult = await NoteEntity.updater(noteLoadResult.value)
-    .withAuthorizationResults()
+  const noteUpdateResult = await NoteEntity.updaterWithAuthorizationResults(noteLoadResult.value)
     .setField('title', title)
     .setField('body', body)
     .updateAsync();
@@ -101,17 +100,17 @@ router.put('/:id', async (ctx) => {
 router.delete('/:id', async (ctx) => {
   const viewerContext = ctx.state.viewerContext;
 
-  const noteLoadResult = await NoteEntity.loader(viewerContext)
-    .withAuthorizationResults()
-    .loadByIDAsync(ctx.params['id']!);
+  const noteLoadResult = await NoteEntity.loaderWithAuthorizationResults(
+    viewerContext,
+  ).loadByIDAsync(ctx.params['id']!);
   if (!noteLoadResult.ok) {
     ctx.throw(403, noteLoadResult.reason);
     return;
   }
 
-  const noteDeleteResult = await NoteEntity.deleter(noteLoadResult.value)
-    .withAuthorizationResults()
-    .deleteAsync();
+  const noteDeleteResult = await NoteEntity.deleterWithAuthorizationResults(
+    noteLoadResult.value,
+  ).deleteAsync();
   if (!noteDeleteResult.ok) {
     ctx.throw(403, noteDeleteResult.reason);
     return;

--- a/packages/entity-example/src/schema.ts
+++ b/packages/entity-example/src/schema.ts
@@ -46,16 +46,14 @@ export const resolvers: IResolvers<any, GraphqlContext> = {
       return viewerContext.userID;
     },
     async noteByID(_root, args, { viewerContext }) {
-      return await NoteEntity.loader(viewerContext).enforcing().loadByIDAsync(args.id);
+      return await NoteEntity.loader(viewerContext).loadByIDAsync(args.id);
     },
   } as IObjectTypeResolver<any, GraphqlContext>,
 
   User: {
     id: (root) => root,
     async notes(root, _args, { viewerContext }) {
-      return await NoteEntity.loader(viewerContext)
-        .enforcing()
-        .loadManyByFieldEqualingAsync('userID', root);
+      return await NoteEntity.loader(viewerContext).loadManyByFieldEqualingAsync('userID', root);
     },
   } as IObjectTypeResolver<string, GraphqlContext>,
 
@@ -73,27 +71,21 @@ export const resolvers: IResolvers<any, GraphqlContext> = {
       }
 
       return await NoteEntity.creator(viewerContext)
-        .enforcing()
         .setField('userID', viewerContext.userID)
         .setField('title', args.note.title)
         .setField('body', args.note.body)
         .createAsync();
     },
     async updateNote(_root, args, { viewerContext }) {
-      const existingNote = await NoteEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDAsync(args.id);
+      const existingNote = await NoteEntity.loader(viewerContext).loadByIDAsync(args.id);
       return await NoteEntity.updater(existingNote)
-        .enforcing()
         .setField('title', args.note.title)
         .setField('body', args.note.body)
         .updateAsync();
     },
     async deleteNote(_root, args, { viewerContext }) {
-      const existingNote = await NoteEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDAsync(args.id);
-      await NoteEntity.deleter(existingNote).enforcing().deleteAsync();
+      const existingNote = await NoteEntity.loader(viewerContext).loadByIDAsync(args.id);
+      await NoteEntity.deleter(existingNote).deleteAsync();
       return existingNote;
     },
   } as IObjectTypeResolver<any, GraphqlContext>,

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -141,16 +141,13 @@ describe('Entity cache inconsistency', () => {
     );
 
     const entity1 = await TestEntity.creator(viewerContext)
-      .enforcing()
       .setField('other_string', 'hello')
       .setField('third_string', 'initial')
       .createAsync();
 
     // put entities in cache and dataloader
-    await TestEntity.loader(viewerContext).enforcing().loadByIDAsync(entity1.getID());
-    await TestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByFieldEqualingAsync('other_string', 'hello');
+    await TestEntity.loader(viewerContext).loadByIDAsync(entity1.getID());
+    await TestEntity.loader(viewerContext).loadByFieldEqualingAsync('other_string', 'hello');
 
     let openBarrier1: () => void;
     const barrier1 = new Promise<void>((resolve) => {
@@ -173,7 +170,7 @@ describe('Entity cache inconsistency', () => {
         const viewerContextInternal = new ViewerContext(
           createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
         );
-        await TestEntity.loader(viewerContextInternal).enforcing().loadByIDAsync(entity1.getID());
+        await TestEntity.loader(viewerContextInternal).loadByIDAsync(entity1.getID());
 
         openBarrier2!();
       })(),
@@ -181,7 +178,6 @@ describe('Entity cache inconsistency', () => {
         'postgres',
         async (queryContext) => {
           await TestEntity.updater(entity1, queryContext)
-            .enforcing()
             .setField('third_string', 'updated')
             .updateAsync();
 
@@ -198,12 +194,11 @@ describe('Entity cache inconsistency', () => {
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
 
-    const loadedById = await TestEntity.loader(viewerContextLast)
-      .enforcing()
-      .loadByIDAsync(entity1.getID());
-    const loadedByField = await TestEntity.loader(viewerContextLast)
-      .enforcing()
-      .loadByFieldEqualingAsync('other_string', 'hello');
+    const loadedById = await TestEntity.loader(viewerContextLast).loadByIDAsync(entity1.getID());
+    const loadedByField = await TestEntity.loader(viewerContextLast).loadByFieldEqualingAsync(
+      'other_string',
+      'hello',
+    );
 
     expect(loadedById.getField('third_string')).toEqual('updated');
     expect(loadedByField!.getField('third_string')).toEqual('updated');

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -79,29 +79,26 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
       );
 
-      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
+      const parent = await ParentEntity.creator(viewerContext).createAsync();
       const child = await ChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', parent.getID())
         .createAsync();
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByFieldEqualingAsync('parent_id', parent.getID()),
+        ChildEntity.loader(viewerContext).loadByFieldEqualingAsync('parent_id', parent.getID()),
       ).resolves.not.toBeNull();
 
-      await ParentEntity.deleter(parent).enforcing().deleteAsync();
+      await ParentEntity.deleter(parent).deleteAsync();
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.toBeNull();
 
       await expect(
-        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID()),
+        ChildEntity.loader(viewerContext).loadByIDNullableAsync(child.getID()),
       ).resolves.toBeNull();
     });
   });

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -129,10 +129,10 @@ describe('Entity integrity', () => {
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
 
-    const entity1 = await TestEntity.creator(viewerContext).enforcing().createAsync();
+    const entity1 = await TestEntity.creator(viewerContext).createAsync();
 
     await expect(
-      TestEntity.updater(entity1).enforcing().setField('id', uuidv4()).updateAsync(),
+      TestEntity.updater(entity1).setField('id', uuidv4()).updateAsync(),
     ).rejects.toThrow('id field updates not supported: (entityClass = TestEntity)');
 
     // ensure cache consistency
@@ -140,9 +140,7 @@ describe('Entity integrity', () => {
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
 
-    const loadedById = await TestEntity.loader(viewerContextLast)
-      .enforcing()
-      .loadByIDAsync(entity1.getID());
+    const loadedById = await TestEntity.loader(viewerContextLast).loadByIDAsync(entity1.getID());
 
     expect(loadedById.getID()).toEqual(entity1.getID());
   });

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -221,40 +221,38 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
 
-    const category1 = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const category1 = await CategoryEntity.creator(viewerContext).createAsync();
     const other1 = await OtherEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', category1.getID())
       .createAsync();
     await CategoryEntity.updater(category1)
-      .enforcing()
       .setField('parent_other_id', other1.getID())
       .updateAsync();
 
-    await CategoryEntity.deleter(category1).enforcing().deleteAsync();
+    await CategoryEntity.deleter(category1).deleteAsync();
 
     if (edgeDeletionBehavior === EntityEdgeDeletionBehavior.SET_NULL) {
       await expect(
-        CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(category1.getID()),
+        CategoryEntity.loader(viewerContext).loadByIDNullableAsync(category1.getID()),
       ).resolves.toBeNull();
-      const otherLoaded = await OtherEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(other1.getID());
+      const otherLoaded = await OtherEntity.loader(viewerContext).loadByIDNullableAsync(
+        other1.getID(),
+      );
       expect(otherLoaded?.getField('parent_category_id')).toBeNull();
     } else if (edgeDeletionBehavior === EntityEdgeDeletionBehavior.SET_NULL_INVALIDATE_CACHE_ONLY) {
       await expect(
-        CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(category1.getID()),
+        CategoryEntity.loader(viewerContext).loadByIDNullableAsync(category1.getID()),
       ).resolves.toBeNull();
-      const otherLoaded = await OtherEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(other1.getID());
+      const otherLoaded = await OtherEntity.loader(viewerContext).loadByIDNullableAsync(
+        other1.getID(),
+      );
       expect(otherLoaded?.getField('parent_category_id')).toBeNull();
     } else {
       await expect(
-        CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(category1.getID()),
+        CategoryEntity.loader(viewerContext).loadByIDNullableAsync(category1.getID()),
       ).resolves.toBeNull();
       await expect(
-        OtherEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(other1.getID()),
+        OtherEntity.loader(viewerContext).loadByIDNullableAsync(other1.getID()),
       ).resolves.toBeNull();
     }
   });

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -175,7 +175,6 @@ describe(LocalMemorySecondaryEntityCache, () => {
     const viewerContext = new TestViewerContext(createTestEntityCompanionProvider());
 
     const createdEntity = await LocalMemoryTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'wat')
       .createAsync();
 
@@ -184,7 +183,7 @@ describe(LocalMemorySecondaryEntityCache, () => {
         localMemoryTestEntityConfiguration,
         GenericLocalMemoryCacher.createLRUCache<LocalMemoryTestEntityFields>({}),
       ),
-      LocalMemoryTestEntity.loader(viewerContext).withAuthorizationResults(),
+      LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 
     const loadParams = { id: createdEntity.getID() };
@@ -220,7 +219,7 @@ describe(LocalMemorySecondaryEntityCache, () => {
         localMemoryTestEntityConfiguration,
         GenericLocalMemoryCacher.createLRUCache<LocalMemoryTestEntityFields>({}),
       ),
-      LocalMemoryTestEntity.loader(viewerContext).withAuthorizationResults(),
+      LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 
     const loadParams = { id: FAKE_ID };

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -80,7 +80,6 @@ describe(RedisSecondaryEntityCache, () => {
     );
 
     const createdEntity = await RedisTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('name', 'wat')
       .createAsync();
 
@@ -90,7 +89,7 @@ describe(RedisSecondaryEntityCache, () => {
         genericRedisCacheContext,
         (loadParams) => `test-key-${loadParams.id}`,
       ),
-      RedisTestEntity.loader(viewerContext).withAuthorizationResults(),
+      RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 
     const loadParams = { id: createdEntity.getID() };
@@ -129,7 +128,7 @@ describe(RedisSecondaryEntityCache, () => {
         genericRedisCacheContext,
         (loadParams) => `test-key-${loadParams.id}`,
       ),
-      RedisTestEntity.loader(viewerContext).withAuthorizationResults(),
+      RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 
     const loadParams = { id: FAKE_ID };

--- a/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
@@ -410,8 +410,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
       let associatedEntityResult: Result<ReadonlyEntity<any, any, any, any>> | null;
       if (associatedEntityLookupByField) {
         associatedEntityResult = await currentEntity
-          .associationLoader(this.queryContext)
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults(this.queryContext)
           .loadAssociatedEntityByFieldEqualingAsync(
             fieldIdentifyingAssociatedEntity,
             associatedEntityClass,
@@ -419,8 +418,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
           );
       } else {
         const associatedEntityResultLocal = await currentEntity
-          .associationLoader(this.queryContext)
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults(this.queryContext)
           .loadAssociatedEntityAsync(fieldIdentifyingAssociatedEntity, associatedEntityClass);
 
         if (associatedEntityResultLocal.ok && associatedEntityResultLocal.value === null) {

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -1,3 +1,11 @@
+import {
+  AuthorizationResultBasedCreateMutator,
+  AuthorizationResultBasedDeleteMutator,
+  AuthorizationResultBasedUpdateMutator,
+} from './AuthorizationResultBasedEntityMutator';
+import EnforcingEntityCreator from './EnforcingEntityCreator';
+import EnforcingEntityDeleter from './EnforcingEntityDeleter';
+import EnforcingEntityUpdater from './EnforcingEntityUpdater';
 import { EntityCompanionDefinition } from './EntityCompanionProvider';
 import EntityCreator from './EntityCreator';
 import EntityDeleter from './EntityDeleter';
@@ -65,16 +73,60 @@ export default abstract class Entity<
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
       .getQueryContext(),
-  ): EntityCreator<
+  ): EnforcingEntityCreator<
     TMFields,
     TMID,
     TMViewerContext,
-    TMViewerContext2,
     TMEntity,
     TMPrivacyPolicy,
     TMSelectedFields
   > {
-    return new EntityCreator(viewerContext, queryContext, this);
+    return new EntityCreator(viewerContext, queryContext, this).enforcing();
+  }
+
+  /**
+   * Vend mutator for creating a new entity in given query context.
+   * @param viewerContext - viewer context of creating user
+   * @param queryContext - query context in which to perform the create
+   * @returns mutator for creating an entity
+   */
+  static creatorWithAuthorizationResults<
+    TMFields extends object,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMViewerContext extends ViewerContext,
+    TMViewerContext2 extends TMViewerContext,
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields,
+  >(
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
+    viewerContext: TMViewerContext2,
+    queryContext: EntityQueryContext = viewerContext
+      .getViewerScopedEntityCompanionForClass(this)
+      .getQueryContextProvider()
+      .getQueryContext(),
+  ): AuthorizationResultBasedCreateMutator<
+    TMFields,
+    TMID,
+    TMViewerContext,
+    TMEntity,
+    TMPrivacyPolicy,
+    TMSelectedFields
+  > {
+    return new EntityCreator(viewerContext, queryContext, this).withAuthorizationResults();
   }
 
   /**
@@ -111,8 +163,60 @@ export default abstract class Entity<
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
       .getQueryContext(),
-  ): EntityUpdater<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
-    return new EntityUpdater(existingEntity, queryContext, this);
+  ): EnforcingEntityUpdater<
+    TMFields,
+    TMID,
+    TMViewerContext,
+    TMEntity,
+    TMPrivacyPolicy,
+    TMSelectedFields
+  > {
+    return new EntityUpdater(existingEntity, queryContext, this).enforcing();
+  }
+
+  /**
+   * Vend mutator for updating an existing entity in given query context.
+   * @param existingEntity - entity to update
+   * @param queryContext - query context in which to perform the update
+   * @returns mutator for updating existingEntity
+   */
+  static updaterWithAuthorizationResults<
+    TMFields extends object,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMViewerContext extends ViewerContext,
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields,
+  >(
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
+    existingEntity: TMEntity,
+    queryContext: EntityQueryContext = existingEntity
+      .getViewerContext()
+      .getViewerScopedEntityCompanionForClass(this)
+      .getQueryContextProvider()
+      .getQueryContext(),
+  ): AuthorizationResultBasedUpdateMutator<
+    TMFields,
+    TMID,
+    TMViewerContext,
+    TMEntity,
+    TMPrivacyPolicy,
+    TMSelectedFields
+  > {
+    return new EntityUpdater(existingEntity, queryContext, this).withAuthorizationResults();
   }
 
   /**
@@ -149,8 +253,60 @@ export default abstract class Entity<
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
       .getQueryContext(),
-  ): EntityDeleter<TMFields, TMID, TMViewerContext, TMEntity, TMPrivacyPolicy, TMSelectedFields> {
-    return new EntityDeleter(existingEntity, queryContext, this);
+  ): EnforcingEntityDeleter<
+    TMFields,
+    TMID,
+    TMViewerContext,
+    TMEntity,
+    TMPrivacyPolicy,
+    TMSelectedFields
+  > {
+    return new EntityDeleter(existingEntity, queryContext, this).enforcing();
+  }
+
+  /**
+   * Vend mutator for deleting an existing entity in given query context.
+   * @param existingEntity - entity to delete
+   * @param queryContext - query context in which to perform the delete
+   * @returns mutator for deleting existingEntity
+   */
+  static deleterWithAuthorizationResults<
+    TMFields extends object,
+    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMViewerContext extends ViewerContext,
+    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMPrivacyPolicy extends EntityPrivacyPolicy<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMSelectedFields
+    >,
+    TMSelectedFields extends keyof TMFields = keyof TMFields,
+  >(
+    this: IEntityClass<
+      TMFields,
+      TMID,
+      TMViewerContext,
+      TMEntity,
+      TMPrivacyPolicy,
+      TMSelectedFields
+    >,
+    existingEntity: TMEntity,
+    queryContext: EntityQueryContext = existingEntity
+      .getViewerContext()
+      .getViewerScopedEntityCompanionForClass(this)
+      .getQueryContextProvider()
+      .getQueryContext(),
+  ): AuthorizationResultBasedDeleteMutator<
+    TMFields,
+    TMID,
+    TMViewerContext,
+    TMEntity,
+    TMPrivacyPolicy,
+    TMSelectedFields
+  > {
+    return new EntityDeleter(existingEntity, queryContext, this).withAuthorizationResults();
   }
 }
 

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
@@ -14,26 +14,23 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testOtherEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+        TestEntity.creatorWithAuthorizationResults(viewerContext).createAsync(),
       );
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', testOtherEntity.getID())
           .createAsync(),
       );
       const loadedOther = await enforceAsyncResult(
         testEntity
-          .associationLoader()
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults()
           .loadAssociatedEntityAsync('stringField', TestEntity),
       );
       expect(loadedOther.getID()).toEqual(testOtherEntity.getID());
 
       const loadedOther2 = await enforceAsyncResult(
         testEntity
-          .associationLoader()
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults()
           .loadAssociatedEntityAsync('nullableField', TestEntity),
       );
       expect(loadedOther2).toBeNull();
@@ -45,24 +42,21 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+        TestEntity.creatorWithAuthorizationResults(viewerContext).createAsync(),
       );
       const testOtherEntity1 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', testEntity.getID())
           .createAsync(),
       );
       const testOtherEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', testEntity.getID())
           .createAsync(),
       );
       const loaded = await enforceResultsAsync(
         testEntity
-          .associationLoader()
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults()
           .loadManyAssociatedEntitiesAsync(TestEntity, 'stringField'),
       );
       expect(loaded).toHaveLength(2);
@@ -76,17 +70,15 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testOtherEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+        TestEntity.creatorWithAuthorizationResults(viewerContext).createAsync(),
       );
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', testOtherEntity.getID())
           .createAsync(),
       );
       const loadedOtherResult = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityByFieldEqualingAsync('stringField', TestEntity, 'customIdField');
       expect(loadedOtherResult?.enforceValue().getID()).toEqual(testOtherEntity.getID());
     });
@@ -95,14 +87,12 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', uuidv4())
           .createAsync(),
       );
       const loadedOtherResult = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityByFieldEqualingAsync('stringField', TestEntity, 'customIdField');
       expect(loadedOtherResult).toBeNull();
     });
@@ -111,14 +101,12 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', 'blah')
           .createAsync(),
       );
       const loadedOtherResult = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityByFieldEqualingAsync('nullableField', TestEntity, 'customIdField');
       expect(loadedOtherResult).toBeNull();
     });
@@ -129,24 +117,21 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+        TestEntity.creatorWithAuthorizationResults(viewerContext).createAsync(),
       );
       const testOtherEntity1 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', testEntity.getID())
           .createAsync(),
       );
       const testOtherEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', testEntity.getID())
           .createAsync(),
       );
       const loaded = await enforceResultsAsync(
         testEntity
-          .associationLoader()
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults()
           .loadManyAssociatedEntitiesByFieldEqualingAsync(
             'customIdField',
             TestEntity,
@@ -162,12 +147,11 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+        TestEntity.creatorWithAuthorizationResults(viewerContext).createAsync(),
       );
       const loaded = await enforceResultsAsync(
         testEntity
-          .associationLoader()
-          .withAuthorizationResults()
+          .associationLoaderWithAuthorizationResults()
           .loadManyAssociatedEntitiesByFieldEqualingAsync(
             'nullableField',
             TestEntity,
@@ -183,30 +167,26 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
       const testEntity4 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext).withAuthorizationResults().createAsync(),
+        TestEntity.creatorWithAuthorizationResults(viewerContext).createAsync(),
       );
       const testEntity3 = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity2.creatorWithAuthorizationResults(viewerContext)
           .setField('foreignKey', testEntity4.getID())
           .createAsync(),
       );
       const testEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('testIndexedField', testEntity3.getID())
           .createAsync(),
       );
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity2.creatorWithAuthorizationResults(viewerContext)
           .setField('foreignKey', testEntity2.getID())
           .createAsync(),
       );
 
       const loaded2Result = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,
@@ -216,8 +196,7 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       expect(loaded2Result?.enforceValue().getID()).toEqual(testEntity2.getID());
 
       const loaded3Result = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,
@@ -231,8 +210,7 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       expect(loaded3Result?.enforceValue().getID()).toEqual(testEntity3.getID());
 
       const loaded4Result = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,
@@ -255,15 +233,13 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const viewerContext = new TestViewerContext(companionProvider);
 
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity2.creatorWithAuthorizationResults(viewerContext)
           .setField('foreignKey', uuidv4())
           .createAsync(),
       );
 
       const loadResult = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,
@@ -279,21 +255,18 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
 
       const fieldValue = uuidv4();
       const testEntity2 = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('stringField', fieldValue)
           .createAsync(),
       );
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity2.creatorWithAuthorizationResults(viewerContext)
           .setField('foreignKey', fieldValue)
           .createAsync(),
       );
 
       const loaded2Result = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,
@@ -309,15 +282,13 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const viewerContext = new TestViewerContext(companionProvider);
 
       const testEntity = await enforceAsyncResult(
-        TestEntity2.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity2.creatorWithAuthorizationResults(viewerContext)
           .setField('foreignKey', uuidv4())
           .createAsync(),
       );
 
       const loaded2Result = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,
@@ -333,15 +304,13 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       const viewerContext = new TestViewerContext(companionProvider);
 
       const testEntity = await enforceAsyncResult(
-        TestEntity.creator(viewerContext)
-          .withAuthorizationResults()
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
           .setField('nullableField', null)
           .createAsync(),
       );
 
       const loadedResult = await testEntity
-        .associationLoader()
-        .withAuthorizationResults()
+        .associationLoaderWithAuthorizationResults()
         .loadAssociatedEntityThroughAsync([
           {
             associatedEntityClass: TestEntity,

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -1,22 +1,37 @@
+import {
+  AuthorizationResultBasedCreateMutator,
+  AuthorizationResultBasedDeleteMutator,
+  AuthorizationResultBasedUpdateMutator,
+} from '../AuthorizationResultBasedEntityMutator';
+import EnforcingEntityCreator from '../EnforcingEntityCreator';
+import EnforcingEntityDeleter from '../EnforcingEntityDeleter';
+import EnforcingEntityUpdater from '../EnforcingEntityUpdater';
 import Entity from '../Entity';
-import EntityCreator from '../EntityCreator';
-import EntityDeleter from '../EntityDeleter';
-import EntityUpdater from '../EntityUpdater';
 import ViewerContext from '../ViewerContext';
 import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
 import { createUnitTestEntityCompanionProvider } from '../utils/testing/createUnitTestEntityCompanionProvider';
 
 describe(Entity, () => {
   describe('creator', () => {
-    it('creates a new EntityCreator', () => {
+    it('creates a new EnforcingEntityCreator', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.creator(viewerContext)).toBeInstanceOf(EntityCreator);
+      expect(SimpleTestEntity.creator(viewerContext)).toBeInstanceOf(EnforcingEntityCreator);
+    });
+  });
+
+  describe('creatorWithAuthorizationResults', () => {
+    it('creates a new AuthorizationResultBasedCreateMutator', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      expect(SimpleTestEntity.creatorWithAuthorizationResults(viewerContext)).toBeInstanceOf(
+        AuthorizationResultBasedCreateMutator,
+      );
     });
   });
 
   describe('updater', () => {
-    it('creates a new EntityUpdater', () => {
+    it('creates a new EnforcingEntityUpdater', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
       const data = {
@@ -28,12 +43,31 @@ describe(Entity, () => {
         databaseFields: data,
         selectedFields: data,
       });
-      expect(SimpleTestEntity.updater(testEntity)).toBeInstanceOf(EntityUpdater);
+      expect(SimpleTestEntity.updater(testEntity)).toBeInstanceOf(EnforcingEntityUpdater);
+    });
+  });
+
+  describe('updaterWithAuthorizationResults', () => {
+    it('creates a new AuthorizationResultBasedUpdateMutator', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
+      expect(SimpleTestEntity.updaterWithAuthorizationResults(testEntity)).toBeInstanceOf(
+        AuthorizationResultBasedUpdateMutator,
+      );
     });
   });
 
   describe('deleter', () => {
-    it('creates a new EntityDeleter', () => {
+    it('creates a new EnforcingEntityDeleter', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
       const data = {
@@ -45,7 +79,26 @@ describe(Entity, () => {
         databaseFields: data,
         selectedFields: data,
       });
-      expect(SimpleTestEntity.deleter(testEntity)).toBeInstanceOf(EntityDeleter);
+      expect(SimpleTestEntity.deleter(testEntity)).toBeInstanceOf(EnforcingEntityDeleter);
+    });
+  });
+
+  describe('deleterWithAuthorizationResults', () => {
+    it('creates a new AuthorizationResultBasedDeleteMutator', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
+      expect(SimpleTestEntity.deleterWithAuthorizationResults(testEntity)).toBeInstanceOf(
+        AuthorizationResultBasedDeleteMutator,
+      );
     });
   });
 });

--- a/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
@@ -10,10 +10,8 @@ describe(EntityAssociationLoader, () => {
     it('creates a new EnforcingEntityLoader', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      const testEntity = await SimpleTestEntity.creator(viewerContext).enforcing().createAsync();
-      expect(testEntity.associationLoader().enforcing()).toBeInstanceOf(
-        EnforcingEntityAssociationLoader,
-      );
+      const testEntity = await SimpleTestEntity.creator(viewerContext).createAsync();
+      expect(testEntity.associationLoader()).toBeInstanceOf(EnforcingEntityAssociationLoader);
     });
   });
 
@@ -21,8 +19,8 @@ describe(EntityAssociationLoader, () => {
     it('creates a new AuthorizationResultBasedEntityAssociationLoader', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      const testEntity = await SimpleTestEntity.creator(viewerContext).enforcing().createAsync();
-      expect(testEntity.associationLoader().withAuthorizationResults()).toBeInstanceOf(
+      const testEntity = await SimpleTestEntity.creator(viewerContext).createAsync();
+      expect(testEntity.associationLoaderWithAuthorizationResults()).toBeInstanceOf(
         AuthorizationResultBasedEntityAssociationLoader,
       );
     });

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -118,22 +118,19 @@ it('runs through a common workflow', async () => {
   const vc2 = new TestUserViewerContext(entityCompanionProvider, uuidv4());
 
   const blahOwner1 = await enforceAsyncResult(
-    BlahEntity.creator(vc1)
-      .withAuthorizationResults()
+    BlahEntity.creatorWithAuthorizationResults(vc1)
       .setField('ownerID', vc1.getUserID())
       .createAsync(),
   );
 
   await enforceAsyncResult(
-    BlahEntity.creator(vc1)
-      .withAuthorizationResults()
+    BlahEntity.creatorWithAuthorizationResults(vc1)
       .setField('ownerID', vc1.getUserID())
       .createAsync(),
   );
 
   const blahOwner2 = await enforceAsyncResult(
-    BlahEntity.creator(vc2)
-      .withAuthorizationResults()
+    BlahEntity.creatorWithAuthorizationResults(vc2)
       .setField('ownerID', vc2.getUserID())
       .createAsync(),
   );
@@ -145,43 +142,43 @@ it('runs through a common workflow', async () => {
   // check that two people can't read each others data
   await expect(
     enforceAsyncResult(
-      BlahEntity.loader(vc1).withAuthorizationResults().loadByIDAsync(blahOwner2.getID()),
+      BlahEntity.loaderWithAuthorizationResults(vc1).loadByIDAsync(blahOwner2.getID()),
     ),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
   await expect(
     enforceAsyncResult(
-      BlahEntity.loader(vc2).withAuthorizationResults().loadByIDAsync(blahOwner1.getID()),
+      BlahEntity.loaderWithAuthorizationResults(vc2).loadByIDAsync(blahOwner1.getID()),
     ),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
   // check that all of owner 1's objects can be loaded
   const results = await enforceResultsAsync(
-    BlahEntity.loader(vc1)
-      .withAuthorizationResults()
-      .loadManyByFieldEqualingAsync('ownerID', vc1.getUserID()),
+    BlahEntity.loaderWithAuthorizationResults(vc1).loadManyByFieldEqualingAsync(
+      'ownerID',
+      vc1.getUserID(),
+    ),
   );
   expect(results).toHaveLength(2);
 
   // check that two people can't create objects owned by others
   await expect(
     enforceAsyncResult(
-      BlahEntity.creator(vc2)
-        .withAuthorizationResults()
+      BlahEntity.creatorWithAuthorizationResults(vc2)
         .setField('ownerID', blahOwner1.getID())
         .createAsync(),
     ),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 
   // check that empty load many returns nothing
-  const results2 = await BlahEntity.loader(vc1)
-    .withAuthorizationResults()
-    .loadManyByFieldEqualingManyAsync('ownerID', []);
+  const results2 = await BlahEntity.loaderWithAuthorizationResults(
+    vc1,
+  ).loadManyByFieldEqualingManyAsync('ownerID', []);
   for (const value in results2.values) {
     expect(value).toHaveLength(0);
   }
 
   // check that the user can't delete their own data (as specified by privacy rules)
   await expect(
-    enforceAsyncResult(BlahEntity.deleter(blahOwner2).withAuthorizationResults().deleteAsync()),
+    enforceAsyncResult(BlahEntity.deleterWithAuthorizationResults(blahOwner2).deleteAsync()),
   ).rejects.toBeInstanceOf(EntityNotAuthorizedError);
 });

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -527,42 +527,36 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
+      const parent = await ParentEntity.creator(viewerContext).createAsync();
       const child = await ChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', parent.getID())
         .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', child.getID())
         .createAsync();
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID()),
+        ChildEntity.loader(viewerContext).loadByIDNullableAsync(child.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        GrandChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByIDNullableAsync(grandchild.getID()),
+        GrandChildEntity.loader(viewerContext).loadByIDNullableAsync(grandchild.getID()),
       ).resolves.not.toBeNull();
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.deleter(parent).enforcing().deleteAsync();
+      await ParentEntity.deleter(parent).deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID()),
+        ChildEntity.loader(viewerContext).loadByIDNullableAsync(child.getID()),
       ).resolves.toBeNull();
       await expect(
-        GrandChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByIDNullableAsync(grandchild.getID()),
+        GrandChildEntity.loader(viewerContext).loadByIDNullableAsync(grandchild.getID()),
       ).resolves.toBeNull();
 
       // two calls for each trigger, one beforeDelete, one afterDelete
@@ -651,44 +645,38 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
+      const parent = await ParentEntity.creator(viewerContext).createAsync();
       const child = await ChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', parent.getID())
         .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', child.getID())
         .createAsync();
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID()),
+        ChildEntity.loader(viewerContext).loadByIDNullableAsync(child.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        GrandChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByIDNullableAsync(grandchild.getID()),
+        GrandChildEntity.loader(viewerContext).loadByIDNullableAsync(grandchild.getID()),
       ).resolves.not.toBeNull();
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.deleter(parent).enforcing().deleteAsync();
+      await ParentEntity.deleter(parent).deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.toBeNull();
 
-      const loadedChild = await ChildEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDAsync(child.getID());
+      const loadedChild = await ChildEntity.loader(viewerContext).loadByIDAsync(child.getID());
       expect(loadedChild.getField('parent_id')).toBeNull();
 
-      const loadedGrandchild = await GrandChildEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDAsync(grandchild.getID());
+      const loadedGrandchild = await GrandChildEntity.loader(viewerContext).loadByIDAsync(
+        grandchild.getID(),
+      );
       expect(loadedGrandchild.getField('parent_id')).toEqual(loadedChild.getID());
 
       // two calls for only parent trigger, one beforeDelete, one afterDelete
@@ -766,28 +754,22 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
+      const parent = await ParentEntity.creator(viewerContext).createAsync();
       const child = await ChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', parent.getID())
         .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', child.getID())
         .createAsync();
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByFieldEqualingAsync('parent_id', parent.getID()),
+        ChildEntity.loader(viewerContext).loadByFieldEqualingAsync('parent_id', parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        GrandChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByFieldEqualingAsync('parent_id', child.getID()),
+        GrandChildEntity.loader(viewerContext).loadByFieldEqualingAsync('parent_id', child.getID()),
       ).resolves.not.toBeNull();
 
       const childCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
@@ -809,7 +791,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       expect(grandChildCachedBefore.get(child.getID())?.status).toEqual(CacheStatus.HIT);
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.deleter(parent).enforcing().deleteAsync();
+      await ParentEntity.deleter(parent).deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       const childCachedAfter = await childCacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
@@ -821,17 +803,15 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       expect(grandChildCachedAfter.get(child.getID())?.status).toEqual(CacheStatus.HIT);
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.toBeNull();
 
-      const loadedChild = await ChildEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDAsync(child.getID());
+      const loadedChild = await ChildEntity.loader(viewerContext).loadByIDAsync(child.getID());
       expect(loadedChild).not.toBeNull();
 
-      const loadedGrandchild = await GrandChildEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDAsync(grandchild.getID());
+      const loadedGrandchild = await GrandChildEntity.loader(viewerContext).loadByIDAsync(
+        grandchild.getID(),
+      );
       expect(loadedGrandchild.getField('parent_id')).toEqual(loadedChild.getID());
 
       // two calls for only parent trigger, one beforeDelete, one afterDelete
@@ -907,28 +887,22 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new TestViewerContext(companionProvider);
 
-      const parent = await ParentEntity.creator(viewerContext).enforcing().createAsync();
+      const parent = await ParentEntity.creator(viewerContext).createAsync();
       const child = await ChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', parent.getID())
         .createAsync();
       const grandchild = await GrandChildEntity.creator(viewerContext)
-        .enforcing()
         .setField('parent_id', child.getID())
         .createAsync();
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByFieldEqualingAsync('parent_id', parent.getID()),
+        ChildEntity.loader(viewerContext).loadByFieldEqualingAsync('parent_id', parent.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        GrandChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByFieldEqualingAsync('parent_id', child.getID()),
+        GrandChildEntity.loader(viewerContext).loadByFieldEqualingAsync('parent_id', child.getID()),
       ).resolves.not.toBeNull();
 
       const childCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
@@ -950,7 +924,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       expect(grandChildCachedBefore.get(child.getID())?.status).toEqual(CacheStatus.HIT);
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
-      await ParentEntity.deleter(parent).enforcing().deleteAsync();
+      await ParentEntity.deleter(parent).deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       const childCachedAfter = await childCacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
@@ -962,15 +936,13 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       expect(grandChildCachedAfter.get(child.getID())?.status).toEqual(CacheStatus.MISS);
 
       await expect(
-        ParentEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(parent.getID()),
+        ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
       ).resolves.toBeNull();
       await expect(
-        ChildEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(child.getID()),
+        ChildEntity.loader(viewerContext).loadByIDNullableAsync(child.getID()),
       ).resolves.not.toBeNull();
       await expect(
-        GrandChildEntity.loader(viewerContext)
-          .enforcing()
-          .loadByIDNullableAsync(grandchild.getID()),
+        GrandChildEntity.loader(viewerContext).loadByIDNullableAsync(grandchild.getID()),
       ).resolves.not.toBeNull();
 
       // two calls for each trigger, one beforeDelete, one afterDelete

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -11,9 +11,7 @@ describe(EntityLoader, () => {
     it('creates a new EnforcingEntityLoader', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.loader(viewerContext).enforcing()).toBeInstanceOf(
-        EnforcingEntityLoader,
-      );
+      expect(SimpleTestEntity.loader(viewerContext)).toBeInstanceOf(EnforcingEntityLoader);
     });
   });
 
@@ -21,7 +19,7 @@ describe(EntityLoader, () => {
     it('creates a new AuthorizationResultBasedEntityLoader', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.loader(viewerContext).withAuthorizationResults()).toBeInstanceOf(
+      expect(SimpleTestEntity.loaderWithAuthorizationResults(viewerContext)).toBeInstanceOf(
         AuthorizationResultBasedEntityLoader,
       );
     });
@@ -31,7 +29,7 @@ describe(EntityLoader, () => {
     it('returns a instance of EntityLoaderUtils', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.loader(viewerContext).utils()).toBeInstanceOf(EntityLoaderUtils);
+      expect(SimpleTestEntity.loaderUtils(viewerContext)).toBeInstanceOf(EntityLoaderUtils);
     });
   });
 });

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -76,9 +76,9 @@ class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutation
     mutationInfo: EntityTriggerMutationInfo<BlahFields, string, ViewerContext, BlahEntity>,
   ): Promise<void> {
     if (mutationInfo.type === EntityMutationType.DELETE) {
-      const entityLoaded = await BlahEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(entity.getID());
+      const entityLoaded = await BlahEntity.loader(viewerContext).loadByIDNullableAsync(
+        entity.getID(),
+      );
       if (entityLoaded) {
         throw new Error(
           'should not have been able to re-load the entity after delete. this means the cache has not been cleared',
@@ -94,11 +94,9 @@ describe(EntityMutatorFactory, () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     // put it in cache
-    const entity = await BlahEntity.creator(viewerContext).enforcing().createAsync();
-    const entityLoaded = await BlahEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(entity.getID());
+    const entity = await BlahEntity.creator(viewerContext).createAsync();
+    const entityLoaded = await BlahEntity.loader(viewerContext).loadByIDAsync(entity.getID());
 
-    await BlahEntity.deleter(entityLoaded).enforcing().deleteAsync();
+    await BlahEntity.deleter(entityLoaded).deleteAsync();
   });
 });

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -32,7 +32,7 @@ describe(EntitySecondaryCacheLoader, () => {
     it('calls into secondary cache with correct params', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
-      const createdEntity = await SimpleTestEntity.creator(vc1).enforcing().createAsync();
+      const createdEntity = await SimpleTestEntity.creator(vc1).createAsync();
       const loadParams = { id: createdEntity.getID() };
 
       const secondaryEntityCacheMock =
@@ -44,7 +44,7 @@ describe(EntitySecondaryCacheLoader, () => {
 
       const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
         secondaryEntityCache,
-        SimpleTestEntity.loader(vc1).withAuthorizationResults(),
+        SimpleTestEntity.loaderWithAuthorizationResults(vc1),
       );
 
       await secondaryCacheLoader.loadManyAsync([loadParams]);
@@ -57,7 +57,7 @@ describe(EntitySecondaryCacheLoader, () => {
     it('constructs and authorizes entities', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
-      const createdEntity = await SimpleTestEntity.creator(vc1).enforcing().createAsync();
+      const createdEntity = await SimpleTestEntity.creator(vc1).createAsync();
       const loadParams = { id: createdEntity.getID() };
 
       const secondaryEntityCacheMock =
@@ -67,7 +67,7 @@ describe(EntitySecondaryCacheLoader, () => {
       ).thenResolve(new Map([[loadParams, createdEntity.getAllFields()]]));
       const secondaryEntityCache = instance(secondaryEntityCacheMock);
 
-      const loader = SimpleTestEntity.loader(vc1).withAuthorizationResults();
+      const loader = SimpleTestEntity.loaderWithAuthorizationResults(vc1);
       const spiedPrivacyPolicy = spy(loader.utils['privacyPolicy']);
       const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(secondaryEntityCache, loader);
 
@@ -90,13 +90,13 @@ describe(EntitySecondaryCacheLoader, () => {
     it('calls invalidate on the secondary cache', async () => {
       const vc1 = new ViewerContext(createUnitTestEntityCompanionProvider());
 
-      const createdEntity = await SimpleTestEntity.creator(vc1).enforcing().createAsync();
+      const createdEntity = await SimpleTestEntity.creator(vc1).createAsync();
       const loadParams = { id: createdEntity.getID() };
 
       const secondaryEntityCacheMock =
         mock<ISecondaryEntityCache<SimpleTestFields, TestLoadParams>>();
       const secondaryEntityCache = instance(secondaryEntityCacheMock);
-      const loader = SimpleTestEntity.loader(vc1).withAuthorizationResults();
+      const loader = SimpleTestEntity.loaderWithAuthorizationResults(vc1);
       const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(secondaryEntityCache, loader);
       await secondaryCacheLoader.invalidateManyAsync([loadParams]);
 

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -87,44 +87,34 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const parentCategory = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const parentCategory = await CategoryEntity.creator(viewerContext).createAsync();
     const subCategory = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', parentCategory.getID())
       .createAsync();
     const subSubCategory = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', subCategory.getID())
       .createAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subCategory.getID()),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(subSubCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subSubCategory.getID()),
     ).resolves.not.toBeNull();
 
-    await CategoryEntity.deleter(parentCategory).enforcing().deleteAsync();
+    await CategoryEntity.deleter(parentCategory).deleteAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
     ).resolves.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subCategory.getID()),
     ).resolves.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(subSubCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subSubCategory.getID()),
     ).resolves.toBeNull();
   });
 
@@ -134,23 +124,21 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const categoryA = await CategoryEntity.creator(viewerContext).createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', categoryA.getID())
       .createAsync();
     await CategoryEntity.updater(categoryA)
-      .enforcing()
       .setField('parent_category_id', categoryB.getID())
       .updateAsync();
 
-    await CategoryEntity.deleter(categoryA).enforcing().deleteAsync();
+    await CategoryEntity.deleter(categoryA).deleteAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(categoryA.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(categoryA.getID()),
     ).resolves.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(categoryB.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(categoryB.getID()),
     ).resolves.toBeNull();
   });
 });
@@ -162,46 +150,38 @@ describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const parentCategory = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const parentCategory = await CategoryEntity.creator(viewerContext).createAsync();
     const subCategory = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', parentCategory.getID())
       .createAsync();
     const subSubCategory = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', subCategory.getID())
       .createAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subCategory.getID()),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(subSubCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subSubCategory.getID()),
     ).resolves.not.toBeNull();
 
-    await CategoryEntity.deleter(parentCategory).enforcing().deleteAsync();
+    await CategoryEntity.deleter(parentCategory).deleteAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
     ).resolves.toBeNull();
 
-    const loadedSubCategory = await CategoryEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(subCategory.getID());
+    const loadedSubCategory = await CategoryEntity.loader(viewerContext).loadByIDAsync(
+      subCategory.getID(),
+    );
     expect(loadedSubCategory.getField('parent_category_id')).toBeNull();
 
-    const loadedSubSubCategory = await CategoryEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(subSubCategory.getID());
+    const loadedSubSubCategory = await CategoryEntity.loader(viewerContext).loadByIDAsync(
+      subSubCategory.getID(),
+    );
     expect(loadedSubSubCategory.getField('parent_category_id')).not.toBeNull();
   });
 
@@ -211,21 +191,19 @@ describe('EntityEdgeDeletionBehavior.SET_NULL', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const categoryA = await CategoryEntity.creator(viewerContext).createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', categoryA.getID())
       .createAsync();
     await CategoryEntity.updater(categoryA)
-      .enforcing()
       .setField('parent_category_id', categoryB.getID())
       .updateAsync();
 
-    await CategoryEntity.deleter(categoryA).enforcing().deleteAsync();
+    await CategoryEntity.deleter(categoryA).deleteAsync();
 
-    const loadedCategoryB = await CategoryEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(categoryB.getID());
+    const loadedCategoryB = await CategoryEntity.loader(viewerContext).loadByIDAsync(
+      categoryB.getID(),
+    );
     expect(loadedCategoryB.getField('parent_category_id')).toBeNull();
   });
 });
@@ -239,30 +217,28 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const parentCategory = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const parentCategory = await CategoryEntity.creator(viewerContext).createAsync();
     const subCategory = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', parentCategory.getID())
       .createAsync();
     const subSubCategory = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', subCategory.getID())
       .createAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByFieldEqualingAsync('parent_category_id', parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByFieldEqualingAsync(
+        'parent_category_id',
+        parentCategory.getID(),
+      ),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByFieldEqualingAsync('parent_category_id', subCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByFieldEqualingAsync(
+        'parent_category_id',
+        subCategory.getID(),
+      ),
     ).resolves.not.toBeNull();
 
     const categoryCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(
@@ -281,7 +257,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     );
     expect(subSubCategoryCachedBefore.get(subCategory.getID())?.status).toEqual(CacheStatus.HIT);
 
-    await CategoryEntity.deleter(parentCategory).enforcing().deleteAsync();
+    await CategoryEntity.deleter(parentCategory).deleteAsync();
 
     const subCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
       parentCategory.getID(),
@@ -295,17 +271,13 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     expect(subSubCategoryCachedAfter.get(subCategory.getID())?.status).toEqual(CacheStatus.MISS);
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(parentCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
     ).resolves.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext).enforcing().loadByIDNullableAsync(subCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subCategory.getID()),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByIDNullableAsync(subSubCategory.getID()),
+      CategoryEntity.loader(viewerContext).loadByIDNullableAsync(subSubCategory.getID()),
     ).resolves.not.toBeNull();
   });
 
@@ -317,25 +289,25 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).enforcing().createAsync();
+    const categoryA = await CategoryEntity.creator(viewerContext).createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
-      .enforcing()
       .setField('parent_category_id', categoryA.getID())
       .createAsync();
     await CategoryEntity.updater(categoryA)
-      .enforcing()
       .setField('parent_category_id', categoryB.getID())
       .updateAsync();
 
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByFieldEqualingAsync('parent_category_id', categoryA.getID()),
+      CategoryEntity.loader(viewerContext).loadByFieldEqualingAsync(
+        'parent_category_id',
+        categoryA.getID(),
+      ),
     ).resolves.not.toBeNull();
     await expect(
-      CategoryEntity.loader(viewerContext)
-        .enforcing()
-        .loadByFieldEqualingAsync('parent_category_id', categoryB.getID()),
+      CategoryEntity.loader(viewerContext).loadByFieldEqualingAsync(
+        'parent_category_id',
+        categoryB.getID(),
+      ),
     ).resolves.not.toBeNull();
 
     const categoryCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(
@@ -350,7 +322,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     expect(categoriesCachedBefore.get(categoryA.getID())?.status).toEqual(CacheStatus.HIT);
     expect(categoriesCachedBefore.get(categoryB.getID())?.status).toEqual(CacheStatus.HIT);
 
-    await CategoryEntity.deleter(categoryA).enforcing().deleteAsync();
+    await CategoryEntity.deleter(categoryA).deleteAsync();
 
     const categoriesCachedAfter = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
       categoryA.getID(),

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -1,7 +1,10 @@
 import { instance, mock } from 'ts-mockito';
 
-import EntityAssociationLoader from '../EntityAssociationLoader';
-import EntityLoader from '../EntityLoader';
+import AuthorizationResultBasedEntityAssociationLoader from '../AuthorizationResultBasedEntityAssociationLoader';
+import AuthorizationResultBasedEntityLoader from '../AuthorizationResultBasedEntityLoader';
+import EnforcingEntityAssociationLoader from '../EnforcingEntityAssociationLoader';
+import EnforcingEntityLoader from '../EnforcingEntityLoader';
+import EntityLoaderUtils from '../EntityLoaderUtils';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 import SimpleTestEntity from '../testfixtures/SimpleTestEntity';
@@ -157,7 +160,7 @@ describe(ReadonlyEntity, () => {
   });
 
   describe('associationLoader', () => {
-    it('returns a new association loader', () => {
+    it('returns a new EnforcingEntityAssociationLoader', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
       const data = {
@@ -169,15 +172,52 @@ describe(ReadonlyEntity, () => {
         databaseFields: data,
         selectedFields: data,
       });
-      expect(testEntity.associationLoader()).toBeInstanceOf(EntityAssociationLoader);
+      expect(testEntity.associationLoader()).toBeInstanceOf(EnforcingEntityAssociationLoader);
+    });
+  });
+
+  describe('associationLoaderWithAuthorizationResults', () => {
+    it('returns a new AuthorizationResultBasedEntityAssociationLoader', () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      const data = {
+        id: 'what',
+      };
+      const testEntity = new SimpleTestEntity({
+        viewerContext,
+        id: 'what',
+        databaseFields: data,
+        selectedFields: data,
+      });
+      expect(testEntity.associationLoaderWithAuthorizationResults()).toBeInstanceOf(
+        AuthorizationResultBasedEntityAssociationLoader,
+      );
     });
   });
 
   describe('loader', () => {
-    it('creates a new EntityLoader', async () => {
+    it('creates a new EnforcingEntityLoader', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.loader(viewerContext)).toBeInstanceOf(EntityLoader);
+      expect(SimpleTestEntity.loader(viewerContext)).toBeInstanceOf(EnforcingEntityLoader);
+    });
+  });
+
+  describe('loaderWithAuthorizationResults', () => {
+    it('creates a new AuthorizationResultBasedEntityLoader', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      expect(SimpleTestEntity.loaderWithAuthorizationResults(viewerContext)).toBeInstanceOf(
+        AuthorizationResultBasedEntityLoader,
+      );
+    });
+  });
+
+  describe('loaderUtils', () => {
+    it('creates a new EntityLoaderUtils', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+      expect(SimpleTestEntity.loaderUtils(viewerContext)).toBeInstanceOf(EntityLoaderUtils);
     });
   });
 });

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -14,13 +14,11 @@ describe('Two entities backed by the same table', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     const one = await OneTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('entity_type', EntityType.ONE)
       .setField('common_other_field', 'wat')
       .createAsync();
 
     const two = await TwoTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('entity_type', EntityType.TWO)
       .setField('other_field', 'blah')
       .setField('common_other_field', 'wat')
@@ -30,16 +28,16 @@ describe('Two entities backed by the same table', () => {
     expect(two).toBeInstanceOf(TwoTestEntity);
 
     await expect(
-      TwoTestEntity.loader(viewerContext).enforcing().loadByIDAsync(one.getID()),
+      TwoTestEntity.loader(viewerContext).loadByIDAsync(one.getID()),
     ).rejects.toThrowError('TwoTestEntity must be instantiated with two data');
 
     await expect(
-      OneTestEntity.loader(viewerContext).enforcing().loadByIDAsync(two.getID()),
+      OneTestEntity.loader(viewerContext).loadByIDAsync(two.getID()),
     ).rejects.toThrowError('OneTestEntity must be instantiated with one data');
 
-    const manyResults = await OneTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadManyByFieldEqualingAsync('common_other_field', 'wat');
+    const manyResults = await OneTestEntity.loaderWithAuthorizationResults(
+      viewerContext,
+    ).loadManyByFieldEqualingAsync('common_other_field', 'wat');
     const successfulManyResults = successfulResults(manyResults);
     const failedManyResults = failedResults(manyResults);
 
@@ -51,14 +49,14 @@ describe('Two entities backed by the same table', () => {
       'OneTestEntity must be instantiated with one data',
     );
 
-    const fieldEqualityConjunctionResults = await OneTestEntity.loader(viewerContext)
-      .withAuthorizationResults()
-      .loadManyByFieldEqualityConjunctionAsync([
-        {
-          fieldName: 'common_other_field',
-          fieldValue: 'wat',
-        },
-      ]);
+    const fieldEqualityConjunctionResults = await OneTestEntity.loaderWithAuthorizationResults(
+      viewerContext,
+    ).loadManyByFieldEqualityConjunctionAsync([
+      {
+        fieldName: 'common_other_field',
+        fieldValue: 'wat',
+      },
+    ]);
     const successfulfieldEqualityConjunctionResultsResults = successfulResults(
       fieldEqualityConjunctionResults,
     );

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -13,18 +13,14 @@ describe('Two entities backed by the same table', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     const entity1 = await OneTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('fake_field', 'hello')
       .createAsync();
     expect(entity1).toBeInstanceOf(OneTestEntity);
 
-    const entity2 = await TwoTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(entity1.getID());
+    const entity2 = await TwoTestEntity.loader(viewerContext).loadByIDAsync(entity1.getID());
     expect(entity2).toBeInstanceOf(TwoTestEntity);
 
     const updated2 = await TwoTestEntity.updater(entity2)
-      .enforcing()
       .setField('fake_field', 'world')
       .setField('other_field', 'wat')
       .updateAsync();
@@ -34,9 +30,7 @@ describe('Two entities backed by the same table', () => {
       fake_field: 'world',
     });
 
-    const loaded1 = await OneTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(entity1.getID());
+    const loaded1 = await OneTestEntity.loader(viewerContext).loadByIDAsync(entity1.getID());
     expect(loaded1.getAllFields()).toMatchObject({
       id: updated2.getID(),
       fake_field: 'world',
@@ -48,37 +42,37 @@ describe('Two entities backed by the same table', () => {
     const viewerContext = new ViewerContext(companionProvider);
 
     const entity = await TwoTestEntity.creator(viewerContext)
-      .enforcing()
       .setField('fake_field', 'hello')
       .setField('other_field', 'huh')
       .createAsync();
 
-    const loadedEntity = await TwoTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByFieldEqualingAsync('other_field', 'huh');
+    const loadedEntity = await TwoTestEntity.loader(viewerContext).loadByFieldEqualingAsync(
+      'other_field',
+      'huh',
+    );
     expect(loadedEntity?.getAllFields()).toMatchObject({
       id: entity.getID(),
       fake_field: 'hello',
       other_field: 'huh',
     });
 
-    const loaded1 = await OneTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByIDAsync(entity.getID());
-    await OneTestEntity.updater(loaded1).enforcing().setField('fake_field', 'world').updateAsync();
+    const loaded1 = await OneTestEntity.loader(viewerContext).loadByIDAsync(entity.getID());
+    await OneTestEntity.updater(loaded1).setField('fake_field', 'world').updateAsync();
 
-    const loaded2 = await TwoTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByFieldEqualingAsync('other_field', 'huh');
+    const loaded2 = await TwoTestEntity.loader(viewerContext).loadByFieldEqualingAsync(
+      'other_field',
+      'huh',
+    );
     expect(loaded2?.getAllFields()).toMatchObject({
       id: entity.getID(),
       fake_field: 'world',
       other_field: 'huh',
     });
 
-    const loaded22 = await TwoTestEntity.loader(viewerContext)
-      .enforcing()
-      .loadByFieldEqualingAsync('fake_field', 'world');
+    const loaded22 = await TwoTestEntity.loader(viewerContext).loadByFieldEqualingAsync(
+      'fake_field',
+      'world',
+    );
     expect(loaded22?.getAllFields()).toMatchObject({
       id: entity.getID(),
       fake_field: 'world',

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -50,9 +50,7 @@ describe(canViewerUpdateAsync, () => {
   it('appropriately executes update privacy policy', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext).createAsync();
     const canViewerUpdate = await canViewerUpdateAsync(SimpleTestDenyDeleteEntity, testEntity);
     expect(canViewerUpdate).toBe(true);
     const canViewerUpdateResult = await getCanViewerUpdateResultAsync(
@@ -65,9 +63,7 @@ describe(canViewerUpdateAsync, () => {
   it('denies when policy denies', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     const canViewerUpdate = await canViewerUpdateAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerUpdate).toBe(false);
     const canViewerUpdateResult = await getCanViewerUpdateResultAsync(
@@ -83,9 +79,7 @@ describe(canViewerUpdateAsync, () => {
   it('rethrows non-authorization errors', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext).createAsync();
     await expect(canViewerUpdateAsync(SimpleTestThrowOtherErrorEntity, testEntity)).rejects.toThrow(
       'update error',
     );
@@ -99,9 +93,7 @@ describe(canViewerDeleteAsync, () => {
   it('appropriately executes update privacy policy', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
     expect(canViewerDelete).toBe(true);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -114,9 +106,7 @@ describe(canViewerDeleteAsync, () => {
   it('denies when policy denies', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext).createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyDeleteEntity, testEntity);
     expect(canViewerDelete).toBe(false);
     const canViewerDeleteResult = await getCanViewerDeleteResultAsync(
@@ -132,12 +122,9 @@ describe(canViewerDeleteAsync, () => {
   it('denies when recursive policy denies for CASCADE_DELETE', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     // add another entity referencing testEntity that would cascade deletion to itself when testEntity is deleted
     const leafEntity = await LeafDenyDeleteEntity.creator(viewerContext)
-      .enforcing()
       .setField('simple_test_deny_update_cascade_delete_id', testEntity.getID())
       .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
@@ -155,12 +142,9 @@ describe(canViewerDeleteAsync, () => {
   it('denies when recursive policy denies for SET_NULL', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     // add another entity referencing testEntity that would set null to its column when testEntity is deleted
     const leafEntity = await LeafDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
       .setField('simple_test_deny_update_set_null_id', testEntity.getID())
       .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
@@ -178,17 +162,13 @@ describe(canViewerDeleteAsync, () => {
   it('allows when recursive policy allows for CASCADE_DELETE and SET_NULL', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     // add another entity referencing testEntity that would cascade deletion to itself when testEntity is deleted
     await LeafDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
       .setField('simple_test_deny_update_cascade_delete_id', testEntity.getID())
       .createAsync();
     // add another entity referencing testEntity that would set null to its column when testEntity is deleted
     await LeafDenyDeleteEntity.creator(viewerContext)
-      .enforcing()
       .setField('simple_test_deny_update_set_null_id', testEntity.getID())
       .createAsync();
 
@@ -204,9 +184,7 @@ describe(canViewerDeleteAsync, () => {
   it('rethrows non-authorization errors', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext).createAsync();
     await expect(
       canViewerDeleteAsync(SimpleTestThrowOtherErrorEntity, testEntity),
     ).rejects.toThrowError('delete error');
@@ -218,11 +196,8 @@ describe(canViewerDeleteAsync, () => {
   it('returns false when edge cannot be read', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     const leafEntity = await LeafDenyReadEntity.creator(viewerContext)
-      .enforcing()
       .setField('simple_test_id', testEntity.getID())
       .createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
@@ -240,11 +215,8 @@ describe(canViewerDeleteAsync, () => {
   it('rethrows non-authorization edge read errors', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext)
-      .enforcing()
-      .createAsync();
+    const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
-      .enforcing()
       .setField('simple_test_id', testEntity.getID())
       .createAsync();
     await expect(canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity)).rejects.toThrowError(
@@ -261,11 +233,11 @@ describe(canViewerDeleteAsync, () => {
     const canViewerDelete = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
       'postgres',
       async (queryContext) => {
-        const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext, queryContext)
-          .enforcing()
-          .createAsync();
+        const testEntity = await SimpleTestDenyUpdateEntity.creator(
+          viewerContext,
+          queryContext,
+        ).createAsync();
         await LeafDenyReadEntity.creator(viewerContext, queryContext)
-          .enforcing()
           .setField('simple_test_id', testEntity.getID())
           .createAsync();
         // this would fail if transactions weren't supported or correctly passed through
@@ -277,11 +249,11 @@ describe(canViewerDeleteAsync, () => {
     const canViewerDeleteResult = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
       'postgres',
       async (queryContext) => {
-        const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext, queryContext)
-          .enforcing()
-          .createAsync();
+        const testEntity = await SimpleTestDenyUpdateEntity.creator(
+          viewerContext,
+          queryContext,
+        ).createAsync();
         await LeafDenyReadEntity.creator(viewerContext, queryContext)
-          .enforcing()
           .setField('simple_test_id', testEntity.getID())
           .createAsync();
         // this would fail if transactions weren't supported or correctly passed through

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -21,20 +21,18 @@ describe(canViewerDeleteAsync, () => {
       const viewerContext = new ViewerContext(companionProvider);
 
       // create root
-      const testEntity = await TestEntity.creator(viewerContext).enforcing().createAsync();
+      const testEntity = await TestEntity.creator(viewerContext).createAsync();
 
       // create a bunch of leaves referencing root with
       // edgeDeletionPermissionInferenceBehavior = EntityEdgeDeletionPermissionInferenceBehavior.ONE_IMPLIES_ALL
       for (let i = 0; i < 10; i++) {
         await TestLeafEntity.creator(viewerContext)
-          .enforcing()
           .setField('test_entity_id', testEntity.getID())
           .createAsync();
       }
 
       for (let i = 0; i < 10; i++) {
         await TestLeafLookupByFieldEntity.creator(viewerContext)
-          .enforcing()
           .setField('test_entity_id', testEntity.getID())
           .createAsync();
       }
@@ -65,12 +63,11 @@ describe(canViewerDeleteAsync, () => {
       const viewerContext = new ViewerContext(companionProvider);
 
       // create root
-      const testEntity = await TestEntity.creator(viewerContext).enforcing().createAsync();
+      const testEntity = await TestEntity.creator(viewerContext).createAsync();
 
       // create a bunch of leaves with no edgeDeletionPermissionInferenceBehavior
       for (let i = 0; i < 10; i++) {
         await TestLeafNoInferenceEntity.creator(viewerContext)
-          .enforcing()
           .setField('test_entity_id', testEntity.getID())
           .createAsync();
       }


### PR DESCRIPTION
# Why

This addresses the comment on #253:

> it'd be a good idea to push out a breaking change to Entity where everything is enforcing by default and you need to call unenforcing() (or withAuthorizationResults())

The reason this is possible now is that after the breaking change from that PR, it is a typescript error breaking change instead of an implicit breaking change to default the loaders/mutations to the enforcing versions.

# How

The new CRUD interface for entity will look like:
```
await TestEntity.creator(vc).setField(...).createAsync();
await TestEntity.creatorWithAuthorizationResults(vc).setField(...).updateAsync();

await TestEntity.updater(entity).setField(...).createAsync();
await TestEntity.updaterWithAuthorizationResults(entity).setField(...).updateAsync();

await TestEntity.deleter(entity).deleteAsync();
await TestEntity.deleterWithAuthorizationResults(entity).deleteAsync();

await TestEntity.loader(vc).getByIDAsync(id);
await TestEntity.loaderWithAuthorizationResults(vc).getByIDAsync(id);

await entity.associationLoader().loadAssociatedEntityAsync(...);
await entity.associationLoaderWithAuthorizationResults().loadAssociatedEntityAsync(...);
```

# Test Plan

Full test coverage.
