### PR TITLE
feat: convert batched/cached loader interface to holder pattern

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -2,6 +2,8 @@ import {
   CacheAdapterFlavor,
   CacheAdapterFlavorDefinition,
   CacheStatus,
+  SingleFieldHolder,
+  SingleFieldValueHolder,
   ViewerContext,
 } from '@expo/entity';
 import { v4 as uuidv4 } from 'uuid';
@@ -48,9 +50,11 @@ describe(GenericLocalMemoryCacher, () => {
         .entityCompanionDefinition.entityConfiguration.tableName,
     )!['genericCacher'];
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
-      cacheKeyMaker('id', entity1.getID()),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
     ]);
-    const cachedValue = cachedResult.get(cacheKeyMaker('id', entity1.getID()))!;
+    const cachedValue = cachedResult.get(
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
+    )!;
     expect(cachedValue).toMatchObject({
       status: CacheStatus.HIT,
       item: {
@@ -70,9 +74,13 @@ describe(GenericLocalMemoryCacher, () => {
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([
-      cacheKeyMaker('id', nonExistentId),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(nonExistentId)),
     ]);
-    expect(nonExistentCachedResult.get(cacheKeyMaker('id', nonExistentId))).toMatchObject({
+    expect(
+      nonExistentCachedResult.get(
+        cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(nonExistentId)),
+      ),
+    ).toMatchObject({
       status: CacheStatus.NEGATIVE,
     });
 
@@ -88,9 +96,11 @@ describe(GenericLocalMemoryCacher, () => {
       entity1.getAllFields(),
     );
     const cachedResultMiss = await entitySpecificGenericCacher.loadManyAsync([
-      cacheKeyMaker('id', entity1.getID()),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
     ]);
-    const cachedValueMiss = cachedResultMiss.get(cacheKeyMaker('id', entity1.getID()));
+    const cachedValueMiss = cachedResultMiss.get(
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
+    );
     expect(cachedValueMiss).toMatchObject({ status: CacheStatus.MISS });
   });
 
@@ -127,9 +137,11 @@ describe(GenericLocalMemoryCacher, () => {
         .entityCompanionDefinition.entityConfiguration.tableName,
     )!['genericCacher'];
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
-      cacheKeyMaker('id', entity1.getID()),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
     ]);
-    const cachedValue = cachedResult.get(cacheKeyMaker('id', entity1.getID()))!;
+    const cachedValue = cachedResult.get(
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
+    )!;
     expect(cachedValue).toMatchObject({
       status: CacheStatus.MISS,
     });
@@ -144,9 +156,13 @@ describe(GenericLocalMemoryCacher, () => {
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedResult = await entitySpecificGenericCacher.loadManyAsync([
-      cacheKeyMaker('id', nonExistentId),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(nonExistentId)),
     ]);
-    expect(nonExistentCachedResult.get(cacheKeyMaker('id', nonExistentId))).toMatchObject({
+    expect(
+      nonExistentCachedResult.get(
+        cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(nonExistentId)),
+      ),
+    ).toMatchObject({
       status: CacheStatus.MISS,
     });
   });

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -1,5 +1,5 @@
 import { Batcher } from '@expo/batcher';
-import { ViewerContext, zipToMap } from '@expo/entity';
+import { SingleFieldHolder, SingleFieldValueHolder, ViewerContext, zipToMap } from '@expo/entity';
 import invariant from 'invariant';
 import Redis from 'ioredis';
 import nullthrows from 'nullthrows';
@@ -132,7 +132,10 @@ describe(GenericRedisCacher, () => {
     expect(entity1.getID()).toEqual(entity2.getID());
     expect(entity2.getID()).toEqual(nullthrows(entity3).getID());
 
-    const cacheKeyEntity1 = cacheKeyMaker('id', entity1Created.getID());
+    const cacheKeyEntity1 = cacheKeyMaker(
+      new SingleFieldHolder('id'),
+      new SingleFieldValueHolder(entity1Created.getID()),
+    );
     const cachedJSON = await redis.get(cacheKeyEntity1);
     const cachedValue = JSON.parse(cachedJSON!);
     expect(cachedValue).toMatchObject({
@@ -140,7 +143,10 @@ describe(GenericRedisCacher, () => {
       name: 'blah',
     });
 
-    const cacheKeyEntity1NameField = cacheKeyMaker('name', entity1Created.getField('name'));
+    const cacheKeyEntity1NameField = cacheKeyMaker(
+      new SingleFieldHolder('name'),
+      new SingleFieldValueHolder(entity1Created.getField('name')),
+    );
     await RedisTestEntity.loader(viewerContext).loadByFieldEqualingAsync(
       'name',
       entity1Created.getField('name'),
@@ -154,7 +160,10 @@ describe(GenericRedisCacher, () => {
         nonExistentId,
       );
     expect(entityNonExistentResult.ok).toBe(false);
-    const cacheKeyNonExistent = cacheKeyMaker('id', nonExistentId);
+    const cacheKeyNonExistent = cacheKeyMaker(
+      new SingleFieldHolder('id'),
+      new SingleFieldValueHolder(nonExistentId),
+    );
     const nonExistentCachedValue = await redis.get(cacheKeyNonExistent);
     expect(nonExistentCachedValue).toEqual('');
     // load again through entities framework to ensure it reads negative result

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -1,4 +1,4 @@
-import { ViewerContext } from '@expo/entity';
+import { SingleFieldHolder, SingleFieldValueHolder, ViewerContext } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
 import Redis from 'ioredis';
 import { URL } from 'url';
@@ -56,7 +56,7 @@ describe(GenericRedisCacher, () => {
     );
 
     const cachedJSON = await (genericRedisCacheContext.redisClient as Redis).get(
-      cacheKeyMaker('id', entity1.getID()),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
     );
     const cachedValue = JSON.parse(cachedJSON!);
     expect(cachedValue).toMatchObject({
@@ -74,7 +74,7 @@ describe(GenericRedisCacher, () => {
     expect(entityNonExistentResult.ok).toBe(false);
 
     const nonExistentCachedValue = await (genericRedisCacheContext.redisClient as Redis).get(
-      cacheKeyMaker('id', nonExistentId),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(nonExistentId)),
     );
     expect(nonExistentCachedValue).toEqual('');
 
@@ -88,7 +88,7 @@ describe(GenericRedisCacher, () => {
     // invalidate from cache to ensure it invalidates correctly
     await RedisTestEntity.loaderUtils(viewerContext).invalidateFieldsAsync(entity1.getAllFields());
     const cachedValueNull = await (genericRedisCacheContext.redisClient as Redis).get(
-      cacheKeyMaker('id', entity1.getID()),
+      cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
     );
     expect(cachedValueNull).toBe(null);
   });

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -1,4 +1,10 @@
-import { CacheStatus, UUIDField, EntityConfiguration } from '@expo/entity';
+import {
+  CacheStatus,
+  UUIDField,
+  EntityConfiguration,
+  SingleFieldHolder,
+  SingleFieldValueHolder,
+} from '@expo/entity';
 import { Redis, Pipeline } from 'ioredis';
 import { mock, when, instance, anything, verify } from 'ts-mockito';
 
@@ -41,9 +47,18 @@ describe(GenericRedisCacher, () => {
         entityConfiguration,
       );
 
-      const cacheKeyWat = genericCacher['makeCacheKey']('id', 'wat');
-      const cacheKeyWho = genericCacher['makeCacheKey']('id', 'who');
-      const cacheKeyWhy = genericCacher['makeCacheKey']('id', 'why');
+      const cacheKeyWat = genericCacher['makeCacheKey'](
+        new SingleFieldHolder('id'),
+        new SingleFieldValueHolder('wat'),
+      );
+      const cacheKeyWho = genericCacher['makeCacheKey'](
+        new SingleFieldHolder('id'),
+        new SingleFieldValueHolder('who'),
+      );
+      const cacheKeyWhy = genericCacher['makeCacheKey'](
+        new SingleFieldHolder('id'),
+        new SingleFieldValueHolder('why'),
+      );
 
       redisResults.set(cacheKeyWat, JSON.stringify({ id: 'wat' }));
       redisResults.set(cacheKeyWho, '');
@@ -103,7 +118,10 @@ describe(GenericRedisCacher, () => {
         entityConfiguration,
       );
 
-      const cacheKey = genericCacher['makeCacheKey']('id', 'wat');
+      const cacheKey = genericCacher['makeCacheKey'](
+        new SingleFieldHolder('id'),
+        new SingleFieldValueHolder('wat'),
+      );
 
       await genericCacher.cacheManyAsync(new Map([[cacheKey, { id: 'wat' }]]));
 
@@ -142,7 +160,10 @@ describe(GenericRedisCacher, () => {
         entityConfiguration,
       );
 
-      const cacheKey = genericCacher['makeCacheKey']('id', 'wat');
+      const cacheKey = genericCacher['makeCacheKey'](
+        new SingleFieldHolder('id'),
+        new SingleFieldValueHolder('wat'),
+      );
 
       await genericCacher.cacheDBMissesAsync([cacheKey]);
 
@@ -169,7 +190,10 @@ describe(GenericRedisCacher, () => {
         },
         entityConfiguration,
       );
-      const cacheKey = genericCacher['makeCacheKey']('id', 'wat');
+      const cacheKey = genericCacher['makeCacheKey'](
+        new SingleFieldHolder('id'),
+        new SingleFieldValueHolder('wat'),
+      );
 
       await genericCacher.invalidateManyAsync([cacheKey]);
 

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -44,14 +44,16 @@ export default class PostgresEntityDatabaseAdapter<
   protected async fetchManyWhereInternalAsync(
     queryInterface: Knex,
     tableName: string,
-    tableField: string,
-    tableValues: readonly any[],
+    tableColumns: readonly string[],
+    tableValueValues: (readonly any[])[],
   ): Promise<object[]> {
+    const rawPlaceholders = tableColumns.map(() => '??').join(', ');
     return await wrapNativePostgresCallAsync(() =>
+      // queryInterface.select().from(tableName).whereIn(tableFields, tableFieldsValues),
       queryInterface
         .select()
         .from(tableName)
-        .whereRaw('?? = ANY(?)', [tableField, tableValues as any[]]),
+        .whereRaw(`(${rawPlaceholders}) = ANY(?)`, [...tableColumns, tableValueValues]),
     );
   }
 

--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -34,16 +34,19 @@ class InMemoryDatabaseAdapter<T extends Record<string, any>> extends EntityDatab
   protected async fetchManyWhereInternalAsync(
     _queryInterface: any,
     _tableName: string,
-    tableField: string,
-    tableValues: readonly any[],
+    tableColumns: readonly string[],
+    tableValueValues: (readonly any[])[],
   ): Promise<object[]> {
-    return tableValues.reduce((acc, fieldValue) => {
+    const results = tableValueValues.reduce((acc, tableValues) => {
       return acc.concat(
         dbObjects.filter((obj) => {
-          return obj[tableField] === fieldValue;
+          return tableColumns.every((tableColumn, index) => {
+            return obj[tableColumn] === tableValues[index];
+          });
         }),
       );
     }, []);
+    return [...results];
   }
 
   private static compareByOrderBys(

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/invariant": "^2.2.37",
     "@types/jest": "^29.5.12",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^20.14.1",
     "@types/uuid": "^8.3.0",
     "ctix": "^2.7.0",
@@ -44,6 +45,7 @@
     "eslint-config-universe": "^14.0.0",
     "eslint-plugin-tsdoc": "^0.3.0",
     "jest": "^29.7.0",
+    "lodash": "^4.17.21",
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.1.0",
     "ts-jest": "^29.2.5",

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -96,7 +96,7 @@ export default class EntityConfiguration<TFields extends Record<string, any>> {
     }
   }
 
-  private static computeCacheableKeys<TFields>(
+  private static computeCacheableKeys<TFields extends Record<string, any>>(
     schema: ReadonlyMap<keyof TFields, EntityFieldDefinition<any>>,
   ): ReadonlySet<keyof TFields> {
     return reduceMap(

--- a/packages/entity/src/GenericEntityCacheAdapter.ts
+++ b/packages/entity/src/GenericEntityCacheAdapter.ts
@@ -2,6 +2,7 @@ import invariant from 'invariant';
 
 import IEntityCacheAdapter from './IEntityCacheAdapter';
 import IEntityGenericCacher from './IEntityGenericCacher';
+import { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
 import { CacheLoadResult } from './internal/ReadThroughEntityCache';
 import { mapKeys } from './utils/collections/maps';
 
@@ -13,55 +14,61 @@ export default class GenericEntityCacheAdapter<TFields extends Record<string, an
 {
   constructor(private readonly genericCacher: IEntityGenericCacher<TFields>) {}
 
-  public async loadManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
+  public async loadManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    values: readonly TLoadValue[],
+  ): Promise<ReadonlyMap<TLoadValue, CacheLoadResult<TFields>>> {
     const redisCacheKeyToFieldValueMapping = new Map(
-      fieldValues.map((fieldValue) => [
-        this.genericCacher.makeCacheKey(fieldName, fieldValue),
-        fieldValue,
-      ]),
+      values.map((value) => [this.genericCacher.makeCacheKey(key, value), value]),
     );
     const cacheResults = await this.genericCacher.loadManyAsync(
       Array.from(redisCacheKeyToFieldValueMapping.keys()),
     );
 
-    return mapKeys(cacheResults, (redisCacheKey) => {
+    const result = key.vendNewLoadValueMap<CacheLoadResult<TFields>>();
+    for (const [redisCacheKey, cacheResult] of cacheResults) {
       const fieldValue = redisCacheKeyToFieldValueMapping.get(redisCacheKey);
       invariant(
         fieldValue !== undefined,
         'Unspecified cache key %s returned from generic cacher',
         redisCacheKey,
       );
-      return fieldValue;
-    });
+      result.set(fieldValue, cacheResult);
+    }
+    return result;
   }
 
-  public async cacheManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>,
-  ): Promise<void> {
+  public async cacheManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(key: TLoadKey, objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {
     await this.genericCacher.cacheManyAsync(
-      mapKeys(objectMap, (fieldValue) => this.genericCacher.makeCacheKey(fieldName, fieldValue)),
+      mapKeys(objectMap, (value) => this.genericCacher.makeCacheKey(key, value)),
     );
   }
 
-  public async cacheDBMissesAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<void> {
+  public async cacheDBMissesAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
     await this.genericCacher.cacheDBMissesAsync(
-      fieldValues.map((fieldValue) => this.genericCacher.makeCacheKey(fieldName, fieldValue)),
+      values.map((value) => this.genericCacher.makeCacheKey(key, value)),
     );
   }
 
-  public async invalidateManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<void> {
+  public async invalidateManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
     await this.genericCacher.invalidateManyAsync(
-      fieldValues.map((fieldValue) => this.genericCacher.makeCacheKey(fieldName, fieldValue)),
+      values.map((value) => this.genericCacher.makeCacheKey(key, value)),
     );
   }
 }

--- a/packages/entity/src/IEntityCacheAdapter.ts
+++ b/packages/entity/src/IEntityCacheAdapter.ts
@@ -1,3 +1,4 @@
+import { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
 import { CacheLoadResult } from './internal/ReadThroughEntityCache';
 
 /**
@@ -7,43 +8,59 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
 export default interface IEntityCacheAdapter<TFields extends Record<string, any>> {
   /**
    * Load many objects from cache.
-   * @param fieldName - object field being queried
-   * @param fieldValues - fieldName field values being queried
-   * @returns map from all field values to a CacheLoadResult for each input value
+   * @param key - load key to load
+   * @param values - load values to load for the key
+   * @returns map from all load values to a CacheLoadResult for that value
    */
-  loadManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>>;
+  loadManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    values: readonly TLoadValue[],
+  ): Promise<ReadonlyMap<TLoadValue, CacheLoadResult<TFields>>>;
 
   /**
    * Cache many objects fetched from the DB.
-   * @param fieldName - object field being queried
-   * @param objectMap - map from field value to object to cache
+   * @param key - load key to cache
+   * @param objectMap - map from load value to object to cache for the key
    */
-  cacheManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>,
+  cacheManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>,
   ): Promise<void>;
 
   /**
    * Negatively cache objects that could not be found in the cache or DB.
-   * @param fieldName - object field being queried
-   * @param fieldValues - fieldValues for objects reported as CacheStatus.NEGATIVE
-   *                    in the cache and not found in the DB.
+   * @param key - load key to cache misses for
+   * @param values - load values for objects reported as CacheStatus.NEGATIVE
+   *                 in the cache and not found in the DB.
    */
-  cacheDBMissesAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
+  cacheDBMissesAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    values: readonly TLoadValue[],
   ): Promise<void>;
 
   /**
-   * Invalidate the cache for objects cached by (fieldName, fieldValue).
-   * @param fieldName - object field being queried
-   * @param fieldValues - fieldName field values to be invalidated
+   * Invalidate the cache for objects cached by (key, value).
+   * @param key - load key to invalidate
+   * @param values - load values to be invalidated for the key
    */
-  invalidateManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
+  invalidateManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    values: readonly TLoadValue[],
   ): Promise<void>;
 }

--- a/packages/entity/src/IEntityGenericCacher.ts
+++ b/packages/entity/src/IEntityGenericCacher.ts
@@ -1,3 +1,4 @@
+import { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
 import { CacheLoadResult } from './internal/ReadThroughEntityCache';
 
 /**
@@ -36,10 +37,17 @@ export default interface IEntityGenericCacher<TFields extends Record<string, any
   invalidateManyAsync(keys: readonly string[]): Promise<void>;
 
   /**
-   * Create a cache key for a field and value of a object being cached or invalidated.
+   * Create a cache key for a load key and load value of a object being cached or invalidated.
    *
-   * @param fieldName - name of the object field for this cache key
-   * @param fieldValue - value of the obejct field for this cache key
+   * @param key - load key of the cache key
+   * @param value - load value of the cache key
    */
-  makeCacheKey<N extends keyof TFields>(fieldName: N, fieldValue: NonNullable<TFields[N]>): string;
+  makeCacheKey<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    value: TLoadValue,
+  ): string;
 }

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -11,6 +11,7 @@ import { enforceResultsAsync } from '../entityUtils';
 import EntityNotFoundError from '../errors/EntityNotFoundError';
 import EntityDataManager from '../internal/EntityDataManager';
 import ReadThroughEntityCache from '../internal/ReadThroughEntityCache';
+import { SingleFieldValueHolder, SingleFieldValueHolderMap } from '../internal/SingleFieldHolder';
 import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
 import TestEntity, {
   TestFields,
@@ -631,9 +632,22 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const dataManagerMock = mock<EntityDataManager<TestFields>>();
 
     const id1 = uuidv4();
-    when(
-      dataManagerMock.loadManyByFieldEqualingAsync(anything(), anything(), anything()),
-    ).thenResolve(new Map().set(id1, [{ customIdField: id1 }]));
+    when(dataManagerMock.loadManyEqualingAsync(anything(), anything(), anything())).thenResolve(
+      new SingleFieldValueHolderMap<
+        TestFields,
+        'customIdField',
+        readonly Readonly<TestFields>[]
+      >().set(new SingleFieldValueHolder(id1), [
+        {
+          customIdField: id1,
+          testIndexedField: '',
+          stringField: '',
+          intField: 0,
+          dateField: new Date(),
+          nullableField: null,
+        },
+      ]),
+    );
 
     const rejectionError = new Error();
 
@@ -689,9 +703,9 @@ describe(AuthorizationResultBasedEntityLoader, () => {
 
     const error = new Error();
 
-    when(
-      dataManagerMock.loadManyByFieldEqualingAsync(anything(), anything(), anything()),
-    ).thenReject(error);
+    when(dataManagerMock.loadManyEqualingAsync(anything(), anything(), anything())).thenReject(
+      error,
+    );
 
     const dataManagerInstance = instance(dataManagerMock);
 

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -449,7 +449,10 @@ describe(EnforcingEntityLoader, () => {
     );
 
     // ensure known differences still exist for sanity check
-    const knownLoaderOnlyDifferences = ['validateFieldValues'];
+    const knownLoaderOnlyDifferences = [
+      'validateFieldAndValues',
+      'validateFieldAndValuesAndConvertToHolders',
+    ];
     expect(nonEnforcingLoaderProperties).toEqual(
       expect.arrayContaining(knownLoaderOnlyDifferences),
     );

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -13,6 +13,7 @@ import EntityPrivacyPolicy, {
 } from '../EntityPrivacyPolicy';
 import { EntityTransactionalQueryContext, EntityQueryContext } from '../EntityQueryContext';
 import { CacheStatus } from '../internal/ReadThroughEntityCache';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
 import PrivacyPolicyRule, { RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
 import TestViewerContext from '../testfixtures/TestViewerContext';
 import { InMemoryFullCacheStubCacheAdapter } from '../utils/testing/StubCacheAdapter';
@@ -775,32 +776,46 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const childCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
         'entityCompanion'
       ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
-      const childCachedBefore = await childCacheAdapter.loadManyAsync('parent_id', [
-        parent.getID(),
-      ]);
-      expect(childCachedBefore.get(parent.getID())?.status).toEqual(CacheStatus.HIT);
+      const childCachedBefore = await childCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(parent.getID())],
+      );
+      expect(childCachedBefore.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
+        CacheStatus.HIT,
+      );
 
       const grandChildCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(
         GrandChildEntity,
       )['entityCompanion']['tableDataCoordinator'][
         'cacheAdapter'
       ] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
-      const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync('parent_id', [
-        child.getID(),
-      ]);
-      expect(grandChildCachedBefore.get(child.getID())?.status).toEqual(CacheStatus.HIT);
+      const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(child.getID())],
+      );
+      expect(grandChildCachedBefore.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
+        CacheStatus.HIT,
+      );
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
       await ParentEntity.deleter(parent).deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
-      const childCachedAfter = await childCacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
-      expect(childCachedAfter.get(parent.getID())?.status).toEqual(CacheStatus.MISS);
+      const childCachedAfter = await childCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(parent.getID())],
+      );
+      expect(childCachedAfter.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
+        CacheStatus.MISS,
+      );
 
-      const grandChildCachedAfter = await grandChildCacheAdapter.loadManyAsync('parent_id', [
-        child.getID(),
-      ]);
-      expect(grandChildCachedAfter.get(child.getID())?.status).toEqual(CacheStatus.HIT);
+      const grandChildCachedAfter = await grandChildCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(child.getID())],
+      );
+      expect(grandChildCachedAfter.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
+        CacheStatus.HIT,
+      );
 
       await expect(
         ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),
@@ -908,32 +923,46 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       const childCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
         'entityCompanion'
       ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
-      const childCachedBefore = await childCacheAdapter.loadManyAsync('parent_id', [
-        parent.getID(),
-      ]);
-      expect(childCachedBefore.get(parent.getID())?.status).toEqual(CacheStatus.HIT);
+      const childCachedBefore = await childCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(parent.getID())],
+      );
+      expect(childCachedBefore.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
+        CacheStatus.HIT,
+      );
 
       const grandChildCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(
         GrandChildEntity,
       )['entityCompanion']['tableDataCoordinator'][
         'cacheAdapter'
       ] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
-      const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync('parent_id', [
-        child.getID(),
-      ]);
-      expect(grandChildCachedBefore.get(child.getID())?.status).toEqual(CacheStatus.HIT);
+      const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(child.getID())],
+      );
+      expect(grandChildCachedBefore.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
+        CacheStatus.HIT,
+      );
 
       privacyPolicyEvaluationRecords.shouldRecord = true;
       await ParentEntity.deleter(parent).deleteAsync();
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
-      const childCachedAfter = await childCacheAdapter.loadManyAsync('parent_id', [parent.getID()]);
-      expect(childCachedAfter.get(parent.getID())?.status).toEqual(CacheStatus.MISS);
+      const childCachedAfter = await childCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(parent.getID())],
+      );
+      expect(childCachedAfter.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
+        CacheStatus.MISS,
+      );
 
-      const grandChildCachedAfter = await grandChildCacheAdapter.loadManyAsync('parent_id', [
-        child.getID(),
-      ]);
-      expect(grandChildCachedAfter.get(child.getID())?.status).toEqual(CacheStatus.MISS);
+      const grandChildCachedAfter = await grandChildCacheAdapter.loadManyAsync(
+        new SingleFieldHolder('parent_id'),
+        [new SingleFieldValueHolder(child.getID())],
+      );
+      expect(grandChildCachedAfter.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
+        CacheStatus.MISS,
+      );
 
       await expect(
         ParentEntity.loader(viewerContext).loadByIDNullableAsync(parent.getID()),

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -5,6 +5,7 @@ import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition';
 import { UUIDField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
 import { CacheStatus } from '../internal/ReadThroughEntityCache';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
 import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
 import TestViewerContext from '../testfixtures/TestViewerContext';
 import { InMemoryFullCacheStubCacheAdapter } from '../utils/testing/StubCacheAdapter';
@@ -246,29 +247,39 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     )['entityCompanion']['tableDataCoordinator'][
       'cacheAdapter'
     ] as InMemoryFullCacheStubCacheAdapter<CategoryFields>;
-    const subCategoryCachedBefore = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
-      parentCategory.getID(),
-    ]);
-    expect(subCategoryCachedBefore.get(parentCategory.getID())?.status).toEqual(CacheStatus.HIT);
+    const subCategoryCachedBefore = await categoryCacheAdapter.loadManyAsync(
+      new SingleFieldHolder('parent_category_id'),
+      [new SingleFieldValueHolder(parentCategory.getID())],
+    );
+    expect(
+      subCategoryCachedBefore.get(new SingleFieldValueHolder(parentCategory.getID()))?.status,
+    ).toEqual(CacheStatus.HIT);
 
     const subSubCategoryCachedBefore = await categoryCacheAdapter.loadManyAsync(
-      'parent_category_id',
-      [subCategory.getID()],
+      new SingleFieldHolder('parent_category_id'),
+      [new SingleFieldValueHolder(subCategory.getID())],
     );
-    expect(subSubCategoryCachedBefore.get(subCategory.getID())?.status).toEqual(CacheStatus.HIT);
+    expect(
+      subSubCategoryCachedBefore.get(new SingleFieldValueHolder(subCategory.getID()))?.status,
+    ).toEqual(CacheStatus.HIT);
 
     await CategoryEntity.deleter(parentCategory).deleteAsync();
 
-    const subCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
-      parentCategory.getID(),
-    ]);
-    expect(subCategoryCachedAfter.get(parentCategory.getID())?.status).toEqual(CacheStatus.MISS);
+    const subCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync(
+      new SingleFieldHolder('parent_category_id'),
+      [new SingleFieldValueHolder(parentCategory.getID())],
+    );
+    expect(
+      subCategoryCachedAfter.get(new SingleFieldValueHolder(parentCategory.getID()))?.status,
+    ).toEqual(CacheStatus.MISS);
 
     const subSubCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync(
-      'parent_category_id',
-      [subCategory.getID()],
+      new SingleFieldHolder('parent_category_id'),
+      [new SingleFieldValueHolder(subCategory.getID())],
     );
-    expect(subSubCategoryCachedAfter.get(subCategory.getID())?.status).toEqual(CacheStatus.MISS);
+    expect(
+      subSubCategoryCachedAfter.get(new SingleFieldValueHolder(subCategory.getID()))?.status,
+    ).toEqual(CacheStatus.MISS);
 
     await expect(
       CategoryEntity.loader(viewerContext).loadByIDNullableAsync(parentCategory.getID()),
@@ -315,20 +326,34 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     )['entityCompanion']['tableDataCoordinator'][
       'cacheAdapter'
     ] as InMemoryFullCacheStubCacheAdapter<CategoryFields>;
-    const categoriesCachedBefore = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
-      categoryA.getID(),
-      categoryB.getID(),
-    ]);
-    expect(categoriesCachedBefore.get(categoryA.getID())?.status).toEqual(CacheStatus.HIT);
-    expect(categoriesCachedBefore.get(categoryB.getID())?.status).toEqual(CacheStatus.HIT);
+    const categoriesCachedBefore = await categoryCacheAdapter.loadManyAsync(
+      new SingleFieldHolder('parent_category_id'),
+      [
+        new SingleFieldValueHolder(categoryA.getID()),
+        new SingleFieldValueHolder(categoryB.getID()),
+      ],
+    );
+    expect(
+      categoriesCachedBefore.get(new SingleFieldValueHolder(categoryA.getID()))?.status,
+    ).toEqual(CacheStatus.HIT);
+    expect(
+      categoriesCachedBefore.get(new SingleFieldValueHolder(categoryB.getID()))?.status,
+    ).toEqual(CacheStatus.HIT);
 
     await CategoryEntity.deleter(categoryA).deleteAsync();
 
-    const categoriesCachedAfter = await categoryCacheAdapter.loadManyAsync('parent_category_id', [
-      categoryA.getID(),
-      categoryB.getID(),
-    ]);
-    expect(categoriesCachedAfter.get(categoryA.getID())?.status).toEqual(CacheStatus.MISS);
-    expect(categoriesCachedAfter.get(categoryB.getID())?.status).toEqual(CacheStatus.MISS);
+    const categoriesCachedAfter = await categoryCacheAdapter.loadManyAsync(
+      new SingleFieldHolder('parent_category_id'),
+      [
+        new SingleFieldValueHolder(categoryA.getID()),
+        new SingleFieldValueHolder(categoryB.getID()),
+      ],
+    );
+    expect(
+      categoriesCachedAfter.get(new SingleFieldValueHolder(categoryA.getID()))?.status,
+    ).toEqual(CacheStatus.MISS);
+    expect(
+      categoriesCachedAfter.get(new SingleFieldValueHolder(categoryB.getID()))?.status,
+    ).toEqual(CacheStatus.MISS);
   });
 });

--- a/packages/entity/src/entityUtils.ts
+++ b/packages/entity/src/entityUtils.ts
@@ -109,7 +109,10 @@ const isError = <T>(value: T | Error): value is Error => {
   return value instanceof Error;
 };
 
-export const pick = <T extends object, U extends keyof T>(object: T, props: U[]): Pick<T, U> => {
+export const pick = <T extends object, U extends keyof T>(
+  object: T,
+  props: readonly U[],
+): Pick<T, U> => {
   const propsSet = new Set(props);
   return Object.fromEntries(
     Object.entries(object).filter((entry) => propsSet.has(entry[0] as any)),

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -68,9 +68,11 @@ export { default as EntityNotAuthorizedError } from './errors/EntityNotAuthorize
 export { default as EntityNotFoundError } from './errors/EntityNotFoundError';
 export { default as EntityDataManager } from './internal/EntityDataManager';
 export * from './internal/EntityFieldTransformationUtils';
+export * from './internal/EntityLoadInterfaces';
 export { default as EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator';
 export { default as ReadThroughEntityCache } from './internal/ReadThroughEntityCache';
 export * from './internal/ReadThroughEntityCache';
+export * from './internal/SingleFieldHolder';
 export * from './metrics/EntityMetricsUtils';
 export { type default as IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
 export * from './metrics/IEntityMetricsAdapter';

--- a/packages/entity/src/internal/EntityLoadInterfaces.ts
+++ b/packages/entity/src/internal/EntityLoadInterfaces.ts
@@ -1,0 +1,130 @@
+import EntityConfiguration from '../EntityConfiguration';
+import { ISerializable, SerializableKeyMap } from '../utils/collections/SerializableKeyMap';
+
+/**
+ * Load method type identifier of a load key. Used for keying data loaders and identification in metrics.
+ */
+export enum EntityLoadMethodType {
+  /**
+   * Load method type for loading entities by single fieldName and fieldValue(s).
+   */
+  SINGLE = 'single',
+}
+
+/**
+ * Interface responsible for defining how the key and corresponding load values behave in the data manager, cache adapter,
+ * and database adapter during entity field loading.
+ */
+export interface IEntityLoadKey<
+  TFields extends Record<string, any>,
+  TSerializedLoadValue,
+  TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+> {
+  /**
+   * Debug string representation of the load key. Printed in console logs and error messages.
+   */
+  debugString(): string;
+
+  /**
+   * Vends a new empty load value map with a key type corresponding to the load value type of this load key.
+   *
+   * @returns A new empty load value map.
+   */
+  vendNewLoadValueMap<V>(): LoadValueMap<TSerializedLoadValue, TLoadValue, V>;
+
+  /**
+   * Determines if this key is cacheable in cache adapters according to the entity configuration.
+   *
+   * @param entityConfiguration - The entity configuration to check.
+   * @returns Boolean indicating whether this key is cacheable.
+   */
+  isCacheable(entityConfiguration: EntityConfiguration<TFields>): boolean;
+
+  /**
+   * Creates cache key parts for this key and a load value given an entity configuration.
+   * These parts will be included as part of the cache key.
+   *
+   * @param entityConfiguration - The entity configuration used to derive cache key parts.
+   * @param value - The load value for which to create cache key parts for.
+   * @returns An object containing the cache key type and parts.
+   */
+  createCacheKeyPartsForLoadValue(
+    entityConfiguration: EntityConfiguration<TFields>,
+    value: TLoadValue,
+  ): readonly string[];
+
+  /**
+   * Gets the load method type of this key. Used as part of cache keys and data loader keys.
+   */
+  getLoadMethodType(): EntityLoadMethodType;
+
+  /**
+   * Gets the data loader key for this key. For single field keys, this is the field name. For composite keys, this is a
+   * unique identifier for the composite key.
+   */
+  getDataManagerDataLoaderKey(): string;
+
+  /**
+   * Serialize a load value for use in the data manager data loader as the dataloader value key.
+   */
+  serializeLoadValue(value: TLoadValue): TSerializedLoadValue;
+
+  /**
+   * Deserialize a load value for use in the data manager data loader as the dataloader value key.
+   */
+  deserializeLoadValue(value: TSerializedLoadValue): TLoadValue;
+
+  /**
+   * Validate that that the load values adhere to the typescript types at runtime in order to
+   * prevent inadvertently passing invalid values to the data loader, cache adapter, or database adapter.
+   * @param values - The load values to validate.
+   * @param entityClassName - The name of the entity class to which the load values belong (for error message only).
+   */
+  validateRuntimeLoadValuesForDataManagerDataLoader(
+    values: readonly TLoadValue[],
+    entityClassName: string,
+  ): void;
+
+  /**
+   * Get the database columns for this key given an entity configuration.
+   *
+   * @param entityConfiguration - The entity configuration.
+   * @returns An array of database column names.
+   */
+  getDatabaseColumns(entityConfiguration: EntityConfiguration<TFields>): readonly string[];
+
+  /**
+   * Get the database values corresponding to the database columns for this key for a load value.
+   *
+   * @param value - The load value.
+   * @returns An array of database values.
+   */
+  getDatabaseValues(value: TLoadValue): readonly any[];
+
+  /**
+   * Get the load value for an entity fields object from the database.
+   *
+   * @param object - The entity fields object.
+   * @returns The load value for the object or null if the load value would be invalid for the object (for example, if the value is null).
+   */
+  getLoadValueForObject(object: Readonly<TFields>): TLoadValue | null;
+}
+
+/**
+ * Interface for a load value corresponding to a load key.
+ */
+export interface IEntityLoadValue<TSerialized> extends ISerializable<TSerialized> {
+  /**
+   * Debug string representation of the load value. Printed in console logs and error messages.
+   */
+  debugString(): string;
+}
+
+/**
+ * Map from load value interface to value.
+ */
+export abstract class LoadValueMap<
+  TSerialized,
+  TLoadValue extends IEntityLoadValue<TSerialized>,
+  V,
+> extends SerializableKeyMap<TSerialized, TLoadValue, V> {}

--- a/packages/entity/src/internal/SingleFieldHolder.ts
+++ b/packages/entity/src/internal/SingleFieldHolder.ts
@@ -1,0 +1,127 @@
+import invariant from 'invariant';
+
+import EntityConfiguration from '../EntityConfiguration';
+import { getDatabaseFieldForEntityField } from './EntityFieldTransformationUtils';
+import {
+  EntityLoadMethodType,
+  IEntityLoadKey,
+  IEntityLoadValue,
+  LoadValueMap,
+} from './EntityLoadInterfaces';
+
+/**
+ * A load key that represents a single field (fieldName) on an entity.
+ */
+export class SingleFieldHolder<TFields extends Record<string, any>, N extends keyof TFields>
+  implements IEntityLoadKey<TFields, NonNullable<TFields[N]>, SingleFieldValueHolder<TFields, N>>
+{
+  constructor(public readonly fieldName: N) {}
+
+  debugString(): string {
+    return `SingleFieldHolder[${String(this.fieldName)}]`;
+  }
+
+  public isCacheable(entityConfiguration: EntityConfiguration<TFields>): boolean {
+    return entityConfiguration.cacheableKeys.has(this.fieldName);
+  }
+
+  public getDatabaseColumns(entityConfiguration: EntityConfiguration<TFields>): string[] {
+    return [getDatabaseFieldForEntityField(entityConfiguration, this.fieldName)];
+  }
+
+  getDatabaseValues(value: SingleFieldValueHolder<TFields, N>): readonly any[] {
+    return [value.fieldValue];
+  }
+
+  getLoadValueForObject(object: Readonly<TFields>): SingleFieldValueHolder<TFields, N> | null {
+    const value = object[this.fieldName];
+    if (value === null || value === undefined) {
+      return null;
+    }
+    return new SingleFieldValueHolder(value);
+  }
+
+  createCacheKeyPartsForLoadValue(
+    entityConfiguration: EntityConfiguration<TFields>,
+    value: SingleFieldValueHolder<TFields, N>,
+  ): readonly string[] {
+    const columnName = entityConfiguration.entityToDBFieldsKeyMapping.get(this.fieldName);
+    invariant(columnName, `database field mapping missing for ${String(this.fieldName)}`);
+    return [columnName, String(value.fieldValue)];
+  }
+
+  getLoadMethodType(): EntityLoadMethodType {
+    return EntityLoadMethodType.SINGLE;
+  }
+
+  getDataManagerDataLoaderKey(): string {
+    return this.fieldName as string;
+  }
+
+  serializeLoadValue(value: SingleFieldValueHolder<TFields, N>): NonNullable<TFields[N]> {
+    return value.serialize();
+  }
+
+  deserializeLoadValue(value: NonNullable<TFields[N]>): SingleFieldValueHolder<TFields, N> {
+    return SingleFieldValueHolder.deserialize(value);
+  }
+
+  validateRuntimeLoadValuesForDataManagerDataLoader(
+    values: readonly SingleFieldValueHolder<TFields, N>[],
+    entityClassName: string,
+  ): void {
+    const nullOrUndefinedValueIndex = values.findIndex(
+      (value) => value.fieldValue === null || value.fieldValue === undefined,
+    );
+    if (nullOrUndefinedValueIndex >= 0) {
+      throw new Error(
+        `Invalid load: ${entityClassName} (${String(this.fieldName)} = ${
+          values[nullOrUndefinedValueIndex]?.fieldValue
+        })`,
+      );
+    }
+  }
+
+  vendNewLoadValueMap<V>(): LoadValueMap<
+    NonNullable<TFields[N]>,
+    SingleFieldValueHolder<TFields, N>,
+    V
+  > {
+    return new SingleFieldValueHolderMap();
+  }
+}
+
+/**
+ * A load value for a SingleFieldHolder.
+ */
+export class SingleFieldValueHolder<TFields extends Record<string, any>, N extends keyof TFields>
+  implements IEntityLoadValue<NonNullable<TFields[N]>>
+{
+  constructor(public readonly fieldValue: NonNullable<TFields[N]>) {}
+
+  debugString(): string {
+    return `SingleFieldValueHolder[${String(this.fieldValue)}]`;
+  }
+
+  serialize(): NonNullable<TFields[N]> {
+    return this.fieldValue;
+  }
+
+  static deserialize<TFields extends Record<string, any>, N extends keyof TFields>(
+    fieldValue: NonNullable<TFields[N]>,
+  ): SingleFieldValueHolder<TFields, N> {
+    return new SingleFieldValueHolder(fieldValue);
+  }
+}
+
+export class SingleFieldValueHolderMap<
+  TFields extends Record<string, any>,
+  N extends keyof TFields,
+  V,
+> extends LoadValueMap<NonNullable<TFields[N]>, SingleFieldValueHolder<TFields, N>, V> {
+  protected override deserializeKey(
+    serializedKey: NonNullable<TFields[N]>,
+  ): SingleFieldValueHolder<TFields, N> {
+    return SingleFieldValueHolder.deserialize(serializedKey);
+  }
+}

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -25,7 +25,9 @@ import {
 import StubDatabaseAdapter from '../../utils/testing/StubDatabaseAdapter';
 import StubQueryContextProvider from '../../utils/testing/StubQueryContextProvider';
 import EntityDataManager from '../EntityDataManager';
+import { EntityLoadMethodType } from '../EntityLoadInterfaces';
 import ReadThroughEntityCache from '../ReadThroughEntityCache';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../SingleFieldHolder';
 
 const getObjects = (): Map<string, TestFields[]> =>
   new Map([
@@ -83,25 +85,25 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    const entityDatas = await entityDataManager.loadManyByFieldEqualingAsync(
+    const entityDatas = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      'customIdField',
-      ['2'],
+      new SingleFieldHolder('customIdField'),
+      [new SingleFieldValueHolder('2')],
     );
-    expect(entityDatas.get('2')).toHaveLength(1);
+    expect(entityDatas.get(new SingleFieldValueHolder('2'))).toHaveLength(1);
 
     expect(dbSpy).toHaveBeenCalled();
     expect(cacheSpy).toHaveBeenCalled();
     dbSpy.mockClear();
     cacheSpy.mockClear();
 
-    const entityDatas2 = await entityDataManager.loadManyByFieldEqualingAsync(
+    const entityDatas2 = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      'testIndexedField',
-      ['unique2', 'unique3'],
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique2'), new SingleFieldValueHolder('unique3')],
     );
-    expect(entityDatas2.get('unique2')).toHaveLength(1);
-    expect(entityDatas2.get('unique3')).toHaveLength(1);
+    expect(entityDatas2.get(new SingleFieldValueHolder('unique2'))).toHaveLength(1);
+    expect(entityDatas2.get(new SingleFieldValueHolder('unique3'))).toHaveLength(1);
 
     expect(dbSpy).toHaveBeenCalled();
     expect(cacheSpy).toHaveBeenCalled();
@@ -131,25 +133,25 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    const entityDatas = await entityDataManager.loadManyByFieldEqualingAsync(
+    const entityDatas = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      'customIdField',
-      ['1'],
+      new SingleFieldHolder('customIdField'),
+      [new SingleFieldValueHolder('1')],
     );
-    expect(entityDatas.get('1')).toHaveLength(1);
+    expect(entityDatas.get(new SingleFieldValueHolder('1'))).toHaveLength(1);
 
     expect(dbSpy).toHaveBeenCalled();
     expect(cacheSpy).toHaveBeenCalled();
     dbSpy.mockClear();
     cacheSpy.mockClear();
 
-    const entityDatas2 = await entityDataManager.loadManyByFieldEqualingAsync(
+    const entityDatas2 = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      'testIndexedField',
-      ['unique2', 'unique3'],
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique2'), new SingleFieldValueHolder('unique3')],
     );
-    expect(entityDatas2.get('unique2')).toHaveLength(1);
-    expect(entityDatas2.get('unique3')).toHaveLength(1);
+    expect(entityDatas2.get(new SingleFieldValueHolder('unique2'))).toHaveLength(1);
+    expect(entityDatas2.get(new SingleFieldValueHolder('unique3'))).toHaveLength(1);
 
     expect(dbSpy).toHaveBeenCalled();
     expect(cacheSpy).toHaveBeenCalled();
@@ -187,12 +189,16 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique2',
-    ]);
-    await entityDataManager2.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique2',
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique2')],
+    );
+    await entityDataManager2.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique2')],
+    );
 
     expect(dbSpy).toHaveBeenCalledTimes(1);
     expect(cacheSpy).toHaveBeenCalledTimes(2);
@@ -223,12 +229,16 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique2',
-    ]);
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique2',
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique2')],
+    );
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique2')],
+    );
 
     expect(dbSpy).toHaveBeenCalledTimes(1);
     expect(cacheSpy).toHaveBeenCalledTimes(1);
@@ -259,23 +269,23 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    const entityData = await entityDataManager.loadManyByFieldEqualingAsync(
+    const entityData = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      'stringField',
-      ['hello', 'world'],
+      new SingleFieldHolder('stringField'),
+      [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
     );
-    const entityData2 = await entityDataManager.loadManyByFieldEqualingAsync(
+    const entityData2 = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      'stringField',
-      ['hello', 'world'],
+      new SingleFieldHolder('stringField'),
+      [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
     );
 
     expect(dbSpy).toHaveBeenCalledTimes(1);
     expect(cacheSpy).toHaveBeenCalledTimes(1);
 
     expect(entityData).toMatchObject(entityData2);
-    expect(entityData.get('hello')).toHaveLength(2);
-    expect(entityData.get('world')).toHaveLength(1);
+    expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
+    expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
 
     dbSpy.mockReset();
     cacheSpy.mockReset();
@@ -305,13 +315,17 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      objectInQuestion['testIndexedField'],
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+    );
     await entityDataManager.invalidateObjectFieldsAsync(objectInQuestion);
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      objectInQuestion['testIndexedField'],
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+    );
 
     expect(dbSpy).toHaveBeenCalledTimes(2);
     expect(cacheSpy).toHaveBeenCalledTimes(2);
@@ -344,13 +358,17 @@ describe(EntityDataManager, () => {
     const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
     const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
 
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      objectInQuestion['testIndexedField'],
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+    );
     await entityDataManager.invalidateObjectFieldsAsync(objectInQuestion);
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'customIdField', [
-      objectInQuestion['customIdField'],
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('customIdField'),
+      [new SingleFieldValueHolder(objectInQuestion['customIdField'])],
+    );
 
     expect(dbSpy).toHaveBeenCalledTimes(2);
     expect(cacheSpy).toHaveBeenCalledTimes(2);
@@ -382,14 +400,16 @@ describe(EntityDataManager, () => {
 
     const entityDatas = await new StubQueryContextProvider().runInTransactionAsync(
       async (queryContext) => {
-        return await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'customIdField', [
-          '1',
-        ]);
+        return await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('customIdField'),
+          [new SingleFieldValueHolder('1')],
+        );
       },
       {},
     );
 
-    expect(entityDatas.get('1')).toHaveLength(1);
+    expect(entityDatas.get(new SingleFieldValueHolder('1'))).toHaveLength(1);
 
     expect(dbSpy).toHaveBeenCalled();
     expect(cacheSpy).not.toHaveBeenCalled();
@@ -464,7 +484,11 @@ describe(EntityDataManager, () => {
     const queryContext = new StubQueryContextProvider().getQueryContext();
 
     await expect(
-      entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'customIdField', ['2']),
+      entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('customIdField'),
+        [new SingleFieldValueHolder('2')],
+      ),
     ).rejects.toThrow();
   });
 
@@ -492,9 +516,11 @@ describe(EntityDataManager, () => {
 
     // make call to loadManyByFieldEqualingAsync to populate cache and dataloader, ensure metrics are recorded
     // for dataloader, cache, and database
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique1',
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique1')],
+    );
     verify(
       metricsAdapterMock.logDataManagerLoadEvent(
         objectContaining({
@@ -511,6 +537,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.DATALOADER,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -520,6 +547,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.CACHE,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -529,6 +557,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.DATABASE,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -537,9 +566,11 @@ describe(EntityDataManager, () => {
 
     // make second call to loadManyByFieldEqualingAsync, ensure metrics are only recorded for dataloader since
     // entity is in local dataloader
-    await entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique1',
-    ]);
+    await entityDataManager.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique1')],
+    );
     verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).once();
     verify(
       metricsAdapterMock.incrementDataManagerLoadCount(
@@ -547,6 +578,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.DATALOADER,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -563,10 +595,11 @@ describe(EntityDataManager, () => {
       metricsAdapter,
       TestEntity.name,
     );
-    await entityDataManager2.loadManyByFieldEqualingAsync(queryContext, 'testIndexedField', [
-      'unique1',
-      'unique2',
-    ]);
+    await entityDataManager2.loadManyEqualingAsync(
+      queryContext,
+      new SingleFieldHolder('testIndexedField'),
+      [new SingleFieldValueHolder('unique1'), new SingleFieldValueHolder('unique2')],
+    );
     verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).thrice();
     verify(
       metricsAdapterMock.incrementDataManagerLoadCount(
@@ -574,6 +607,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.DATALOADER,
           fieldValueCount: 2,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -583,6 +617,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.CACHE,
           fieldValueCount: 2,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -592,6 +627,7 @@ describe(EntityDataManager, () => {
           type: IncrementLoadCountEventType.DATABASE,
           fieldValueCount: 1,
           entityClassName: TestEntity.name,
+          loadType: EntityLoadMethodType.SINGLE,
         }),
       ),
     ).once();
@@ -663,13 +699,19 @@ describe(EntityDataManager, () => {
     const queryContext = new StubQueryContextProvider().getQueryContext();
 
     await expect(
-      entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'nullableField', [null as any]),
+      entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('nullableField'),
+        [new SingleFieldValueHolder(null as any)],
+      ),
     ).rejects.toThrowError('Invalid load: TestEntity (nullableField = null)');
 
     await expect(
-      entityDataManager.loadManyByFieldEqualingAsync(queryContext, 'nullableField', [
-        undefined as any,
-      ]),
+      entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('nullableField'),
+        [new SingleFieldValueHolder(undefined as any)],
+      ),
     ).rejects.toThrowError('Invalid load: TestEntity (nullableField = undefined)');
   });
 });

--- a/packages/entity/src/internal/__tests__/TSMockitoExtensions-test.ts
+++ b/packages/entity/src/internal/__tests__/TSMockitoExtensions-test.ts
@@ -1,0 +1,68 @@
+import {
+  SingleFieldHolder,
+  SingleFieldValueHolder,
+  SingleFieldValueHolderMap,
+} from '../SingleFieldHolder';
+import {
+  deepEqualEntityAware,
+  DeepEqualEntityAwareMatcher,
+  isEqualWithEntityAware,
+} from './TSMockitoExtensions';
+
+describe(deepEqualEntityAware, () => {
+  it('should return a DeepEqualEntityAwareMatcher', () => {
+    const actual = deepEqualEntityAware('foo');
+    expect(actual).toBeInstanceOf(DeepEqualEntityAwareMatcher);
+    expect(actual.toString()).toBe('deepEqualEntityAware(foo)');
+
+    const actual2 = deepEqualEntityAware(['bar']);
+    expect(actual2.toString()).toBe('deepEqualEntityAware([bar])');
+  });
+});
+
+describe(isEqualWithEntityAware, () => {
+  it('works for basic cases', () => {
+    expect(isEqualWithEntityAware('foo', 'foo')).toBe(true);
+    expect(isEqualWithEntityAware('foo', 'bar')).toBe(false);
+
+    const obj1 = { foo: 'bar' };
+    const obj2 = { foo: 'bar' };
+    expect(isEqualWithEntityAware(obj1, obj2)).toBe(true);
+  });
+
+  it('works for nested matchers', () => {
+    const obj1 = { foo: deepEqualEntityAware('bar') };
+    const obj2 = { foo: 'bar' };
+    expect(isEqualWithEntityAware(obj1, obj2)).toBe(true);
+  });
+
+  it('works for SingleFieldHolder', () => {
+    const singleFieldHolder1 = new SingleFieldHolder('foo');
+    const singleFieldHolder2 = new SingleFieldHolder('foo');
+    const singleFieldHolder3 = new SingleFieldHolder('bar');
+    expect(isEqualWithEntityAware(singleFieldHolder1, singleFieldHolder2)).toBe(true);
+    expect(isEqualWithEntityAware(singleFieldHolder1, singleFieldHolder3)).toBe(false);
+  });
+
+  it('works for SingleFieldValueHolder', () => {
+    const singleFieldValueHolder1 = new SingleFieldValueHolder('foo');
+    const singleFieldValueHolder2 = new SingleFieldValueHolder('foo');
+    const singleFieldValueHolder3 = new SingleFieldValueHolder('bar');
+    expect(isEqualWithEntityAware(singleFieldValueHolder1, singleFieldValueHolder2)).toBe(true);
+    expect(isEqualWithEntityAware(singleFieldValueHolder1, singleFieldValueHolder3)).toBe(false);
+  });
+
+  it('works for SerializableKeyMap', () => {
+    const map1 = new SingleFieldValueHolderMap(
+      new Map([[new SingleFieldValueHolder('foo'), 'bar']]),
+    );
+    const map2 = new SingleFieldValueHolderMap(
+      new Map([[new SingleFieldValueHolder('foo'), 'bar']]),
+    );
+    const map3 = new SingleFieldValueHolderMap(
+      new Map([[new SingleFieldValueHolder('foo2'), 'bar']]),
+    );
+    expect(isEqualWithEntityAware(map1, map2)).toBe(true);
+    expect(isEqualWithEntityAware(map1, map3)).toBe(false);
+  });
+});

--- a/packages/entity/src/internal/__tests__/TSMockitoExtensions.ts
+++ b/packages/entity/src/internal/__tests__/TSMockitoExtensions.ts
@@ -1,0 +1,54 @@
+import isEqualWith from 'lodash/isEqualWith';
+import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
+
+import { SerializableKeyMap } from '../../utils/collections/SerializableKeyMap';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../SingleFieldHolder';
+
+export function isEqualWithEntityAware(expected: any, actual: any): boolean {
+  return isEqualWith(expected, actual, (expected: any, actual: any): boolean | undefined => {
+    if (expected instanceof Matcher) {
+      return expected.match(actual);
+    }
+
+    if (expected instanceof SingleFieldHolder && actual instanceof SingleFieldHolder) {
+      return expected.fieldName === actual.fieldName;
+    }
+
+    if (expected instanceof SingleFieldValueHolder && actual instanceof SingleFieldValueHolder) {
+      return expected.fieldValue === actual.fieldValue;
+    }
+
+    if (expected instanceof SerializableKeyMap && actual instanceof SerializableKeyMap) {
+      for (const [key, value] of expected.entries()) {
+        if (!actual.has(key) || !isEqualWith(value, actual.get(key))) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    return undefined;
+  });
+}
+
+export class DeepEqualEntityAwareMatcher<T> extends Matcher {
+  constructor(private readonly expectedValue: T) {
+    super();
+  }
+
+  public override match(value: any): boolean {
+    return isEqualWithEntityAware(this.expectedValue, value);
+  }
+
+  public override toString(): string {
+    if (this.expectedValue instanceof Array) {
+      return `deepEqualEntityAware([${this.expectedValue}])`;
+    } else {
+      return `deepEqualEntityAware(${this.expectedValue})`;
+    }
+  }
+}
+
+export function deepEqualEntityAware<T>(expectedValue: T): T {
+  return new DeepEqualEntityAwareMatcher(expectedValue) as any;
+}

--- a/packages/entity/src/metrics/EntityMetricsUtils.ts
+++ b/packages/entity/src/metrics/EntityMetricsUtils.ts
@@ -2,6 +2,7 @@ import IEntityMetricsAdapter, {
   EntityMetricsLoadType,
   EntityMetricsMutationType,
 } from './IEntityMetricsAdapter';
+import { IEntityLoadValue } from '../internal/EntityLoadInterfaces';
 import { reduceMap } from '../utils/collections/maps';
 
 export const timeAndLogLoadEventAsync =
@@ -31,8 +32,12 @@ export const timeAndLogLoadMapEventAsync =
     loadType: EntityMetricsLoadType,
     entityClassName: string,
   ) =>
-  async <TFields, N extends keyof TFields>(
-    promise: Promise<ReadonlyMap<NonNullable<TFields[N]>, readonly Readonly<TFields>[]>>,
+  async <
+    TFields extends Record<string, any>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    promise: Promise<ReadonlyMap<TLoadValue, readonly Readonly<TFields>[]>>,
   ) => {
     const startTime = Date.now();
     const result = await promise;

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -2,6 +2,7 @@ import {
   EntityAuthorizationAction,
   EntityPrivacyPolicyEvaluationMode,
 } from '../EntityPrivacyPolicy';
+import { EntityLoadMethodType } from '../internal/EntityLoadInterfaces';
 
 export enum EntityMetricsLoadType {
   LOAD_MANY,
@@ -83,6 +84,11 @@ export interface IncrementLoadCountEvent {
    * Type of this event.
    */
   type: IncrementLoadCountEventType;
+
+  /**
+   * Load method type for this event.
+   */
+  loadType: EntityLoadMethodType;
 
   /**
    * Number of field values being loaded for this call.

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 import EntityConfiguration from '../../EntityConfiguration';
 import IEntityCacheAdapter from '../../IEntityCacheAdapter';
 import IEntityCacheAdapterProvider from '../../IEntityCacheAdapterProvider';
+import { IEntityLoadKey, IEntityLoadValue } from '../../internal/EntityLoadInterfaces';
 import { CacheStatus, CacheLoadResult } from '../../internal/ReadThroughEntityCache';
 
 export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
@@ -16,32 +17,39 @@ export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvi
 export class NoCacheStubCacheAdapter<TFields extends Record<string, any>>
   implements IEntityCacheAdapter<TFields>
 {
-  public async loadManyAsync<N extends keyof TFields>(
-    _fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
-    return fieldValues.reduce((acc: Map<NonNullable<TFields[N]>, CacheLoadResult<TFields>>, v) => {
+  public async loadManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    values: readonly TLoadValue[],
+  ): Promise<ReadonlyMap<TLoadValue, CacheLoadResult<TFields>>> {
+    return values.reduce((acc: Map<TLoadValue, CacheLoadResult<TFields>>, v) => {
       acc.set(v, {
         status: CacheStatus.MISS,
       });
       return acc;
-    }, new Map());
+    }, key.vendNewLoadValueMap<CacheLoadResult<TFields>>());
   }
 
-  public async cacheManyAsync<N extends keyof TFields>(
-    _fieldName: N,
-    _objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>,
-  ): Promise<void> {}
+  public async cacheManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(_key: TLoadKey, _objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {}
 
-  public async cacheDBMissesAsync<N extends keyof TFields>(
-    _fieldName: N,
-    _fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<void> {}
+  public async cacheDBMissesAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(_key: TLoadKey, _values: readonly TLoadValue[]): Promise<void> {}
 
-  async invalidateManyAsync<N extends keyof TFields>(
-    _fieldName: N,
-    _fieldValues: readonly TFields[N][],
-  ): Promise<void> {}
+  public async invalidateManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(_key: TLoadKey, _values: readonly TLoadValue[]): Promise<void> {}
 }
 
 export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
@@ -65,21 +73,25 @@ export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, an
     readonly cache: Map<string, Readonly<TFields>>,
   ) {}
 
-  public async loadManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<ReadonlyMap<NonNullable<TFields[N]>, CacheLoadResult<TFields>>> {
-    const results = new Map<NonNullable<TFields[N]>, CacheLoadResult<TFields>>();
-    fieldValues.forEach((fieldValue) => {
-      const cacheKey = this.createCacheKey(fieldName, fieldValue);
+  public async loadManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    key: TLoadKey,
+    values: readonly TLoadValue[],
+  ): Promise<ReadonlyMap<TLoadValue, CacheLoadResult<TFields>>> {
+    const results = key.vendNewLoadValueMap<CacheLoadResult<TFields>>();
+    values.forEach((value) => {
+      const cacheKey = this.createCacheKey(key, value);
       if (!this.cache.has(cacheKey)) {
-        results.set(fieldValue, {
+        results.set(value, {
           status: CacheStatus.MISS,
         });
       } else {
         const objectForFieldValue = this.cache.get(cacheKey);
         invariant(objectForFieldValue !== undefined, 'should have set value for key');
-        results.set(fieldValue, {
+        results.set(value, {
           status: CacheStatus.HIT,
           item: objectForFieldValue,
         });
@@ -88,37 +100,46 @@ export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, an
     return results;
   }
 
-  public async cacheManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    objectMap: ReadonlyMap<NonNullable<TFields[N]>, Readonly<TFields>>,
-  ): Promise<void> {
-    objectMap.forEach((obj, fieldValue) => {
-      const cacheKey = this.createCacheKey(fieldName, fieldValue);
+  public async cacheManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(key: TLoadKey, objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {
+    objectMap.forEach((obj, value) => {
+      const cacheKey = this.createCacheKey(key, value);
       this.cache.set(cacheKey, obj);
     });
   }
 
-  public async cacheDBMissesAsync<N extends keyof TFields>(
-    _fieldName: N,
-    _fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<void> {}
+  public async cacheDBMissesAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(_key: TLoadKey, _values: readonly TLoadValue[]): Promise<void> {}
 
-  public async invalidateManyAsync<N extends keyof TFields>(
-    fieldName: N,
-    fieldValues: readonly NonNullable<TFields[N]>[],
-  ): Promise<void> {
-    fieldValues.forEach((fieldValue) => {
-      const cacheKey = this.createCacheKey(fieldName, fieldValue);
+  public async invalidateManyAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
+    values.forEach((value) => {
+      const cacheKey = this.createCacheKey(key, value);
       this.cache.delete(cacheKey);
     });
   }
 
-  private createCacheKey<N extends keyof TFields>(fieldName: N, fieldValue: TFields[N]): string {
+  private createCacheKey<
+    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(key: TLoadKey, value: TLoadValue): string {
+    const cacheKeyType = key.getLoadMethodType();
+    const parts = key.createCacheKeyPartsForLoadValue(this.entityConfiguration, value);
     return [
       this.entityConfiguration.tableName,
+      cacheKeyType,
       `v${this.entityConfiguration.cacheKeyVersion}`,
-      fieldName as string,
-      String(fieldValue),
+      ...parts,
     ].join(':');
   }
 }

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -48,20 +48,23 @@ export default class StubDatabaseAdapter<
   protected async fetchManyWhereInternalAsync(
     _queryInterface: any,
     tableName: string,
-    tableField: string,
-    tableValues: readonly any[],
+    tableColumns: readonly string[],
+    tableValueValues: (readonly any[])[],
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
-    return tableValues.reduce(
-      (acc, fieldValue) => {
+    const results = tableValueValues.reduce(
+      (acc, fieldValues) => {
         return acc.concat(
           objectCollection.filter((obj) => {
-            return obj[tableField] === fieldValue;
+            return tableColumns.every((field, index) => {
+              return obj[field] === fieldValues[index];
+            });
           }),
         );
       },
-      [] as { [key: string]: any },
+      [] as { [key: string]: any }[],
     );
+    return [...results];
   }
 
   private static compareByOrderBys(

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -2,6 +2,7 @@ import { instance, mock } from 'ts-mockito';
 
 import { OrderByOrdering } from '../../../EntityDatabaseAdapter';
 import { EntityQueryContext } from '../../../EntityQueryContext';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../../../internal/SingleFieldHolder';
 import {
   DateIDTestFields,
   dateIDTestEntityConfiguration,
@@ -51,10 +52,12 @@ describe(StubDatabaseAdapter, () => {
         ),
       );
 
-      const results = await databaseAdapter.fetchManyWhereAsync(queryContext, 'stringField', [
-        'huh',
-      ]);
-      expect(results.get('huh')).toHaveLength(1);
+      const results = await databaseAdapter.fetchManyWhereAsync(
+        queryContext,
+        new SingleFieldHolder('stringField'),
+        [new SingleFieldValueHolder('huh')],
+      );
+      expect(results.get(new SingleFieldValueHolder('huh'))).toHaveLength(1);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1785,6 +1785,7 @@ __metadata:
     "@expo/results": "npm:^1.0.0"
     "@types/invariant": "npm:^2.2.37"
     "@types/jest": "npm:^29.5.12"
+    "@types/lodash": "npm:^4.17.16"
     "@types/node": "npm:^20.14.1"
     "@types/uuid": "npm:^8.3.0"
     ctix: "npm:^2.7.0"
@@ -1795,6 +1796,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.3.0"
     invariant: "npm:^2.2.4"
     jest: "npm:^29.7.0"
+    lodash: "npm:^4.17.21"
     prettier: "npm:^3.3.3"
     prettier-plugin-organize-imports: "npm:^4.1.0"
     ts-jest: "npm:^29.2.5"
@@ -3526,6 +3528,13 @@ __metadata:
   dependencies:
     "@types/koa": "npm:*"
   checksum: 10c0/e5a924254b0416ec929b148d39505e3084cfedd5043003baaf76db6e3e9a172a3373e0093e4668375c0e59e81dc7686f4abb201160e8614d84ed40c68b9b5c56
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.17.16":
+  version: 4.17.16
+  resolution: "@types/lodash@npm:4.17.16"
+  checksum: 10c0/cf017901b8ab1d7aabc86d5189d9288f4f99f19a75caf020c0e2c77b8d4cead4db0d0b842d009b029339f92399f49f34377dd7c2721053388f251778b4c23534
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Step 2 of #201.

This PR abstracts out (genericizes) the load key and load value interfaces for batched/cached loading in preparation for composite field loading.

# How

Accomplishing this requires a number of things:
1. A set of interfaces for the keys and load values to be used to load entity field objects.
2. A concrete implementation of that interface for the current use case (single fieldName, fieldValue(s)).
3. Data structure changes in the adapters and data manager to handle the new key type not being comparable via `===`. (see base PR for new map data structure for using these objects as keys).
4. Updates to the test matchers to know how to compare the serializable holder objects.

# Test Plan

Update a number of tests and add a few new tests. This has full coverage.
