### PR TITLE
chore: add CI check for needing to run ctix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
         node-version-file: package.json
     - run: yarn --frozen-lockfile
     - run: yarn lint -- -- --max-warnings=0
+    - name: Check if barrels are up to date
+      run: yarn ctix && [ -z "$(git status --porcelain)" ]
     - run: yarn test -- -- --coverage
     - run: yarn integration -- -- --coverage
     - uses: codecov/codecov-action@v1


### PR DESCRIPTION
# Why

#255 switched barreling to `ctix` and fully-automated it (no manual intervention). But the intention is still to have the author run the command when they add new files in case they don't want the new files to be exported in the barrel.

This PR adds a CI step to ensure that the barrels are up to date.

# How

Run `yarn ctix` and check if working directory is dirty. If so, fail the CI run.

# Test Plan

1. Add a file with an export, `Blah.ts`, in src. Don't run `yarn ctix`.
2. Push PR
3. See CI failure.
