### PR TITLE
feat: require explicit cache option at runtime for id fields

### DIFF
--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -161,6 +161,7 @@ export interface EntityFieldDefinitionOptions {
 export abstract class EntityFieldDefinition<T> {
   readonly columnName: string;
   readonly cache: boolean;
+  readonly hasExplicitCacheOption: boolean;
   readonly association: EntityAssociationDefinition<any, any, any, any, any, any> | undefined;
   /**
    *
@@ -169,6 +170,7 @@ export abstract class EntityFieldDefinition<T> {
   constructor(options: EntityFieldDefinitionOptions) {
     this.columnName = options.columnName;
     this.cache = options.cache ?? false;
+    this.hasExplicitCacheOption = 'cache' in options;
     this.association = options.association;
   }
 


### PR DESCRIPTION
# Why

This is the runtime equivalent of #276.

# How

Much fewer lines, but throws an error at module import time rather than at compile time.

# Test Plan

Tests aren't passing currently.