### PR TITLE
[rfc][breaking] Make ID fields cacheable by default

### DIFF
--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -161,6 +161,7 @@ export interface EntityFieldDefinitionOptions {
 export abstract class EntityFieldDefinition<T> {
   readonly columnName: string;
   readonly cache: boolean;
+  readonly hasExplicitCacheOption: boolean;
   readonly association: EntityAssociationDefinition<any, any, any, any, any, any> | undefined;
   /**
    *
@@ -168,6 +169,7 @@ export abstract class EntityFieldDefinition<T> {
    */
   constructor(options: EntityFieldDefinitionOptions) {
     this.columnName = options.columnName;
+    this.hasExplicitCacheOption = 'cache' in options;
     this.cache = options.cache ?? false;
     this.association = options.association;
   }

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -40,7 +40,38 @@ describe(EntityConfiguration, () => {
     });
 
     it('filters cacheable fields', () => {
-      expect(blahEntityConfiguration.cacheableKeys).toEqual(new Set(['cacheable']));
+      expect(blahEntityConfiguration.cacheableKeys).toEqual(new Set(['id', 'cacheable']));
+    });
+
+    it('makes the ID field cacheable by default', () => {
+      const entityConfiguration = new EntityConfiguration<Blah2T>({
+        idField: 'id',
+        tableName: 'blah',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      });
+      expect(entityConfiguration.cacheableKeys).toEqual(new Set(['id']));
+    });
+
+    it('makes the ID field non-cacheable when the cache option is set to false', () => {
+      const entityConfiguration = new EntityConfiguration<Blah2T>({
+        idField: 'id',
+        tableName: 'blah',
+        schema: {
+          id: new UUIDField({
+            columnName: 'id',
+            cache: false,
+          }),
+        },
+        databaseAdapterFlavor: 'postgres',
+        cacheAdapterFlavor: 'redis',
+      });
+      expect(entityConfiguration.cacheableKeys).toEqual(new Set([]));
     });
 
     describe('cache key version', () => {


### PR DESCRIPTION
# Why

We've seen people repeatedly forget to add `cache: true` to ID fields, and our 10th query ranked by load was a simple "by ID" query that could have been cached. It wasn't causing database problems but would have been better to use Redis.

# How

I opted to make ID fields cacheable by default, with the option to explicitly specify `cache: false` if you want to opt out. This is a breaking change, as all implicitly uncacheable ID fields are now implicitly cacheable.

As an alternative, I considered requiring ID fields to explicitly set the `cache` option, rather than defaulting to true or false. It's easy to implement a runtime check for this.

However, to get static warnings, this requires changing the TypeScript generic type parameter of EntityConfiguration to look like `EntityConfiguration<'id', ExampleFields>`, which was too redundant for my taste. Namely, the `'id'` part is already specified in the EntityConfiguration's `idField`, and we'd be specifying `'id'` for just about every entity.

# Test Plan

Added unit tests that specific check that ID fields are automatically cacheable, and that you can opt out with `cache: false`.
