### PR TITLE
feat: enforce explicit id field cache property

### DIFF
--- a/packages/entity-database-adapter-knex/src/EntityFields.ts
+++ b/packages/entity-database-adapter-knex/src/EntityFields.ts
@@ -3,7 +3,10 @@ import { EntityFieldDefinition } from '@expo/entity';
 /**
  * EntityFieldDefinition for a Postres column with a JS JSON array type.
  */
-export class JSONArrayField extends EntityFieldDefinition<any[]> {
+export class JSONArrayField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  any[],
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: any[]): boolean {
     return Array.isArray(value);
   }
@@ -13,7 +16,9 @@ export class JSONArrayField extends EntityFieldDefinition<any[]> {
  * EntityFieldDefinition for a Postgres column that may be a JS JSON array type.
  * Does not do any validation.
  */
-export class MaybeJSONArrayField extends EntityFieldDefinition<any | any[]> {
+export class MaybeJSONArrayField<
+  TRequireExplicitCache extends boolean,
+> extends EntityFieldDefinition<any | any[], TRequireExplicitCache> {
   protected validateInputValueInternal(_value: any): boolean {
     return true;
   }
@@ -22,7 +27,10 @@ export class MaybeJSONArrayField extends EntityFieldDefinition<any | any[]> {
 /**
  * EntityFieldDefinition for a Postgres BIGINT column.
  */
-export class BigIntField extends EntityFieldDefinition<string> {
+export class BigIntField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  string,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: string): boolean {
     return typeof value === 'string';
   }

--- a/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
@@ -145,6 +145,7 @@ export const ErrorsTestEntityConfiguration = new EntityConfiguration<ErrorsTestE
   schema: {
     id: new IntField({
       columnName: 'id',
+      cache: false,
     }),
     fieldNonNull: new StringField({
       columnName: 'field_non_null',

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -104,6 +104,7 @@ export const invalidTestEntityConfiguration = new EntityConfiguration<
   schema: {
     id: new IntField({
       columnName: 'id',
+      cache: false,
     }),
     name: new StringField({
       columnName: 'name',

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -160,5 +160,5 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
-  compositeFieldDefinitions: [{ compositeField: ['hasACat', 'hasADog'] }],
+  compositeFieldDefinitions: [{ compositeField: ['hasACat', 'hasADog'], cache: false }],
 });

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -40,6 +40,7 @@ export default class NoteEntity extends Entity<NoteFields, 'id', ExampleViewerCo
         schema: {
           id: new UUIDField({
             columnName: 'id',
+            cache: true,
           }),
           userID: new UUIDField({
             columnName: 'user_id',

--- a/packages/entity-ip-address-field/src/EntityFields.ts
+++ b/packages/entity-ip-address-field/src/EntityFields.ts
@@ -1,7 +1,10 @@
 import { EntityFieldDefinition } from '@expo/entity';
 import { Address4, Address6 } from 'ip-address';
 
-export class IPAddressField extends EntityFieldDefinition<string> {
+export class IPAddressField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  string,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: string): boolean {
     return Address4.isValid(value) || Address6.isValid(value);
   }

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -97,6 +97,7 @@ export const localMemoryTestEntityConfiguration = new EntityConfiguration<
   schema: {
     id: new UUIDField({
       columnName: 'id',
+      cache: false,
     }),
     name: new StringField({
       columnName: 'name',

--- a/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
@@ -56,6 +56,7 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
   schema: {
     id: new UUIDField({
       columnName: 'id',
+      cache: false,
     }),
     name: new StringField({
       columnName: 'name',

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -1,4 +1,8 @@
-import { EntityFieldDefinition } from './EntityFieldDefinition';
+import {
+  EntityFieldDefinition,
+  EntityFieldDefinitionOptions,
+  EntityFieldDefinitionOptionsExplicitCache,
+} from './EntityFieldDefinition';
 
 // Use our own regex since the `uuid` package doesn't support validating UUIDv6/7/8 yet
 const UUID_REGEX =
@@ -7,7 +11,10 @@ const UUID_REGEX =
 /**
  * EntityFieldDefinition for a column with a JS string type.
  */
-export class StringField extends EntityFieldDefinition<string> {
+export class StringField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  string,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: string): boolean {
     return typeof value === 'string';
   }
@@ -17,7 +24,9 @@ export class StringField extends EntityFieldDefinition<string> {
  * EntityFieldDefinition for a column with a JS string type.
  * Enforces that the string is a valid UUID.
  */
-export class UUIDField extends StringField {
+export class UUIDField<
+  TRequireExplicitCache extends boolean,
+> extends StringField<TRequireExplicitCache> {
   protected override validateInputValueInternal(value: string): boolean {
     return super.validateInputValueInternal(value) && UUID_REGEX.test(value);
   }
@@ -26,7 +35,10 @@ export class UUIDField extends StringField {
 /**
  * EntityFieldDefinition for a column with a JS Date type.
  */
-export class DateField extends EntityFieldDefinition<Date> {
+export class DateField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  Date,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: Date): boolean {
     return value instanceof Date;
   }
@@ -35,7 +47,10 @@ export class DateField extends EntityFieldDefinition<Date> {
 /**
  * EntityFieldDefinition for a column with a JS boolean type.
  */
-export class BooleanField extends EntityFieldDefinition<boolean> {
+export class BooleanField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  boolean,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: boolean): boolean {
     return typeof value === 'boolean';
   }
@@ -45,7 +60,10 @@ export class BooleanField extends EntityFieldDefinition<boolean> {
  * EntityFieldDefinition for a column with a JS number type.
  * Enforces that the number is an integer.
  */
-export class IntField extends EntityFieldDefinition<number> {
+export class IntField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  number,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: number): boolean {
     return typeof value === 'number' && Number.isInteger(value);
   }
@@ -55,7 +73,10 @@ export class IntField extends EntityFieldDefinition<number> {
  * EntityFieldDefinition for a column with a JS number type.
  * Enforces that the number is a float (which includes integers in JS).
  */
-export class FloatField extends EntityFieldDefinition<number> {
+export class FloatField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  number,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: number): boolean {
     return typeof value === 'number';
   }
@@ -65,7 +86,10 @@ export class FloatField extends EntityFieldDefinition<number> {
  * EntityFieldDefinition for a column with a JS string array type.
  * Enforces that every member of the string array is a string.
  */
-export class StringArrayField extends EntityFieldDefinition<string[]> {
+export class StringArrayField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  string[],
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: string[]): boolean {
     return Array.isArray(value) && value.every((subValue) => typeof subValue === 'string');
   }
@@ -74,7 +98,10 @@ export class StringArrayField extends EntityFieldDefinition<string[]> {
 /**
  * EntityFieldDefinition for a column with a JS JSON object type.
  */
-export class JSONObjectField extends EntityFieldDefinition<object> {
+export class JSONObjectField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  object,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: object): boolean {
     return typeof value === 'object' && !Array.isArray(value);
   }
@@ -83,7 +110,10 @@ export class JSONObjectField extends EntityFieldDefinition<object> {
 /**
  * EntityFieldDefinition for a enum column with a JS string or number type.
  */
-export class EnumField extends EntityFieldDefinition<string | number> {
+export class EnumField<TRequireExplicitCache extends boolean> extends EntityFieldDefinition<
+  string | number,
+  TRequireExplicitCache
+> {
   protected validateInputValueInternal(value: string | number): boolean {
     return typeof value === 'number' || typeof value === 'string';
   }
@@ -92,9 +122,16 @@ export class EnumField extends EntityFieldDefinition<string | number> {
 /**
  * EntityFieldDefinition for a enum column with a strict typescript enum type.
  */
-export class StrictEnumField<T extends object> extends EnumField {
+export class StrictEnumField<
+  T extends object,
+  TRequireExplicitCache extends boolean,
+> extends EnumField<TRequireExplicitCache> {
   private readonly enum: T;
-  constructor(options: ConstructorParameters<typeof EnumField>[0] & { enum: T }) {
+  constructor(
+    options: TRequireExplicitCache extends true
+      ? EntityFieldDefinitionOptionsExplicitCache & { enum: T }
+      : EntityFieldDefinitionOptions & { enum: T },
+  ) {
     super(options);
     this.enum = options.enum;
   }

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -16,6 +16,7 @@ const blahConfiguration = new EntityConfiguration<BlahFields, 'hello'>({
   schema: {
     hello: new StringField({
       columnName: 'hello',
+      cache: false,
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -20,6 +20,7 @@ describe(EntityConfiguration, () => {
       schema: {
         id: new UUIDField({
           columnName: 'id',
+          cache: false,
         }),
         cacheable: new StringField({
           columnName: 'cacheable',
@@ -33,7 +34,7 @@ describe(EntityConfiguration, () => {
       cacheAdapterFlavor: 'redis',
       compositeFieldDefinitions: [
         { compositeField: ['id', 'cacheable'], cache: true },
-        { compositeField: ['id', 'uniqueButNotCacheable'] },
+        { compositeField: ['id', 'uniqueButNotCacheable'], cache: false },
       ],
     });
 
@@ -77,6 +78,7 @@ describe(EntityConfiguration, () => {
             schema: {
               id: new UUIDField({
                 columnName: 'id',
+                cache: false,
               }),
               cacheable: new StringField({
                 columnName: 'cacheable',
@@ -100,6 +102,7 @@ describe(EntityConfiguration, () => {
             schema: {
               id: new UUIDField({
                 columnName: 'id',
+                cache: false,
               }),
               cacheable: new StringField({
                 columnName: 'cacheable',
@@ -124,6 +127,7 @@ describe(EntityConfiguration, () => {
           schema: {
             id: new UUIDField({
               columnName: 'id',
+              cache: false,
             }),
           },
           databaseAdapterFlavor: 'postgres',
@@ -139,6 +143,7 @@ describe(EntityConfiguration, () => {
           schema: {
             id: new UUIDField({
               columnName: 'id',
+              cache: false,
             }),
           },
           databaseAdapterFlavor: 'postgres',
@@ -174,11 +179,12 @@ describe(EntityConfiguration, () => {
               schema: {
                 id: new UUIDField({
                   columnName: 'id',
+                  cache: false,
                 }),
                 [keyName]: new StringField({
                   columnName: 'any',
                 }),
-              },
+              } as any,
               databaseAdapterFlavor: 'postgres',
               cacheAdapterFlavor: 'redis',
             }),

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -15,7 +15,7 @@ import {
 } from '../EntityFields';
 import describeFieldTestCase from '../utils/testing/describeFieldTestCase';
 
-class TestFieldDefinition extends EntityFieldDefinition<string> {
+class TestFieldDefinition extends EntityFieldDefinition<string, false> {
   protected validateInputValueInternal(value: string): boolean {
     return value === 'helloworld';
   }

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -41,6 +41,7 @@ class BlahEntity extends Entity<BlahFields, 'id', ViewerContext> {
         schema: {
           id: new UUIDField({
             columnName: 'id',
+            cache: false,
           }),
         },
         databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -22,6 +22,7 @@ const blahEntityConfiguration = new EntityConfiguration<BlahT, 'id'>({
   schema: {
     id: new UUIDField({
       columnName: 'id',
+      cache: false,
     }),
     cacheable: new StringField({
       columnName: 'cacheable',

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -16,6 +16,7 @@ export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestF
   schema: {
     id: new DateField({
       columnName: 'custom_id',
+      cache: true,
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -18,6 +18,7 @@ export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestF
   schema: {
     id: new UUIDField({
       columnName: 'custom_id',
+      cache: true,
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -23,6 +23,7 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields, 'cust
   schema: {
     customIdField: new UUIDField({
       columnName: 'custom_id',
+      cache: true,
     }),
     testIndexedField: new StringField({
       columnName: 'test_index',

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -17,6 +17,7 @@ export const testEntity2Configuration = new EntityConfiguration<Test2Fields, 'id
   schema: {
     id: new UUIDField({
       columnName: 'id',
+      cache: false,
     }),
     foreignKey: new UUIDField({
       columnName: 'foreign_key',

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -16,6 +16,7 @@ export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFie
   schema: {
     id: new IntField({
       columnName: 'custom_id',
+      cache: false,
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/testfixtures/TestEntityWithMutationTriggers.ts
+++ b/packages/entity/src/testfixtures/TestEntityWithMutationTriggers.ts
@@ -23,6 +23,7 @@ export const testEntityMTConfiguration = new EntityConfiguration<TestMTFields, '
   schema: {
     id: new UUIDField({
       columnName: 'id',
+      cache: false,
     }),
     stringField: new StringField({
       columnName: 'string_field',

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -447,6 +447,7 @@ class LeafDenyUpdateEntity extends Entity<TestLeafDenyUpdateFields, 'id', Viewer
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           // to ensure edge traversal doesn't process other edges
           unused_other_association: new UUIDField({
@@ -502,6 +503,7 @@ class LeafDenyDeleteEntity extends Entity<TestLeafDenyDeleteFields, 'id', Viewer
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           // deletion behavior should fail since this entity can't be deleted
           simple_test_deny_update_cascade_delete_id: new UUIDField({
@@ -545,6 +547,7 @@ class LeafDenyReadEntity extends Entity<TestLeafDenyReadFields, 'id', ViewerCont
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           simple_test_id: new UUIDField({
             columnName: 'simple_test_id',
@@ -585,6 +588,7 @@ class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, 'id', ViewerCo
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
         },
         databaseAdapterFlavor: 'postgres',
@@ -617,6 +621,7 @@ class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, 'id', ViewerCo
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
         },
         databaseAdapterFlavor: 'postgres',
@@ -653,6 +658,7 @@ class SimpleTestThrowOtherErrorEntity extends Entity<
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           simple_test_id: new UUIDField({
             columnName: 'simple_test_id',

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -134,6 +134,7 @@ class TestEntity extends Entity<TestEntityFields, 'id', ViewerContext> {
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
         },
         databaseAdapterFlavor: 'postgres',
@@ -160,6 +161,7 @@ class TestLeafEntity extends Entity<TestLeafEntityFields, 'id', ViewerContext> {
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           test_entity_id: new UUIDField({
             columnName: 'test_entity_id',

--- a/packages/entity/src/utils/testing/describeFieldTestCase.ts
+++ b/packages/entity/src/utils/testing/describeFieldTestCase.ts
@@ -1,7 +1,7 @@
 import { EntityFieldDefinition } from '../../EntityFieldDefinition';
 
 export default function describeFieldTestCase<T>(
-  fieldDefinition: EntityFieldDefinition<T>,
+  fieldDefinition: EntityFieldDefinition<T, any>,
   validValues: T[],
   invalidValues: any[],
 ): void {


### PR DESCRIPTION
# Why

Discussed #273 offline. What we settled on was that the ID field should need to explicitly specify the cache field. This way it's still possible to not cache, especially during development of a new entity at which time having a cache can be frustrating.

# How

The way this is accomplished is by using the newly-genericized id field to conditionally switching the type of field definition needed for the id field in the schema.

# Test Plan

Run all tests. See that the cache field is required by tsc in the existing entities in these packages.
