### PR TITLE
fix: fix metrics for dataloader waterfall logging

### DIFF
--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -72,7 +72,7 @@ export default class EntityDataManager<TFields extends Record<string, any>> {
       async (fetcherValues) => {
         this.metricsAdapter.incrementDataManagerLoadCount({
           type: IncrementLoadCountEventType.DATABASE,
-          fieldValueCount: fieldValues.length,
+          fieldValueCount: fetcherValues.length,
           entityClassName: this.entityClassName,
         });
         return await this.databaseAdapter.fetchManyWhereAsync(


### PR DESCRIPTION
# Why

Noticed this while building composite key loading. The issue is that this is counting the incorrect number of items being loaded from the database.

# How

Fix field.

# Test Plan

Add a new test for this.