### PR TITLE
feat: add some utility classes and methods in preparation for composite keys

### DIFF
--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -83,6 +83,8 @@ export * from './rules/PrivacyPolicyRule';
 export * from './utils/EntityPrivacyUtils';
 export * from './utils/mergeEntityMutationTriggerConfigurations';
 export * from './utils/collections/maps';
+export * from './utils/collections/SerializableKeyMap';
+export * from './utils/collections/sets';
 export * from './utils/testing/createUnitTestEntityCompanionProvider';
 export { default as describeFieldTestCase } from './utils/testing/describeFieldTestCase';
 export * from './utils/testing/PrivacyPolicyRuleTestUtils';

--- a/packages/entity/src/utils/collections/SerializableKeyMap.ts
+++ b/packages/entity/src/utils/collections/SerializableKeyMap.ts
@@ -1,0 +1,84 @@
+/**
+ * A serializable object. The serialized value is used to determine equality.
+ */
+export interface ISerializable<TSerialized> {
+  serialize(): TSerialized;
+}
+
+/**
+ * A map with keys that are serializable. Serialized keys are considered equal if their serialized values are equal.
+ * Otherwise, the map behaves like a regular Map.
+ */
+export abstract class SerializableKeyMap<TSerialized, K extends ISerializable<TSerialized>, V>
+  implements ReadonlyMap<K, V>, Map<K, V>
+{
+  protected readonly underlyingMap: Map<TSerialized, V>;
+
+  constructor(iterable?: Iterable<readonly [K, V]> | null) {
+    this.underlyingMap = new Map(
+      Array.from(iterable ?? []).map(([key, value]) => [key.serialize(), value]),
+    );
+  }
+
+  protected abstract deserializeKey(serializedKey: TSerialized): K;
+
+  forEach(
+    callbackfn: (value: V, key: K, map: SerializableKeyMap<TSerialized, K, V>) => void,
+    thisArg?: any,
+  ): void {
+    this.underlyingMap.forEach((value, key) => {
+      callbackfn.call(thisArg, value, this.deserializeKey(key), this);
+    });
+  }
+
+  get(key: K): V | undefined {
+    return this.underlyingMap.get(key.serialize());
+  }
+
+  has(key: K): boolean {
+    return this.underlyingMap.has(key.serialize());
+  }
+
+  clear(): void {
+    this.underlyingMap.clear();
+  }
+
+  delete(key: K): boolean {
+    return this.underlyingMap.delete(key.serialize());
+  }
+
+  set(key: K, value: V): this {
+    this.underlyingMap.set(key.serialize(), value);
+    return this;
+  }
+
+  get size(): number {
+    return this.underlyingMap.size;
+  }
+
+  *entries(): MapIterator<[K, V]> {
+    for (const [key, value] of this.underlyingMap.entries()) {
+      yield [this.deserializeKey(key), value];
+    }
+  }
+
+  *keys(): MapIterator<K> {
+    for (const key of this.underlyingMap.keys()) {
+      yield this.deserializeKey(key);
+    }
+  }
+
+  *values(): MapIterator<V> {
+    for (const value of this.underlyingMap.values()) {
+      yield value;
+    }
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.entries();
+  }
+
+  get [Symbol.toStringTag](): string {
+    return 'SerializableKeyMap';
+  }
+}

--- a/packages/entity/src/utils/collections/__tests__/SerializableKeyMap-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/SerializableKeyMap-test.ts
@@ -1,0 +1,119 @@
+import { ISerializable, SerializableKeyMap } from '../SerializableKeyMap';
+
+describe(SerializableKeyMap, () => {
+  it('behaves as a Map/ReadonlyMap', () => {
+    const map = new TestSerializableKeyMap();
+    expect(map.size).toBe(0);
+    expect(map.has(new TestSerializableKey('key'))).toBe(false);
+    expect(map.get(new TestSerializableKey('key'))).toBe(undefined);
+
+    map.set(new TestSerializableKey('key'), 'value');
+    expect(map.size).toBe(1);
+    expect(map.has(new TestSerializableKey('key'))).toBe(true);
+    expect(map.get(new TestSerializableKey('key'))).toBe('value');
+
+    map.delete(new TestSerializableKey('key'));
+    expect(map.size).toBe(0);
+    expect(map.has(new TestSerializableKey('key'))).toBe(false);
+    expect(map.get(new TestSerializableKey('key'))).toBe(undefined);
+
+    map.set(new TestSerializableKey('key'), 'value');
+    expect(map.size).toBe(1);
+    map.clear();
+    expect(map.size).toBe(0);
+    expect(map.get(new TestSerializableKey('key'))).toBe(undefined);
+
+    map.set(new TestSerializableKey('key'), 'value');
+    map.set(new TestSerializableKey('key'), 'value');
+    expect(map.size).toBe(1);
+
+    map.set(new TestSerializableKey('key2'), 'value2');
+    expect(map.size).toBe(2);
+
+    // check keys ordering based on insertion order
+    const keys = Array.from(map.keys());
+    expect(keys.length).toBe(2);
+    expect(keys[0]!.value).toBe('key');
+    expect(keys[1]!.value).toBe('key2');
+
+    // check values ordering based on insertion order
+    const values = Array.from(map.values());
+    expect(values.length).toBe(2);
+    expect(values[0]).toBe('value');
+    expect(values[1]).toBe('value2');
+
+    // check entries ordering based on insertion order
+    const entries = Array.from(map.entries());
+    expect(entries.length).toBe(2);
+    expect(entries[0]![0].value).toBe('key');
+    expect(entries[0]![1]).toBe('value');
+    expect(entries[1]![0].value).toBe('key2');
+    expect(entries[1]![1]).toBe('value2');
+
+    // check forEach ordering based on insertion order
+    const forEachEntries: [TestSerializableKey, string][] = [];
+    map.forEach((value, key) => {
+      forEachEntries.push([key, value]);
+    });
+    expect(forEachEntries.length).toBe(2);
+    expect(forEachEntries[0]![0].value).toBe('key');
+    expect(forEachEntries[0]![1]).toBe('value');
+    expect(forEachEntries[1]![0].value).toBe('key2');
+    expect(forEachEntries[1]![1]).toBe('value2');
+
+    // check iterator ordering based on insertion order
+    const iteratorEntries = Array.from(map);
+    expect(iteratorEntries.length).toBe(2);
+    expect(iteratorEntries[0]![0].value).toBe('key');
+    expect(iteratorEntries[0]![1]).toBe('value');
+    expect(iteratorEntries[1]![0].value).toBe('key2');
+    expect(iteratorEntries[1]![1]).toBe('value2');
+  });
+
+  it('constructs with values', () => {
+    const map = new TestSerializableKeyMap([
+      [new TestSerializableKey('key'), 'value'],
+      [new TestSerializableKey('key2'), 'value2'],
+    ]);
+    expect(map.size).toBe(2);
+    expect(map.get(new TestSerializableKey('key'))).toBe('value');
+    expect(map.get(new TestSerializableKey('key2'))).toBe('value2');
+
+    const keys = Array.from(map.keys());
+    expect(keys.length).toBe(2);
+    expect(keys[0]!.value).toBe('key');
+    expect(keys[1]!.value).toBe('key2');
+  });
+
+  it('has correct toStringTag', () => {
+    const map = new TestSerializableKeyMap();
+    expect(Object.prototype.toString.call(map)).toBe('[object SerializableKeyMap]');
+  });
+});
+
+declare const TestSerializableKeySerializedBrand: unique symbol;
+export type SerializedTestSerializableKey = string & {
+  readonly [TestSerializableKeySerializedBrand]: true;
+};
+
+class TestSerializableKey implements ISerializable<SerializedTestSerializableKey> {
+  constructor(public readonly value: string) {}
+
+  serialize(): SerializedTestSerializableKey {
+    return JSON.stringify(this.value) as SerializedTestSerializableKey;
+  }
+
+  static deserialize(serialized: SerializedTestSerializableKey): TestSerializableKey {
+    return new TestSerializableKey(JSON.parse(serialized));
+  }
+}
+
+class TestSerializableKeyMap extends SerializableKeyMap<
+  SerializedTestSerializableKey,
+  TestSerializableKey,
+  string
+> {
+  protected deserializeKey(serializedKey: SerializedTestSerializableKey): TestSerializableKey {
+    return TestSerializableKey.deserialize(serializedKey);
+  }
+}

--- a/packages/entity/src/utils/collections/__tests__/sets-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/sets-test.ts
@@ -1,0 +1,17 @@
+import { areSetsEqual } from '../sets';
+
+describe(areSetsEqual, () => {
+  it.each([
+    [new Set([1, 2]), new Set([1, 2])],
+    [new Set([1, 2]), new Set([2, 1])],
+  ])('equal cases: %p', (a, b) => {
+    expect(areSetsEqual(a, b)).toBe(true);
+  });
+
+  it.each([
+    [new Set([1, 2, 3]), new Set([1, 2])],
+    [new Set([1, 2]), new Set([1, 2, 3])],
+  ])('non-equal cases: %p', (a, b) => {
+    expect(areSetsEqual(a, b)).toBe(false);
+  });
+});

--- a/packages/entity/src/utils/collections/maps.ts
+++ b/packages/entity/src/utils/collections/maps.ts
@@ -30,7 +30,7 @@ export const mapMap = <K, V, M>(
   map: ReadonlyMap<K, V>,
   mapper: (value: V, key: K) => M,
 ): Map<K, M> => {
-  const resultingMap = new Map();
+  const resultingMap = new Map<K, M>();
   for (const [k, v] of map) {
     resultingMap.set(k, mapper(v, k));
   }
@@ -47,7 +47,7 @@ export const mapMapAsync = async function <K, V, M>(
   map: ReadonlyMap<K, V>,
   mapper: (value: V, key: K) => Promise<M>,
 ): Promise<Map<K, M>> {
-  const resultingMap: Map<K, M> = new Map();
+  const resultingMap = new Map<K, M>();
   await Promise.all(
     Array.from(map.keys()).map(async (k) => {
       const initialValue = map.get(k) as V;
@@ -71,7 +71,7 @@ export const mapKeys = <K, V, K2>(
   map: ReadonlyMap<K, V>,
   mapper: (key: K, value: V) => K2,
 ): Map<K2, V> => {
-  const resultingMap = new Map();
+  const resultingMap = new Map<K2, V>();
   for (const [k, v] of map) {
     resultingMap.set(mapper(k, v), v);
   }
@@ -94,10 +94,9 @@ export const zipToMap = <K, V>(keys: readonly K[], values: readonly V[]): Map<K,
     keys.length === values.length,
     `zipToMap input length mismatch: keys[${keys.length}], values[${values.length}]`,
   );
-  const resultingMap = new Map();
+  const resultingMap = new Map<K, V>();
   for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    resultingMap.set(key, values[i]);
+    resultingMap.set(keys[i]!, values[i]!);
   }
   return resultingMap;
 };
@@ -108,7 +107,7 @@ export const zipToMap = <K, V>(keys: readonly K[], values: readonly V[]): Map<K,
  * @param map - map to invert
  */
 export const invertMap = <K, V>(map: ReadonlyMap<K, V>): Map<V, K> => {
-  const resultingMap = new Map();
+  const resultingMap = new Map<V, K>();
   for (const [k, v] of map) {
     resultingMap.set(v, k);
   }
@@ -185,7 +184,7 @@ export function filterMap<K, V>(
   map: ReadonlyMap<K, V>,
   predicate: (value: V, key: K) => unknown,
 ): Map<K, V> {
-  const resultingMap = new Map();
+  const resultingMap = new Map<K, V>();
   map.forEach((v, k) => {
     if (predicate(v, k)) {
       resultingMap.set(k, v);

--- a/packages/entity/src/utils/collections/sets.ts
+++ b/packages/entity/src/utils/collections/sets.ts
@@ -1,0 +1,3 @@
+export function areSetsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
+  return a.size === b.size && [...a].every((value) => b.has(value));
+}


### PR DESCRIPTION
# Why

This adds the utility classes needed for composite field loading as described in #201.

# How

This adds a few concepts:
- `areSetsEqual` - simple utility for checking set equality
- `SerializableKeyMap` - a map where keys must be of a custom interface for checking equality.

# Test Plan

Add new tests, run them. Full coverage.