### PR TITLE
feat: Create codemod for v0.40.0 -> v0.41.0

### DIFF
--- a/packages/entity-codemod/src/transforms/__testfixtures__/v0.40.0-v0.41.0/test1.input.ts
+++ b/packages/entity-codemod/src/transforms/__testfixtures__/v0.40.0-v0.41.0/test1.input.ts
@@ -1,0 +1,100 @@
+/* eslint-disable */
+
+import { ViewerContext } from '@expo/entity';
+
+async function testWithAuthorizationResults(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entityResult = await TestEntity.creator(viewerContext).withAuthorizationResults().setField('wat', 2).createAsync();
+
+  // updater
+  const updatedEntityResult = await TestEntity.updater(entityResult.enforceValue()).withAuthorizationResults().setField('wat', 3).updateAsync();
+
+  // loader
+  const loadedEntityResult = await TestEntity.loader(viewerContext).withAuthorizationResults().loadByIDAsync('test');
+
+  // deleter
+  await TestEntity.deleter(updatedEntityResult.enforceValue()).withAuthorizationResults().deleteAsync();
+}
+
+async function testEnforcing(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entity = await TestEntity.creator(viewerContext).enforcing().setField('wat', 2).createAsync();
+  const entity2 = await TestEntity.creator(viewerContext).enforcing().setField('wat', 2).setField('who', 3).createAsync();
+  const entity3 = await TestEntity.creator(viewerContext).enforcing()
+    .setField('wat', 2)
+    .setField('who', 3)
+    .setField('who', 4)
+    .setField('who', 5)
+    .setField('who', 6)
+    .setField('who', 7)
+    .setField('who', 8)
+    .setField('who', 9)
+    .createAsync();
+
+  // updater
+  const updatedEntity = await TestEntity.updater(entity).enforcing().setField('wat', 3).updateAsync();
+  const updatedEntity2 = await TestEntity.updater(entity2).enforcing().setField('wat', 3).setField('who', 4).updateAsync();
+  const updatedEntity3 = await TestEntity.updater(entity3).enforcing()
+    .setField('wat', 3)
+    .setField('who', 4)
+    .setField('who', 5)
+    .setField('who', 6)
+    .setField('who', 7)
+    .setField('who', 8)
+    .setField('who', 9)
+    .updateAsync();
+
+  // loader
+  const loadedEntity = await TestEntity.loader(viewerContext).enforcing().loadByIDAsync('test');
+
+  // deleter
+  await TestEntity.deleter(entity).enforcing().deleteAsync();
+}
+
+async function testNoSetField(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entity = await TestEntity.creator(viewerContext).enforcing().createAsync();
+
+  // updater
+  const updatedEntity = await TestEntity.updater(entity).enforcing().updateAsync();
+}
+
+async function testEnforcingWithQueryContext(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entity = await TestEntity.creator(viewerContext, queryContext).enforcing().setField('wat', 2).createAsync();
+
+  // updater
+  const updatedEntity = await TestEntity.updater(entity, queryContext).enforcing().setField('wat', 3).updateAsync();
+
+  // loader
+  const loadedEntity = await TestEntity.loader(viewerContext, queryContext).enforcing().loadByIDAsync('test');
+
+  // deleter
+  await TestEntity.deleter(entity, queryContext).enforcing().deleteAsync();
+}
+
+async function testAssociationLoader(): Promise<void> {
+  await this.associationLoader().withAuthorizationResults().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  );
+
+  await entity.associationLoader().withAuthorizationResults().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  )
+
+  await this.associationLoader().enforcing().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  );
+
+  await entity.associationLoader().enforcing().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  )
+}

--- a/packages/entity-codemod/src/transforms/__testfixtures__/v0.40.0-v0.41.0/test1.output.ts
+++ b/packages/entity-codemod/src/transforms/__testfixtures__/v0.40.0-v0.41.0/test1.output.ts
@@ -1,0 +1,100 @@
+/* eslint-disable */
+
+import { ViewerContext } from '@expo/entity';
+
+async function testWithAuthorizationResults(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entityResult = await TestEntity.creatorWithAuthorizationResults(viewerContext).setField('wat', 2).createAsync();
+
+  // updater
+  const updatedEntityResult = await TestEntity.updaterWithAuthorizationResults(entityResult.enforceValue()).setField('wat', 3).updateAsync();
+
+  // loader
+  const loadedEntityResult = await TestEntity.loaderWithAuthorizationResults(viewerContext).loadByIDAsync('test');
+
+  // deleter
+  await TestEntity.deleterWithAuthorizationResults(updatedEntityResult.enforceValue()).deleteAsync();
+}
+
+async function testEnforcing(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entity = await TestEntity.creator(viewerContext).setField('wat', 2).createAsync();
+  const entity2 = await TestEntity.creator(viewerContext).setField('wat', 2).setField('who', 3).createAsync();
+  const entity3 = await TestEntity.creator(viewerContext)
+    .setField('wat', 2)
+    .setField('who', 3)
+    .setField('who', 4)
+    .setField('who', 5)
+    .setField('who', 6)
+    .setField('who', 7)
+    .setField('who', 8)
+    .setField('who', 9)
+    .createAsync();
+
+  // updater
+  const updatedEntity = await TestEntity.updater(entity).setField('wat', 3).updateAsync();
+  const updatedEntity2 = await TestEntity.updater(entity2).setField('wat', 3).setField('who', 4).updateAsync();
+  const updatedEntity3 = await TestEntity.updater(entity3)
+    .setField('wat', 3)
+    .setField('who', 4)
+    .setField('who', 5)
+    .setField('who', 6)
+    .setField('who', 7)
+    .setField('who', 8)
+    .setField('who', 9)
+    .updateAsync();
+
+  // loader
+  const loadedEntity = await TestEntity.loader(viewerContext).loadByIDAsync('test');
+
+  // deleter
+  await TestEntity.deleter(entity).deleteAsync();
+}
+
+async function testNoSetField(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entity = await TestEntity.creator(viewerContext).createAsync();
+
+  // updater
+  const updatedEntity = await TestEntity.updater(entity).updateAsync();
+}
+
+async function testEnforcingWithQueryContext(viewerContext: ViewerContext): Promise<void> {
+  // creator
+  const entity = await TestEntity.creator(viewerContext, queryContext).setField('wat', 2).createAsync();
+
+  // updater
+  const updatedEntity = await TestEntity.updater(entity, queryContext).setField('wat', 3).updateAsync();
+
+  // loader
+  const loadedEntity = await TestEntity.loader(viewerContext, queryContext).loadByIDAsync('test');
+
+  // deleter
+  await TestEntity.deleter(entity, queryContext).deleteAsync();
+}
+
+async function testAssociationLoader(): Promise<void> {
+  await this.associationLoaderWithAuthorizationResults().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  );
+
+  await entity.associationLoaderWithAuthorizationResults().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  )
+
+  await this.associationLoader().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  );
+
+  await entity.associationLoader().loadAssociatedEntityAsync(
+    'another_id',
+    AnotherEntity,
+    queryContext
+  )
+}

--- a/packages/entity-codemod/src/transforms/__tests__/v0.40.0-v0.41.0-test.ts
+++ b/packages/entity-codemod/src/transforms/__tests__/v0.40.0-v0.41.0-test.ts
@@ -1,0 +1,16 @@
+import { readdirSync } from 'fs';
+import { join } from 'path';
+
+jest.autoMockOff();
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+const fixtureDir = 'v0.40.0-v0.41.0';
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir);
+const fixtures = readdirSync(fixtureDirPath)
+  .filter((file) => file.endsWith('.input.ts'))
+  .map((file) => file.replace('.input.ts', ''));
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, 'v0.40.0-v0.41.0', null, prefix, { parser: 'ts' });
+}

--- a/packages/entity-codemod/src/transforms/v0.40.0-v0.41.0.ts
+++ b/packages/entity-codemod/src/transforms/v0.40.0-v0.41.0.ts
@@ -1,0 +1,81 @@
+import { API, Collection, FileInfo, Options } from 'jscodeshift';
+
+function transformWithAuthorizationResultsEntityChainMethod(
+  j: API['jscodeshift'],
+  root: Collection<any>,
+): void {
+  // Find all entity expressions of the form
+  // `TestEntity.thing(viewerContext).withAuthorizationResults()`
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        property: {
+          name: 'withAuthorizationResults',
+        },
+      },
+    })
+    .forEach((path) => {
+      const withAuthorizationResultsCallExpression = path.node; // TestEntity.thing(viewerContext).withAuthorizationResults()
+      const withAuthorizationResultsCallee = withAuthorizationResultsCallExpression.callee; // TestEntity.thing(viewerContext).withAuthorizationResults
+      if (withAuthorizationResultsCallee.type !== 'MemberExpression') {
+        return;
+      }
+
+      const thingCallExpression = withAuthorizationResultsCallee.object; // TestEntity.thing(viewerContext)
+      if (thingCallExpression.type !== 'CallExpression') {
+        return;
+      }
+      const thingCallee = thingCallExpression.callee; // TestEntity.thing
+      if (thingCallee.type !== 'MemberExpression') {
+        return;
+      }
+
+      if (thingCallee.property.type !== 'Identifier') {
+        return;
+      }
+
+      const newCreatorCalleeName = thingCallee.property.name + 'WithAuthorizationResults';
+      thingCallee.property.name = newCreatorCalleeName;
+
+      path.replace(thingCallExpression);
+    });
+}
+
+function transformEnforcingEntityChainMethod(j: API['jscodeshift'], root: Collection<any>): void {
+  // Find all entity expressions of the form
+  // `TestEntity.thing(viewerContext).enforcing()`
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        property: {
+          name: 'enforcing',
+        },
+      },
+    })
+    .forEach((path) => {
+      const enforcingCallExpression = path.node; // TestEntity.thing(viewerContext).enforcing()
+      const enforcingCallee = enforcingCallExpression.callee; // TestEntity.thing(viewerContext).enforcing
+      if (enforcingCallee.type !== 'MemberExpression') {
+        return;
+      }
+
+      const thingCallExpression = enforcingCallee.object; // TestEntity.thing(viewerContext)
+      if (thingCallExpression.type !== 'CallExpression') {
+        return;
+      }
+
+      path.replace(thingCallExpression);
+    });
+}
+
+export default function transformer(file: FileInfo, api: API, _options: Options): string {
+  const j = api.jscodeshift;
+  const root = j.withParser('ts')(file.source);
+
+  transformWithAuthorizationResultsEntityChainMethod(j, root);
+  transformEnforcingEntityChainMethod(j, root);
+
+  return root.toSource();
+}


### PR DESCRIPTION
# Why

Similar to #259, this creates a codemod to ease over breaking changes for large applications.

In particular, this creates the codemod for #256, which is planned to release as v1.0.0.

# How

Create a codemod with tests.

# Test Plan

Run automated tests.

Manual test in large application:
1. Apply changes from stack up to v0.40.0
2. Run codemod from #259, manually fix other tsc errors.
3. Apply changes from #256 (moving application libraries to v1.0.0.
4. Run this codemod, see it fixes ~99% of tsc errors.