### PR TITLE
chore: fix typedoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Entity is a privacy-aware data layer for defining, caching, and authorizing acce
 
 ## Getting Started
 
-- [Example application](packages/entity-example)
+- [Example application](https://github.com/expo/entity/tree/main/packages/entity-example)
 - [Documentation](https://expo.github.io/entity/)
 
 

--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -10,7 +10,9 @@ import LRUCache from 'lru-cache';
 // Sentinel value we store in local memory to negatively cache a database miss.
 // The sentinel value is distinct from any (positively) cached value.
 export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
-type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
+export type LocalMemoryCacheValue<TFields> =
+  | Readonly<TFields>
+  | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
 export type LocalMemoryCache<TFields> = LRUCache<string, LocalMemoryCacheValue<TFields>>;
 
 export default class GenericLocalMemoryCacher<TFields extends Record<string, any>>

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,11 @@
 {
-  "entryPoints": ["./packages/entity/src/index.ts", "./packages/entity-database-adapter-knex/src/index.ts", "./packages/entity-cache-adapter-redis/src/index.ts"],
+  "entryPoints": ["packages/*"],
+  "entryPointStrategy": "packages",
+  "includeVersion": false,
+  "packageOptions": {
+    "includeVersion": false,
+    "entryPoints": ["src/index.ts"],
+  },
   "out": "doc",
   "exclude": [
     "**/__tests__/**/*.ts",


### PR DESCRIPTION
# Why

Typedoc generation is broken on main.

# How

Typedoc introduced a new monorepo package mode that solves the problem, so update to that.

# Test Plan

`yarn typedoc`, view generated index.html.
