### PR TITLE
chore: update generic constraint for TFields everywhere

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -10,10 +10,13 @@ import LRUCache from 'lru-cache';
 // Sentinel value we store in local memory to negatively cache a database miss.
 // The sentinel value is distinct from any (positively) cached value.
 export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
-export type LocalMemoryCacheValue<TFields> =
+export type LocalMemoryCacheValue<TFields extends Record<string, any>> =
   | Readonly<TFields>
   | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
-export type LocalMemoryCache<TFields> = LRUCache<string, LocalMemoryCacheValue<TFields>>;
+export type LocalMemoryCache<TFields extends Record<string, any>> = LRUCache<
+  string,
+  LocalMemoryCacheValue<TFields>
+>;
 
 export default class GenericLocalMemoryCacher<TFields extends Record<string, any>>
   implements IEntityGenericCacher<TFields>
@@ -23,7 +26,7 @@ export default class GenericLocalMemoryCacher<TFields extends Record<string, any
     private readonly localMemoryCache: LocalMemoryCache<TFields>,
   ) {}
 
-  static createLRUCache<TFields>(
+  static createLRUCache<TFields extends Record<string, any>>(
     options: { maxSize?: number; ttlSeconds?: number } = {},
   ): LocalMemoryCache<TFields> {
     const DEFAULT_LRU_CACHE_MAX_AGE_SECONDS = 10;
@@ -36,7 +39,7 @@ export default class GenericLocalMemoryCacher<TFields extends Record<string, any
     });
   }
 
-  static createNoOpCache<TFields>(): LocalMemoryCache<TFields> {
+  static createNoOpCache<TFields extends Record<string, any>>(): LocalMemoryCache<TFields> {
     return new LRUCache<string, LocalMemoryCacheValue<TFields>>({
       max: 0,
       maxAge: -1,

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -17,7 +17,7 @@ export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdap
    * @returns a no-op local memory cache adapter provider, or one that doesn't cache locally.
    */
   static createNoOpProvider(): IEntityCacheAdapterProvider {
-    return new LocalMemoryCacheAdapterProvider(<TFields>() =>
+    return new LocalMemoryCacheAdapterProvider(<TFields extends Record<string, any>>() =>
       GenericLocalMemoryCacher.createNoOpCache<TFields>(),
     );
   }
@@ -28,7 +28,7 @@ export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdap
   static createProviderWithOptions(
     options: { maxSize?: number; ttlSeconds?: number } = {},
   ): IEntityCacheAdapterProvider {
-    return new LocalMemoryCacheAdapterProvider(<TFields>() =>
+    return new LocalMemoryCacheAdapterProvider(<TFields extends Record<string, any>>() =>
       GenericLocalMemoryCacher.createLRUCache<TFields>(options),
     );
   }
@@ -36,7 +36,9 @@ export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdap
   private readonly localMemoryCacheAdapterMap = new Map<string, GenericEntityCacheAdapter<any>>();
 
   private constructor(
-    private readonly localMemoryCacheCreator: <TFields>() => LocalMemoryCache<TFields>,
+    private readonly localMemoryCacheCreator: <
+      TFields extends Record<string, any>,
+    >() => LocalMemoryCache<TFields>,
   ) {}
 
   public getCacheAdapter<TFields extends Record<string, any>>(

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -23,7 +23,7 @@ import { ExampleViewerContext } from '../viewerContexts';
  * Otherwise, it defers to the next rule in the policy.
  */
 export default class AllowIfUserOwnerPrivacyRule<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TEntity extends ReadonlyEntity<TFields, TID, ExampleViewerContext>,
   TSelectedFields extends keyof TFields = keyof TFields,

--- a/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
@@ -12,7 +12,7 @@ import ViewerContext from './ViewerContext';
  * by foreign keys.
  */
 export default class AuthorizationResultBasedEntityAssociationLoader<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -28,7 +28,7 @@ import { mapMap } from './utils/collections/maps';
  * means an authorization error or entity construction error occurred. Other errors are thrown.
  */
 export default class AuthorizationResultBasedEntityLoader<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
@@ -28,7 +28,7 @@ import IEntityMetricsAdapter, { EntityMetricsMutationType } from './metrics/IEnt
 import { mapMapAsync } from './utils/collections/maps';
 
 abstract class AuthorizationResultBasedBaseMutator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -156,7 +156,7 @@ abstract class AuthorizationResultBasedBaseMutator<
  * Mutator for creating a new entity.
  */
 export class AuthorizationResultBasedCreateMutator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -295,7 +295,7 @@ export class AuthorizationResultBasedCreateMutator<
  * Mutator for updating an existing entity.
  */
 export class AuthorizationResultBasedUpdateMutator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -529,7 +529,7 @@ export class AuthorizationResultBasedUpdateMutator<
  * Mutator for deleting an existing entity.
  */
 export class AuthorizationResultBasedDeleteMutator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -6,7 +6,9 @@ import { CacheStatus, CacheLoadResult } from './internal/ReadThroughEntityCache'
 /**
  * A IEntityCacheAdapter that composes other IEntityCacheAdapter instances.
  */
-export default class ComposedEntityCacheAdapter<TFields> implements IEntityCacheAdapter<TFields> {
+export default class ComposedEntityCacheAdapter<TFields extends Record<string, any>>
+  implements IEntityCacheAdapter<TFields>
+{
   /**
    * @param cacheAdapters - list of cache adapters to compose in order of precedence.
    *                        Earlier cache adapters are read from first and written to (including invalidations) last.

--- a/packages/entity/src/EnforcingEntityAssociationLoader.ts
+++ b/packages/entity/src/EnforcingEntityAssociationLoader.ts
@@ -15,7 +15,7 @@ import { enforceResultsAsync } from './entityUtils';
  * by foreign keys.
  */
 export default class EnforcingEntityAssociationLoader<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EnforcingEntityCreator.ts
+++ b/packages/entity/src/EnforcingEntityCreator.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  * through this creator will throw if authorization is not successful.
  */
 export default class EnforcingEntityCreator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EnforcingEntityDeleter.ts
+++ b/packages/entity/src/EnforcingEntityDeleter.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  * through this deleter will throw if authorization is not successful.
  */
 export default class EnforcingEntityDeleter<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -15,7 +15,7 @@ import { mapMap } from './utils/collections/maps';
  * through this loader will throw if the load is not successful.
  */
 export default class EnforcingEntityLoader<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EnforcingEntityUpdater.ts
+++ b/packages/entity/src/EnforcingEntityUpdater.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  * through this updater will throw if authorization is not successful.
  */
 export default class EnforcingEntityUpdater<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -34,7 +34,7 @@ import ViewerContext from './ViewerContext';
  * own EntityCompanionDefinition.
  */
 export default abstract class Entity<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields,
@@ -314,7 +314,7 @@ export default abstract class Entity<
  * An interface to pass in constructor (class) of an Entity as a function argument.
  */
 export interface IEntityClass<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -11,7 +11,7 @@ import ViewerContext from './ViewerContext';
  * by foreign keys.
  */
 export default class EntityAssociationLoader<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -17,7 +17,7 @@ export interface IPrivacyPolicyClass<TPrivacyPolicy> {
  * Composition root responsible for orchestrating setup of Entity mutators and loaders.
  */
 export default class EntityCompanion<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -50,7 +50,7 @@ export interface CacheAdapterFlavorDefinition {
  * used to power the entity framework for a particular type of entity.
  */
 export interface EntityCompanionDefinition<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -167,7 +167,7 @@ export default class EntityCompanionProvider {
    * @param entityClass - entity class to load
    */
   getCompanionForEntity<
-    TFields extends object,
+    TFields extends Record<string, any>,
     TID extends NonNullable<TFields[TSelectedFields]>,
     TViewerContext extends ViewerContext,
     TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityCreator.ts
+++ b/packages/entity/src/EntityCreator.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  * The primary interface for creating entities.
  */
 export default class EntityCreator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TViewerContext2 extends TViewerContext,

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -11,7 +11,7 @@ import {
  * Equality operand that is used for selecting entities with a field with a single value.
  */
 export interface SingleValueFieldEqualityCondition<
-  TFields,
+  TFields extends Record<string, any>,
   N extends keyof TFields = keyof TFields,
 > {
   fieldName: N;
@@ -22,7 +22,7 @@ export interface SingleValueFieldEqualityCondition<
  * Equality operand that is used for selecting entities with a field matching one of multiple values.
  */
 export interface MultiValueFieldEqualityCondition<
-  TFields,
+  TFields extends Record<string, any>,
   N extends keyof TFields = keyof TFields,
 > {
   fieldName: N;
@@ -33,12 +33,13 @@ export interface MultiValueFieldEqualityCondition<
  * A single equality operand for use in a selection clause.
  * See EntityLoader.loadManyByFieldEqualityConjunctionAsync documentation for examples.
  */
-export type FieldEqualityCondition<TFields, N extends keyof TFields = keyof TFields> =
-  | SingleValueFieldEqualityCondition<TFields, N>
-  | MultiValueFieldEqualityCondition<TFields, N>;
+export type FieldEqualityCondition<
+  TFields extends Record<string, any>,
+  N extends keyof TFields = keyof TFields,
+> = SingleValueFieldEqualityCondition<TFields, N> | MultiValueFieldEqualityCondition<TFields, N>;
 
 export function isSingleValueFieldEqualityCondition<
-  TFields,
+  TFields extends Record<string, any>,
   N extends keyof TFields = keyof TFields,
 >(
   condition: FieldEqualityCondition<TFields, N>,
@@ -64,7 +65,7 @@ export enum OrderByOrdering {
 /**
  * SQL modifiers that only affect the selection but not the projection.
  */
-export interface QuerySelectionModifiers<TFields> {
+export interface QuerySelectionModifiers<TFields extends Record<string, any>> {
   /**
    * Order the entities by specified columns and orders.
    */
@@ -84,7 +85,7 @@ export interface QuerySelectionModifiers<TFields> {
   limit?: number;
 }
 
-export interface QuerySelectionModifiersWithOrderByRaw<TFields>
+export interface QuerySelectionModifiersWithOrderByRaw<TFields extends Record<string, any>>
   extends QuerySelectionModifiers<TFields> {
   /**
    * Order the entities by a raw SQL `ORDER BY` clause.

--- a/packages/entity/src/EntityDeleter.ts
+++ b/packages/entity/src/EntityDeleter.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  * The primary interface for deleting entities.
  */
 export default class EntityDeleter<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -12,7 +12,7 @@ import ViewerContext from './ViewerContext';
  * cached, and authorized against the entity's EntityPrivacyPolicy.
  */
 export default class EntityLoader<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TViewerContext2 extends TViewerContext,

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -12,7 +12,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  * The primary entry point for loading entities.
  */
 export default class EntityLoaderFactory<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityLoaderUtils.ts
+++ b/packages/entity/src/EntityLoaderUtils.ts
@@ -17,7 +17,7 @@ import { mapMapAsync } from './utils/collections/maps';
  * Methods are exposed publicly since in rare cases they may need to be called manually.
  */
 export default class EntityLoaderUtils<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -8,7 +8,7 @@ export enum EntityMutationType {
 }
 
 export type EntityValidatorMutationInfo<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -39,7 +39,7 @@ export type EntityCascadingDeletionInfo = {
 };
 
 export type EntityTriggerMutationInfo<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -7,7 +7,7 @@ import ViewerContext from './ViewerContext';
  * Interface to define trigger behavior for entities.
  */
 export default interface EntityMutationTriggerConfiguration<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -68,7 +68,7 @@ export default interface EntityMutationTriggerConfiguration<
  * same transaction as the mutation itself.
  */
 export abstract class EntityMutationTrigger<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -87,7 +87,7 @@ export abstract class EntityMutationTrigger<
  * since they run after the transaction is committed.
  */
 export abstract class EntityNonTransactionalMutationTrigger<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -8,7 +8,7 @@ import ViewerContext from './ViewerContext';
  * same transaction as the mutation itself before creating or updating an entity.
  */
 export default abstract class EntityMutationValidator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -19,7 +19,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  * The primary interface for creating, mutating, and deleting entities.
  */
 export default class EntityMutatorFactory<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -12,7 +12,7 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './rules/PrivacyPolicyRu
  * Information about the reason this privacy policy is being evaluated.
  */
 export type EntityPrivacyPolicyEvaluationContext<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -53,7 +53,7 @@ export enum EntityPrivacyPolicyEvaluationMode {
 }
 
 export type EntityPrivacyPolicyEvaluator<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -104,7 +104,7 @@ export enum EntityAuthorizationAction {
  * ```
  */
 export default abstract class EntityPrivacyPolicy<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -45,7 +45,7 @@ export interface ISecondaryEntityCache<TFields, TLoadParams> {
  */
 export default abstract class EntitySecondaryCacheLoader<
   TLoadParams,
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/EntityUpdater.ts
+++ b/packages/entity/src/EntityUpdater.ts
@@ -10,7 +10,7 @@ import ViewerContext from './ViewerContext';
  * The primary interface for updating entities.
  */
 export default class EntityUpdater<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/GenericEntityCacheAdapter.ts
+++ b/packages/entity/src/GenericEntityCacheAdapter.ts
@@ -8,7 +8,9 @@ import { mapKeys } from './utils/collections/maps';
 /**
  * A standard IEntityCacheAdapter that coordinates caching through an IEntityGenericCacher.
  */
-export default class GenericEntityCacheAdapter<TFields> implements IEntityCacheAdapter<TFields> {
+export default class GenericEntityCacheAdapter<TFields extends Record<string, any>>
+  implements IEntityCacheAdapter<TFields>
+{
   constructor(private readonly genericCacher: IEntityGenericCacher<TFields>) {}
 
   public async loadManyAsync<N extends keyof TFields>(

--- a/packages/entity/src/GenericSecondaryEntityCache.ts
+++ b/packages/entity/src/GenericSecondaryEntityCache.ts
@@ -10,8 +10,10 @@ import { filterMap, zipToMap } from './utils/collections/maps';
  * single entity load. One common way this may be used is to add a second layer of caching in a hot path that makes
  * a call to EntityLoader.loadManyByFieldEqualityConjunctionAsync is guaranteed to return at most one entity.
  */
-export default abstract class GenericSecondaryEntityCache<TFields, TLoadParams>
-  implements ISecondaryEntityCache<TFields, TLoadParams>
+export default abstract class GenericSecondaryEntityCache<
+  TFields extends Record<string, any>,
+  TLoadParams,
+> implements ISecondaryEntityCache<TFields, TLoadParams>
 {
   constructor(
     protected readonly cacher: IEntityGenericCacher<TFields>,

--- a/packages/entity/src/IEntityCacheAdapter.ts
+++ b/packages/entity/src/IEntityCacheAdapter.ts
@@ -4,7 +4,7 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
  * A cache adapter is an interface by which objects can be
  * cached, fetched from cache, and removed from cache (invalidated).
  */
-export default interface IEntityCacheAdapter<TFields> {
+export default interface IEntityCacheAdapter<TFields extends Record<string, any>> {
   /**
    * Load many objects from cache.
    * @param fieldName - object field being queried

--- a/packages/entity/src/IEntityGenericCacher.ts
+++ b/packages/entity/src/IEntityGenericCacher.ts
@@ -4,7 +4,7 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
  * A generic cacher stores and loads key-value pairs. It also supports negative caching - it stores the absence
  * of keys that don't exist in the backing datastore. It is also responsible for cache key creation.
  */
-export default interface IEntityGenericCacher<TFields> {
+export default interface IEntityGenericCacher<TFields extends Record<string, any>> {
   /**
    * Load many keys from the cache. Return info in a format that is useful for read-through caching and
    * negative caching.

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -21,7 +21,7 @@ import ViewerContext from './ViewerContext';
  * - Entities representing immutable tables.
  */
 export default abstract class ReadonlyEntity<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields,

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -12,7 +12,7 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  * from the viewer-scoped entity companion provider.
  */
 export default class ViewerScopedEntityCompanion<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -21,7 +21,7 @@ export default class ViewerScopedEntityCompanionProvider {
    * @param entityClass - entity class to load
    */
   getViewerScopedCompanionForEntity<
-    TFields extends object,
+    TFields extends Record<string, any>,
     TID extends NonNullable<TFields[TSelectedFields]>,
     TViewerContext extends ViewerContext,
     TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -9,7 +9,7 @@ import ViewerContext from './ViewerContext';
  * Provides a cleaner API for loading entities by passing through the ViewerContext.
  */
 export default class ViewerScopedEntityLoaderFactory<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -13,7 +13,7 @@ import ViewerContext from './ViewerContext';
  * Provides a cleaner API for mutating entities by passing through the ViewerContext.
  */
 export default class ViewerScopedEntityMutatorFactory<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -21,7 +21,9 @@ const entityConfiguration = new EntityConfiguration<BlahFields>({
 });
 
 export const DOES_NOT_EXIST_LOCAL_MEMORY_CACHE = Symbol('doesNotExist');
-type LocalMemoryCacheValue<TFields> = Readonly<TFields> | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
+type LocalMemoryCacheValue<TFields extends Record<string, any>> =
+  | Readonly<TFields>
+  | typeof DOES_NOT_EXIST_LOCAL_MEMORY_CACHE;
 
 class TestLocalCacheAdapter<TFields extends Record<string, any>>
   implements IEntityCacheAdapter<TFields>

--- a/packages/entity/src/errors/EntityInvalidFieldValueError.ts
+++ b/packages/entity/src/errors/EntityInvalidFieldValueError.ts
@@ -5,7 +5,7 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 
 export default class EntityInvalidFieldValueError<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/errors/EntityNotAuthorizedError.ts
+++ b/packages/entity/src/errors/EntityNotAuthorizedError.ts
@@ -4,7 +4,7 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 
 export default class EntityNotAuthorizedError<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/errors/EntityNotFoundError.ts
+++ b/packages/entity/src/errors/EntityNotFoundError.ts
@@ -5,7 +5,7 @@ import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 
 export default class EntityNotFoundError<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -10,7 +10,7 @@ export enum CacheStatus {
   NEGATIVE,
 }
 
-export type CacheLoadResult<TFields> =
+export type CacheLoadResult<TFields extends Record<string, any>> =
   | {
       status: CacheStatus.HIT;
       item: Readonly<TFields>;

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import ViewerContext from '../ViewerContext';
  * Privacy policy rule that always allows.
  */
 export default class AlwaysAllowPrivacyPolicyRule<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import ViewerContext from '../ViewerContext';
  * Privacy policy rule that always denies.
  */
 export default class AlwaysDenyPrivacyPolicyRule<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -8,7 +8,7 @@ import ViewerContext from '../ViewerContext';
  * A no-op policy rule that always skips.
  */
 export default class AlwaysSkipPrivacyPolicyRule<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -37,7 +37,7 @@ export enum RuleEvaluationResult {
  *   would be named something like `DenyIfViewerHasBeenBlockedPrivacyPolicyRule`.
  */
 export default abstract class PrivacyPolicyRule<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -43,7 +43,7 @@ export type EntityPrivacyEvaluationResult =
  * @param queryContext - query context in which to perform the check
  */
 export async function canViewerUpdateAsync<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -83,7 +83,7 @@ export async function canViewerUpdateAsync<
  * @param queryContext - query context in which to perform the check
  */
 export async function getCanViewerUpdateResultAsync<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -113,7 +113,7 @@ export async function getCanViewerUpdateResultAsync<
 }
 
 async function canViewerUpdateInternalAsync<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -165,7 +165,7 @@ async function canViewerUpdateInternalAsync<
  * @param queryContext - query context in which to perform the check
  */
 export async function canViewerDeleteAsync<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -205,7 +205,7 @@ export async function canViewerDeleteAsync<
  * @param queryContext - query context in which to perform the check
  */
 export async function getCanViewerDeleteResultAsync<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -235,7 +235,7 @@ export async function getCanViewerDeleteResultAsync<
 }
 
 async function canViewerDeleteInternalAsync<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -296,7 +296,7 @@ type TestEntityThrowOtherErrorFields = {
 };
 
 class DenyUpdateEntityPrivacyPolicy<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -317,7 +317,7 @@ class DenyUpdateEntityPrivacyPolicy<
 }
 
 class DenyDeleteEntityPrivacyPolicy<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -338,7 +338,7 @@ class DenyDeleteEntityPrivacyPolicy<
 }
 
 class ThrowOtherErrorEntityPrivacyPolicy<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -386,7 +386,7 @@ class ThrowOtherErrorEntityPrivacyPolicy<
 }
 
 class DenyReadEntityPrivacyPolicy<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -97,7 +97,7 @@ type TestLeafEntityFields = {
 };
 
 class AlwaysAllowEntityPrivacyPolicy<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/utils/mergeEntityMutationTriggerConfigurations.ts
+++ b/packages/entity/src/utils/mergeEntityMutationTriggerConfigurations.ts
@@ -7,7 +7,7 @@ function nonNullish<TValue>(value: TValue | null | undefined): value is NonNulla
 }
 
 export function mergeEntityMutationTriggerConfigurations<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -5,7 +5,7 @@ import ViewerContext from '../../ViewerContext';
 import PrivacyPolicyRule, { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule';
 
 export interface Case<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -24,7 +24,7 @@ export interface Case<
 }
 
 export type CaseMap<
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -35,7 +35,7 @@ export type CaseMap<
  * Useful for defining test cases that have async preconditions.
  */
 export const describePrivacyPolicyRuleWithAsyncTestCase = <
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
@@ -95,7 +95,7 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
  * For test simple privacy rules that don't have complex async preconditions.
  */
 export const describePrivacyPolicyRule = <
-  TFields extends object,
+  TFields extends Record<string, any>,
   TID extends NonNullable<TFields[TSelectedFields]>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -13,7 +13,9 @@ export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvi
   }
 }
 
-export class NoCacheStubCacheAdapter<TFields> implements IEntityCacheAdapter<TFields> {
+export class NoCacheStubCacheAdapter<TFields extends Record<string, any>>
+  implements IEntityCacheAdapter<TFields>
+{
   public async loadManyAsync<N extends keyof TFields>(
     _fieldName: N,
     fieldValues: readonly NonNullable<TFields[N]>[],


### PR DESCRIPTION
# Why

While adding support for loading by composite fields, I noticed this was inconsistent and was causing tsc issues. This PR makes all TFields generic consistent to extend `Record<string, any>`.

# How

Grep, replace. tsc

# Test Plan

`yarn tsc`
