### PR TITLE
feat: change entity id field generic to field name and derive type where necessary

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -19,11 +19,13 @@ export type LocalMemoryCache<TFields extends Record<string, any>> = LRUCache<
   LocalMemoryCacheValue<TFields>
 >;
 
-export default class GenericLocalMemoryCacher<TFields extends Record<string, any>>
-  implements IEntityGenericCacher<TFields>
+export default class GenericLocalMemoryCacher<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements IEntityGenericCacher<TFields, TIDField>
 {
   constructor(
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
     private readonly localMemoryCache: LocalMemoryCache<TFields>,
   ) {}
 
@@ -90,7 +92,7 @@ export default class GenericLocalMemoryCacher<TFields extends Record<string, any
   }
 
   public makeCacheKeyForStorage<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue): string {
@@ -111,7 +113,7 @@ export default class GenericLocalMemoryCacher<TFields extends Record<string, any
   }
 
   public makeCacheKeysForInvalidation<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue): readonly string[] {

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -33,7 +33,10 @@ export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdap
     );
   }
 
-  private readonly localMemoryCacheAdapterMap = new Map<string, GenericEntityCacheAdapter<any>>();
+  private readonly localMemoryCacheAdapterMap = new Map<
+    string,
+    GenericEntityCacheAdapter<any, any>
+  >();
 
   private constructor(
     private readonly localMemoryCacheCreator: <
@@ -41,9 +44,9 @@ export default class LocalMemoryCacheAdapterProvider implements IEntityCacheAdap
     >() => LocalMemoryCache<TFields>,
   ) {}
 
-  public getCacheAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): IEntityCacheAdapter<TFields> {
+  public getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): IEntityCacheAdapter<TFields, TIDField> {
     return computeIfAbsent(this.localMemoryCacheAdapterMap, entityConfiguration.tableName, () => {
       const localMemoryCache = this.localMemoryCacheCreator<TFields>();
       return new GenericEntityCacheAdapter(

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -25,9 +25,10 @@ describe(GenericLocalMemoryCacher, () => {
     const viewerContext = new ViewerContext(entityCompanionProvider);
     const genericCacher = viewerContext.entityCompanionProvider.getCompanionForEntity(
       LocalMemoryTestEntity,
-    )['tableDataCoordinator']['cacheAdapter'][
-      'genericCacher'
-    ] as IEntityGenericCacher<LocalMemoryTestEntityFields>;
+    )['tableDataCoordinator']['cacheAdapter']['genericCacher'] as IEntityGenericCacher<
+      LocalMemoryTestEntityFields,
+      'id'
+    >;
 
     const date = new Date();
     const entity1Created = await LocalMemoryTestEntity.creator(viewerContext)
@@ -51,7 +52,7 @@ describe(GenericLocalMemoryCacher, () => {
     ].get(
       viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)
         .entityCompanionDefinition.entityConfiguration.tableName,
-    )!['genericCacher'] as GenericLocalMemoryCacher<LocalMemoryTestEntityFields>;
+    )!['genericCacher'] as IEntityGenericCacher<LocalMemoryTestEntityFields, 'id'>;
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
       genericCacher.makeCacheKeyForStorage(
         new SingleFieldHolder('id'),
@@ -125,9 +126,10 @@ describe(GenericLocalMemoryCacher, () => {
     const viewerContext = new ViewerContext(entityCompanionProvider);
     const genericCacher = viewerContext.entityCompanionProvider.getCompanionForEntity(
       LocalMemoryTestEntity,
-    )['tableDataCoordinator']['cacheAdapter'][
-      'genericCacher'
-    ] as IEntityGenericCacher<LocalMemoryTestEntityFields>;
+    )['tableDataCoordinator']['cacheAdapter']['genericCacher'] as IEntityGenericCacher<
+      LocalMemoryTestEntityFields,
+      'id'
+    >;
     const cacheKeyMaker = genericCacher['makeCacheKeyForStorage'].bind(genericCacher);
 
     const date = new Date();
@@ -152,7 +154,7 @@ describe(GenericLocalMemoryCacher, () => {
     ].get(
       viewerContext.entityCompanionProvider.getCompanionForEntity(LocalMemoryTestEntity)
         .entityCompanionDefinition.entityConfiguration.tableName,
-    )!['genericCacher'];
+    )!['genericCacher'] as IEntityGenericCacher<LocalMemoryTestEntityFields, 'id'>;
     const cachedResult = await entitySpecificGenericCacher.loadManyAsync([
       cacheKeyMaker(new SingleFieldHolder('id'), new SingleFieldValueHolder(entity1.getID())),
     ]);

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
@@ -1,11 +1,11 @@
 import {
   CacheStatus,
-  UUIDField,
   EntityConfiguration,
   GenericEntityCacheAdapter,
   SingleFieldHolder,
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
+  UUIDField,
 } from '@expo/entity';
 
 import GenericLocalMemoryCacher, {
@@ -16,7 +16,7 @@ type BlahFields = {
   id: string;
 };
 
-const entityConfiguration = new EntityConfiguration<BlahFields>({
+const entityConfiguration = new EntityConfiguration<BlahFields, 'id'>({
   idField: 'id',
   tableName: 'blah',
   schema: {
@@ -66,7 +66,10 @@ describe('Use within GenericEntityCacheAdapter', () => {
       const cacheHits = new Map<SingleFieldValueHolder<BlahFields, 'id'>, Readonly<BlahFields>>([
         [new SingleFieldValueHolder('test-id-1'), { id: 'test-id-1' }],
       ]);
-      await cacheAdapter.cacheManyAsync(new SingleFieldHolder<BlahFields, 'id'>('id'), cacheHits);
+      await cacheAdapter.cacheManyAsync(
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
+        cacheHits,
+      );
       await cacheAdapter.cacheDBMissesAsync(new SingleFieldHolder('id'), [
         new SingleFieldValueHolder('test-id-2'),
       ]);
@@ -98,7 +101,7 @@ describe('Use within GenericEntityCacheAdapter', () => {
         ),
       );
       const results = await cacheAdapter.loadManyAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [] as SingleFieldValueHolder<BlahFields, 'id'>[],
       );
       expect(results).toEqual(new SingleFieldValueHolderMap(new Map()));
@@ -183,7 +186,7 @@ describe('Use within GenericEntityCacheAdapter', () => {
         ),
       );
       await cacheAdapter.invalidateManyAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [] as SingleFieldValueHolder<BlahFields, 'id'>[],
       );
     });

--- a/packages/entity-cache-adapter-local-memory/src/testfixtures/LocalMemoryTestEntity.ts
+++ b/packages/entity-cache-adapter-local-memory/src/testfixtures/LocalMemoryTestEntity.ts
@@ -2,12 +2,12 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   DateField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
+  UUIDField,
 } from '@expo/entity';
 
 export type LocalMemoryTestEntityFields = {
@@ -18,12 +18,12 @@ export type LocalMemoryTestEntityFields = {
 
 export default class LocalMemoryTestEntity extends Entity<
   LocalMemoryTestEntityFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     LocalMemoryTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     LocalMemoryTestEntity,
     LocalMemoryTestEntityPrivacyPolicy
@@ -38,14 +38,14 @@ export default class LocalMemoryTestEntity extends Entity<
 
 export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   LocalMemoryTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   LocalMemoryTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
@@ -53,7 +53,7 @@ export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
@@ -61,7 +61,7 @@ export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
@@ -69,30 +69,32 @@ export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
   ];
 }
 
-export const localMemoryTestEntityConfiguration =
-  new EntityConfiguration<LocalMemoryTestEntityFields>({
-    idField: 'id',
-    tableName: 'local_memory_test_entities',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-        cache: true,
-      }),
-      name: new StringField({
-        columnName: 'name',
-        cache: true,
-      }),
-      dateField: new DateField({
-        columnName: 'date_field',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'local-memory',
-  });
+export const localMemoryTestEntityConfiguration = new EntityConfiguration<
+  LocalMemoryTestEntityFields,
+  'id'
+>({
+  idField: 'id',
+  tableName: 'local_memory_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    name: new StringField({
+      columnName: 'name',
+      cache: true,
+    }),
+    dateField: new DateField({
+      columnName: 'date_field',
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'local-memory',
+});

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -82,12 +82,14 @@ export interface GenericRedisCacheContext {
   invalidationStrategy: RedisCacheInvalidationStrategy;
 }
 
-export default class GenericRedisCacher<TFields extends Record<string, any>>
-  implements IEntityGenericCacher<TFields>
+export default class GenericRedisCacher<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements IEntityGenericCacher<TFields, TIDField>
 {
   constructor(
     private readonly context: GenericRedisCacheContext,
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
   ) {}
 
   public async loadManyAsync(
@@ -173,7 +175,7 @@ export default class GenericRedisCacher<TFields extends Record<string, any>>
   }
 
   private makeCacheKeyForCacheKeyVersion<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue, cacheKeyVersion: number): string {
@@ -189,7 +191,7 @@ export default class GenericRedisCacher<TFields extends Record<string, any>>
   }
 
   public makeCacheKeyForStorage<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue): string {
@@ -201,7 +203,7 @@ export default class GenericRedisCacher<TFields extends Record<string, any>>
   }
 
   public makeCacheKeysForInvalidation<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue): readonly string[] {

--- a/packages/entity-cache-adapter-redis/src/RedisCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-redis/src/RedisCacheAdapterProvider.ts
@@ -10,9 +10,9 @@ import GenericRedisCacher, { GenericRedisCacheContext } from './GenericRedisCach
 export default class RedisCacheAdapterProvider implements IEntityCacheAdapterProvider {
   constructor(private readonly context: GenericRedisCacheContext) {}
 
-  getCacheAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): IEntityCacheAdapter<TFields> {
+  getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): IEntityCacheAdapter<TFields, TIDField> {
     return new GenericEntityCacheAdapter(new GenericRedisCacher(this.context, entityConfiguration));
   }
 }

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -107,9 +107,10 @@ describe(GenericRedisCacher, () => {
 
     const genericCacher = viewerContext.entityCompanionProvider.getCompanionForEntity(
       RedisTestEntity,
-    )['tableDataCoordinator']['cacheAdapter'][
-      'genericCacher'
-    ] as IEntityGenericCacher<RedisTestEntityFields>;
+    )['tableDataCoordinator']['cacheAdapter']['genericCacher'] as IEntityGenericCacher<
+      RedisTestEntityFields,
+      'id'
+    >;
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)
       .setField('name', 'blah')

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -53,9 +53,10 @@ describe(GenericRedisCacher, () => {
     );
     const genericCacher = viewerContext.entityCompanionProvider.getCompanionForEntity(
       RedisTestEntity,
-    )['tableDataCoordinator']['cacheAdapter'][
-      'genericCacher'
-    ] as IEntityGenericCacher<RedisTestEntityFields>;
+    )['tableDataCoordinator']['cacheAdapter']['genericCacher'] as IEntityGenericCacher<
+      RedisTestEntityFields,
+      'id'
+    >;
 
     const entity1Created = await RedisTestEntity.creator(viewerContext)
       .setField('name', 'blah')
@@ -85,7 +86,7 @@ describe(GenericRedisCacher, () => {
     );
     const cachedCompositeJSON = await (genericRedisCacheContext.redisClient as Redis).get(
       genericCacher.makeCacheKeyForStorage(
-        new CompositeFieldHolder<RedisTestEntityFields>(['id', 'name']),
+        new CompositeFieldHolder<RedisTestEntityFields, 'id'>(['id', 'name']),
         new CompositeFieldValueHolder({ id: entity2!.getID(), name: 'blah' }),
       ),
     );
@@ -119,7 +120,7 @@ describe(GenericRedisCacher, () => {
       genericRedisCacheContext.redisClient as Redis
     ).get(
       genericCacher.makeCacheKeyForStorage(
-        new CompositeFieldHolder<RedisTestEntityFields>(['id', 'name']),
+        new CompositeFieldHolder<RedisTestEntityFields, 'id'>(['id', 'name']),
         new CompositeFieldValueHolder({ id: nonExistentId, name: 'blah' }),
       ),
     );
@@ -148,7 +149,7 @@ describe(GenericRedisCacher, () => {
     expect(cachedValueNull.every((c) => c === null)).toBe(true);
 
     const cachedValueNullCompositeKeys = genericCacher.makeCacheKeysForInvalidation(
-      new CompositeFieldHolder<RedisTestEntityFields>(['id', 'name']),
+      new CompositeFieldHolder<RedisTestEntityFields, 'id'>(['id', 'name']),
       new CompositeFieldValueHolder({ id: entity1.getID(), name: 'blah' }),
     );
     const cachedValueNullComposite = await (genericRedisCacheContext.redisClient as Redis).mget(

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -1,9 +1,9 @@
 import {
   CacheStatus,
-  UUIDField,
   EntityConfiguration,
   SingleFieldHolder,
   SingleFieldValueHolder,
+  UUIDField,
 } from '@expo/entity';
 import { Redis, Pipeline } from 'ioredis';
 import { mock, when, instance, anything, verify } from 'ts-mockito';
@@ -14,7 +14,7 @@ type BlahFields = {
   id: string;
 };
 
-const entityConfiguration = new EntityConfiguration<BlahFields>({
+const entityConfiguration = new EntityConfiguration<BlahFields, 'id'>({
   idField: 'id',
   tableName: 'blah',
   cacheKeyVersion: 2,

--- a/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-cache-adapter-redis/src/testfixtures/RedisTestEntity.ts
@@ -2,12 +2,12 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   DateField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
+  UUIDField,
 } from '@expo/entity';
 
 export type RedisTestEntityFields = {
@@ -16,10 +16,10 @@ export type RedisTestEntityFields = {
   dateField: Date | null;
 };
 
-export default class RedisTestEntity extends Entity<RedisTestEntityFields, string, ViewerContext> {
+export default class RedisTestEntity extends Entity<RedisTestEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     RedisTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     RedisTestEntity,
     RedisTestEntityPrivacyPolicy
@@ -34,45 +34,25 @@ export default class RedisTestEntity extends Entity<RedisTestEntityFields, strin
 
 export class RedisTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   RedisTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   RedisTestEntity
 > {
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
 }
 
-export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEntityFields>({
+export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEntityFields, 'id'>({
   idField: 'id',
   tableName: 'redis_test_entities',
   schema: {

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -14,7 +14,8 @@ import wrapNativePostgresCallAsync from './errors/wrapNativePostgresCallAsync';
 
 export default class PostgresEntityDatabaseAdapter<
   TFields extends Record<string, any>,
-> extends EntityDatabaseAdapter<TFields> {
+  TIDField extends keyof TFields,
+> extends EntityDatabaseAdapter<TFields, TIDField> {
   protected getFieldTransformerMap(): FieldTransformerMap {
     return new Map<string, FieldTransformer<any>>([
       [

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
@@ -9,9 +9,9 @@ import PostgresEntityDatabaseAdapter from './PostgresEntityDatabaseAdapter';
 export default class PostgresEntityDatabaseAdapterProvider
   implements IEntityDatabaseAdapterProvider
 {
-  getDatabaseAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): EntityDatabaseAdapter<TFields> {
+  getDatabaseAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): EntityDatabaseAdapter<TFields, TIDField> {
     return new PostgresEntityDatabaseAdapter(entityConfiguration);
   }
 }

--- a/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/ErrorsTestEntity.ts
@@ -22,14 +22,10 @@ type ErrorsTestEntityFields = {
 
 const foreignTableName = 'foreign_table';
 
-export default class ErrorsTestEntity extends Entity<
-  ErrorsTestEntityFields,
-  number,
-  ViewerContext
-> {
+export default class ErrorsTestEntity extends Entity<ErrorsTestEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     ErrorsTestEntityFields,
-    number,
+    'id',
     ViewerContext,
     ErrorsTestEntity,
     ErrorsTestEntityPrivacyPolicy
@@ -105,14 +101,14 @@ export default class ErrorsTestEntity extends Entity<
 
 class ErrorsTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   ErrorsTestEntityFields,
-  number,
+  'id',
   ViewerContext,
   ErrorsTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       ErrorsTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       ErrorsTestEntity
     >(),
@@ -120,7 +116,7 @@ class ErrorsTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       ErrorsTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       ErrorsTestEntity
     >(),
@@ -128,7 +124,7 @@ class ErrorsTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       ErrorsTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       ErrorsTestEntity
     >(),
@@ -136,14 +132,14 @@ class ErrorsTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       ErrorsTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       ErrorsTestEntity
     >(),
   ];
 }
 
-export const ErrorsTestEntityConfiguration = new EntityConfiguration<ErrorsTestEntityFields>({
+export const ErrorsTestEntityConfiguration = new EntityConfiguration<ErrorsTestEntityFields, 'id'>({
   idField: 'id',
   tableName: 'postgres_test_entities',
   schema: {

--- a/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/InvalidTestEntity.ts
@@ -17,12 +17,12 @@ type InvalidTestEntityFields = {
 
 export default class InvalidTestEntity extends Entity<
   InvalidTestEntityFields,
-  number,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     InvalidTestEntityFields,
-    number,
+    'id',
     ViewerContext,
     InvalidTestEntity,
     InvalidTestEntityPrivacyPolicy
@@ -57,14 +57,14 @@ export default class InvalidTestEntity extends Entity<
 
 class InvalidTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   InvalidTestEntityFields,
-  number,
+  'id',
   ViewerContext,
   InvalidTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       InvalidTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       InvalidTestEntity
     >(),
@@ -72,7 +72,7 @@ class InvalidTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       InvalidTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       InvalidTestEntity
     >(),
@@ -80,7 +80,7 @@ class InvalidTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       InvalidTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       InvalidTestEntity
     >(),
@@ -88,14 +88,17 @@ class InvalidTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       InvalidTestEntityFields,
-      number,
+      'id',
       ViewerContext,
       InvalidTestEntity
     >(),
   ];
 }
 
-export const invalidTestEntityConfiguration = new EntityConfiguration<InvalidTestEntityFields>({
+export const invalidTestEntityConfiguration = new EntityConfiguration<
+  InvalidTestEntityFields,
+  'id'
+>({
   idField: 'id',
   tableName: 'postgres_test_entities',
   schema: {

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTestEntity.ts
@@ -2,7 +2,6 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   StringField,
   BooleanField,
   StringArrayField,
@@ -11,6 +10,7 @@ import {
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
+  UUIDField,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -33,12 +33,12 @@ type PostgresTestEntityFields = {
 
 export default class PostgresTestEntity extends Entity<
   PostgresTestEntityFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     PostgresTestEntity,
     PostgresTestEntityPrivacyPolicy
@@ -81,14 +81,14 @@ export default class PostgresTestEntity extends Entity<
 
 class PostgresTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   PostgresTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTestEntity
     >(),
@@ -96,7 +96,7 @@ class PostgresTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTestEntity
     >(),
@@ -104,7 +104,7 @@ class PostgresTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTestEntity
     >(),
@@ -112,14 +112,17 @@ class PostgresTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTestEntity
     >(),
   ];
 }
 
-export const postgresTestEntityConfiguration = new EntityConfiguration<PostgresTestEntityFields>({
+export const postgresTestEntityConfiguration = new EntityConfiguration<
+  PostgresTestEntityFields,
+  'id'
+>({
   idField: 'id',
   tableName: 'postgres_test_entities',
   schema: {

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresTriggerTestEntity.ts
@@ -2,7 +2,6 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
@@ -11,6 +10,7 @@ import {
   EntityQueryContext,
   EntityNonTransactionalMutationTrigger,
   EntityTriggerMutationInfo,
+  UUIDField,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -21,12 +21,12 @@ type PostgresTriggerTestEntityFields = {
 
 export default class PostgresTriggerTestEntity extends Entity<
   PostgresTriggerTestEntityFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresTriggerTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     PostgresTriggerTestEntity,
     PostgresTriggerTestEntityPrivacyPolicy
@@ -72,14 +72,14 @@ export default class PostgresTriggerTestEntity extends Entity<
 
 class PostgresTriggerTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   PostgresTriggerTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresTriggerTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTriggerTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTriggerTestEntity
     >(),
@@ -87,7 +87,7 @@ class PostgresTriggerTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTriggerTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTriggerTestEntity
     >(),
@@ -95,7 +95,7 @@ class PostgresTriggerTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTriggerTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTriggerTestEntity
     >(),
@@ -103,7 +103,7 @@ class PostgresTriggerTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresTriggerTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTriggerTestEntity
     >(),
@@ -112,7 +112,7 @@ class PostgresTriggerTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 
 class ThrowConditionallyTrigger extends EntityMutationTrigger<
   PostgresTriggerTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresTriggerTestEntity
 > {
@@ -129,7 +129,7 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
     entity: PostgresTriggerTestEntity,
     _mutationInfo: EntityTriggerMutationInfo<
       PostgresTriggerTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresTriggerTestEntity
     >,
@@ -142,7 +142,7 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
 
 class ThrowConditionallyNonTransactionalTrigger extends EntityNonTransactionalMutationTrigger<
   PostgresTriggerTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresTriggerTestEntity
 > {
@@ -163,19 +163,21 @@ class ThrowConditionallyNonTransactionalTrigger extends EntityNonTransactionalMu
   }
 }
 
-export const postgresTestEntityConfiguration =
-  new EntityConfiguration<PostgresTriggerTestEntityFields>({
-    idField: 'id',
-    tableName: 'postgres_test_entities',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-        cache: true,
-      }),
-      name: new StringField({
-        columnName: 'name',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  });
+export const postgresTestEntityConfiguration = new EntityConfiguration<
+  PostgresTriggerTestEntityFields,
+  'id'
+>({
+  idField: 'id',
+  tableName: 'postgres_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    name: new StringField({
+      columnName: 'name',
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
+});

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresUniqueTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresUniqueTestEntity.ts
@@ -2,11 +2,11 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
+  UUIDField,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -17,12 +17,12 @@ type PostgresUniqueTestEntityFields = {
 
 export default class PostgresUniqueTestEntity extends Entity<
   PostgresUniqueTestEntityFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresUniqueTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     PostgresUniqueTestEntity,
     PostgresUniqueTestEntityPrivacyPolicy
@@ -57,14 +57,14 @@ export default class PostgresUniqueTestEntity extends Entity<
 
 class PostgresUniqueTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   PostgresUniqueTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresUniqueTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresUniqueTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresUniqueTestEntity
     >(),
@@ -72,7 +72,7 @@ class PostgresUniqueTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresUniqueTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresUniqueTestEntity
     >(),
@@ -80,7 +80,7 @@ class PostgresUniqueTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresUniqueTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresUniqueTestEntity
     >(),
@@ -88,26 +88,28 @@ class PostgresUniqueTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresUniqueTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresUniqueTestEntity
     >(),
   ];
 }
 
-export const postgresTestEntityConfiguration =
-  new EntityConfiguration<PostgresUniqueTestEntityFields>({
-    idField: 'id',
-    tableName: 'postgres_test_entities',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-        cache: true,
-      }),
-      name: new StringField({
-        columnName: 'name',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  });
+export const postgresTestEntityConfiguration = new EntityConfiguration<
+  PostgresUniqueTestEntityFields,
+  'id'
+>({
+  idField: 'id',
+  tableName: 'postgres_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    name: new StringField({
+      columnName: 'name',
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
+});

--- a/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/testfixtures/PostgresValidatorTestEntity.ts
@@ -2,7 +2,6 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
@@ -10,6 +9,7 @@ import {
   EntityMutationTrigger,
   EntityQueryContext,
   EntityValidatorMutationInfo,
+  UUIDField,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -20,12 +20,12 @@ type PostgresValidatorTestEntityFields = {
 
 export default class PostgresValidatorTestEntity extends Entity<
   PostgresValidatorTestEntityFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     PostgresValidatorTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     PostgresValidatorTestEntity,
     PostgresValidatorTestEntityPrivacyPolicy
@@ -61,14 +61,14 @@ export default class PostgresValidatorTestEntity extends Entity<
 
 class PostgresValidatorTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   PostgresValidatorTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresValidatorTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresValidatorTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresValidatorTestEntity
     >(),
@@ -76,7 +76,7 @@ class PostgresValidatorTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresValidatorTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresValidatorTestEntity
     >(),
@@ -84,7 +84,7 @@ class PostgresValidatorTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresValidatorTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresValidatorTestEntity
     >(),
@@ -92,7 +92,7 @@ class PostgresValidatorTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       PostgresValidatorTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresValidatorTestEntity
     >(),
@@ -101,7 +101,7 @@ class PostgresValidatorTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 
 class ThrowConditionallyTrigger extends EntityMutationTrigger<
   PostgresValidatorTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   PostgresValidatorTestEntity
 > {
@@ -118,7 +118,7 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
     entity: PostgresValidatorTestEntity,
     _mutationInfo: EntityValidatorMutationInfo<
       PostgresValidatorTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       PostgresValidatorTestEntity
     >,
@@ -129,19 +129,21 @@ class ThrowConditionallyTrigger extends EntityMutationTrigger<
   }
 }
 
-export const postgresTestEntityConfiguration =
-  new EntityConfiguration<PostgresValidatorTestEntityFields>({
-    idField: 'id',
-    tableName: 'postgres_test_entities',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-        cache: true,
-      }),
-      name: new StringField({
-        columnName: 'name',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'redis',
-  });
+export const postgresTestEntityConfiguration = new EntityConfiguration<
+  PostgresValidatorTestEntityFields,
+  'id'
+>({
+  idField: 'id',
+  tableName: 'postgres_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+      cache: true,
+    }),
+    name: new StringField({
+      columnName: 'name',
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
+});

--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -15,9 +15,9 @@ import { v4 as uuidv4 } from 'uuid';
 const dbObjects: Readonly<{ [key: string]: any }>[] = [];
 
 export class InMemoryDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
-  getDatabaseAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): EntityDatabaseAdapter<TFields> {
+  getDatabaseAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): EntityDatabaseAdapter<TFields, TIDField> {
     return new InMemoryDatabaseAdapter(entityConfiguration);
   }
 }
@@ -26,7 +26,10 @@ export class InMemoryDatabaseAdapterProvider implements IEntityDatabaseAdapterPr
  * In-memory database adapter for entity for the purposes of this example. Normally `@expo/entity-database-adapter-knex`
  * or another production adapter would be used. Very similar to StubDatabaseAdapter but shared in a way more akin to a normal database.
  */
-class InMemoryDatabaseAdapter<T extends Record<string, any>> extends EntityDatabaseAdapter<T> {
+class InMemoryDatabaseAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> extends EntityDatabaseAdapter<TFields, TIDField> {
   protected getFieldTransformerMap(): FieldTransformerMap {
     return new Map();
   }
@@ -131,7 +134,7 @@ class InMemoryDatabaseAdapter<T extends Record<string, any>> extends EntityDatab
     _tableName: string,
     object: object,
   ): Promise<object[]> {
-    const configurationPrivate = this['entityConfiguration'] as EntityConfiguration<T>;
+    const configurationPrivate = this['entityConfiguration'];
     const idField = getDatabaseFieldForEntityField(
       configurationPrivate,
       configurationPrivate.idField,

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -24,10 +24,10 @@ import { ExampleViewerContext } from '../viewerContexts';
  */
 export default class AllowIfUserOwnerPrivacyRule<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
-  TEntity extends ReadonlyEntity<TFields, TID, ExampleViewerContext>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, ExampleViewerContext>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends PrivacyPolicyRule<TFields, TID, ExampleViewerContext, TEntity> {
+> extends PrivacyPolicyRule<TFields, TIDField, ExampleViewerContext, TEntity> {
   constructor(private readonly entityOwnerField: keyof TFields) {
     super();
   }
@@ -37,7 +37,7 @@ export default class AllowIfUserOwnerPrivacyRule<
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       ExampleViewerContext,
       TEntity,
       TSelectedFields

--- a/packages/entity-example/src/entities/NoteEntity.ts
+++ b/packages/entity-example/src/entities/NoteEntity.ts
@@ -2,8 +2,8 @@ import {
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
-  UUIDField,
   StringField,
+  UUIDField,
 } from '@expo/entity';
 
 import NotePrivacyPolicy from './NotePrivacyPolicy';
@@ -19,7 +19,7 @@ export interface NoteFields {
 /**
  * A simple entity representing a "notes" table/collection. Each note has an owner, title, and body.
  */
-export default class NoteEntity extends Entity<NoteFields, string, ExampleViewerContext> {
+export default class NoteEntity extends Entity<NoteFields, 'id', ExampleViewerContext> {
   /**
    * The companion provides configuration instructions to the Entity framework for this type
    * of entity. In some languages, this would be representable as "abstract" static members
@@ -27,14 +27,14 @@ export default class NoteEntity extends Entity<NoteFields, string, ExampleViewer
    */
   static defineCompanionDefinition(): EntityCompanionDefinition<
     NoteFields,
-    string,
+    'id',
     ExampleViewerContext,
     NoteEntity,
     NotePrivacyPolicy
   > {
     return {
       entityClass: NoteEntity,
-      entityConfiguration: new EntityConfiguration<NoteFields>({
+      entityConfiguration: new EntityConfiguration<NoteFields, 'id'>({
         idField: 'id',
         tableName: 'notes',
         schema: {

--- a/packages/entity-example/src/entities/NotePrivacyPolicy.ts
+++ b/packages/entity-example/src/entities/NotePrivacyPolicy.ts
@@ -9,20 +9,20 @@ import { ExampleViewerContext } from '../viewerContexts';
  */
 export default class NotePrivacyPolicy extends EntityPrivacyPolicy<
   NoteFields,
-  string,
+  'id',
   ExampleViewerContext,
   NoteEntity
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<NoteFields, string, ExampleViewerContext, NoteEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<NoteFields, 'id', ExampleViewerContext, NoteEntity>(),
   ];
   protected override readonly createRules = [
-    new AllowIfUserOwnerPrivacyRule<NoteFields, string, NoteEntity>('userID'),
+    new AllowIfUserOwnerPrivacyRule<NoteFields, 'id', NoteEntity>('userID'),
   ];
   protected override readonly updateRules = [
-    new AllowIfUserOwnerPrivacyRule<NoteFields, string, NoteEntity>('userID'),
+    new AllowIfUserOwnerPrivacyRule<NoteFields, 'id', NoteEntity>('userID'),
   ];
   protected override readonly deleteRules = [
-    new AllowIfUserOwnerPrivacyRule<NoteFields, string, NoteEntity>('userID'),
+    new AllowIfUserOwnerPrivacyRule<NoteFields, 'id', NoteEntity>('userID'),
   ];
 }

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -5,8 +5,8 @@ import {
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
-  UUIDField,
   StringField,
+  UUIDField,
 } from '@expo/entity';
 import {
   GenericRedisCacheContext,
@@ -27,28 +27,28 @@ interface TestFields {
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   TestFields,
-  string,
+  'id',
   ViewerContext,
   TestEntity
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
 }
 
-class TestEntity extends Entity<TestFields, string, ViewerContext> {
+class TestEntity extends Entity<TestFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy
@@ -61,7 +61,7 @@ class TestEntity extends Entity<TestFields, string, ViewerContext> {
   }
 }
 
-const testEntityConfiguration = new EntityConfiguration<TestFields>({
+const testEntityConfiguration = new EntityConfiguration<TestFields, 'id'>({
   idField: 'id',
   tableName: 'testentities',
   schema: {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -5,8 +5,8 @@ import {
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
-  UUIDField,
   StringField,
+  UUIDField,
 } from '@expo/entity';
 import {
   GenericRedisCacheContext,
@@ -28,28 +28,28 @@ function createTestEntityDefinitonWithCacheKeyVersion(cacheKeyVersion: number) {
 
   class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     TestEntity
   > {
     protected override readonly readRules = [
-      new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+      new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
     ];
     protected override readonly createRules = [
-      new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+      new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
     ];
     protected override readonly updateRules = [
-      new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+      new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
     ];
     protected override readonly deleteRules = [
-      new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+      new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
     ];
   }
 
-  class TestEntity extends Entity<TestFields, string, ViewerContext> {
+  class TestEntity extends Entity<TestFields, 'id', ViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       TestFields,
-      string,
+      'id',
       ViewerContext,
       TestEntity,
       TestEntityPrivacyPolicy
@@ -62,7 +62,7 @@ function createTestEntityDefinitonWithCacheKeyVersion(cacheKeyVersion: number) {
     }
   }
 
-  const testEntityConfiguration = new EntityConfiguration<TestFields>({
+  const testEntityConfiguration = new EntityConfiguration<TestFields, 'id'>({
     idField: 'id',
     tableName: 'testentities',
     cacheKeyVersion,

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -25,28 +25,28 @@ interface TestFields {
 
 class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   TestFields,
-  string,
+  'id',
   ViewerContext,
   TestEntity
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'id', ViewerContext, TestEntity>(),
   ];
 }
 
-class TestEntity extends Entity<TestFields, string, ViewerContext> {
+class TestEntity extends Entity<TestFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy
@@ -59,7 +59,7 @@ class TestEntity extends Entity<TestFields, string, ViewerContext> {
   }
 }
 
-const testEntityConfiguration = new EntityConfiguration<TestFields>({
+const testEntityConfiguration = new EntityConfiguration<TestFields, 'id'>({
   idField: 'id',
   tableName: 'testentities',
   schema: {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -30,18 +30,18 @@ interface OtherFields {
   parent_category_id: string;
 }
 
-class PrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any> {
+class PrivacyPolicy extends EntityPrivacyPolicy<any, 'id', ViewerContext, any> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any>(),
   ];
 }
 
@@ -50,10 +50,10 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
   const categoriesTableName = uuidv4();
   const othersTableName = uuidv4();
 
-  class CategoryEntity extends Entity<CategoryFields, string, ViewerContext> {
+  class CategoryEntity extends Entity<CategoryFields, 'id', ViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       CategoryFields,
-      string,
+      'id',
       ViewerContext,
       CategoryEntity,
       PrivacyPolicy
@@ -66,10 +66,10 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
     }
   }
 
-  class OtherEntity extends Entity<OtherFields, string, ViewerContext> {
+  class OtherEntity extends Entity<OtherFields, 'id', ViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       OtherFields,
-      string,
+      'id',
       ViewerContext,
       OtherEntity,
       PrivacyPolicy
@@ -82,7 +82,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
     }
   }
 
-  const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
+  const categoryEntityConfiguration = new EntityConfiguration<CategoryFields, 'id'>({
     idField: 'id',
     tableName: categoriesTableName,
     inboundEdges: [OtherEntity],
@@ -104,7 +104,7 @@ const makeEntityClasses = async (knex: Knex, edgeDeletionBehavior: EntityEdgeDel
     cacheAdapterFlavor: 'redis',
   });
 
-  const otherEntityConfiguration = new EntityConfiguration<OtherFields>({
+  const otherEntityConfiguration = new EntityConfiguration<OtherFields, 'id'>({
     idField: 'id',
     tableName: othersTableName,
     inboundEdges: [CategoryEntity],

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -16,32 +16,32 @@ interface ChildFields {
   parent_id: string;
 }
 
-class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, 'id', ViewerContext, any, any> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
 }
 
-export default class ChildEntity extends Entity<ChildFields, string, ViewerContext> {
+export default class ChildEntity extends Entity<ChildFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     ChildFields,
-    string,
+    'id',
     ViewerContext,
     ChildEntity,
     TestEntityPrivacyPolicy
   > {
     return {
       entityClass: ChildEntity,
-      entityConfiguration: new EntityConfiguration<ChildFields>({
+      entityConfiguration: new EntityConfiguration<ChildFields, 'id'>({
         idField: 'id',
         tableName: 'children',
         schema: {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -14,32 +14,32 @@ interface ParentFields {
   id: string;
 }
 
-class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, 'id', ViewerContext, any, any> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
 }
 
-export default class ParentEntity extends Entity<ParentFields, string, ViewerContext> {
+export default class ParentEntity extends Entity<ParentFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     ParentFields,
-    string,
+    'id',
     ViewerContext,
     ParentEntity,
     TestEntityPrivacyPolicy
   > {
     return {
       entityClass: ParentEntity,
-      entityConfiguration: new EntityConfiguration<ParentFields>({
+      entityConfiguration: new EntityConfiguration<ParentFields, 'id'>({
         idField: 'id',
         tableName: 'parents',
         inboundEdges: [ChildEntity],

--- a/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
@@ -13,10 +13,11 @@ import {
  */
 export default class LocalMemorySecondaryEntityCache<
   TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
   TLoadParams,
-> extends GenericSecondaryEntityCache<TFields, TLoadParams> {
+> extends GenericSecondaryEntityCache<TFields, TIDField, TLoadParams> {
   constructor(
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     localMemoryCache: LocalMemoryCache<TFields>,
   ) {
     super(new GenericLocalMemoryCacher(entityConfiguration, localMemoryCache), (params) =>

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -9,11 +9,11 @@ import {
   StubDatabaseAdapterProvider,
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
-  UUIDField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
+  UUIDField,
 } from '@expo/entity';
 import {
   GenericLocalMemoryCacher,
@@ -30,12 +30,12 @@ export type LocalMemoryTestEntityFields = {
 
 export default class LocalMemoryTestEntity extends Entity<
   LocalMemoryTestEntityFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     LocalMemoryTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     LocalMemoryTestEntity,
     LocalMemoryTestEntityPrivacyPolicy
@@ -50,14 +50,14 @@ export default class LocalMemoryTestEntity extends Entity<
 
 export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   LocalMemoryTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   LocalMemoryTestEntity
 > {
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
@@ -65,7 +65,7 @@ export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
@@ -73,7 +73,7 @@ export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
@@ -81,28 +81,30 @@ export class LocalMemoryTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       LocalMemoryTestEntityFields,
-      string,
+      'id',
       ViewerContext,
       LocalMemoryTestEntity
     >(),
   ];
 }
 
-export const localMemoryTestEntityConfiguration =
-  new EntityConfiguration<LocalMemoryTestEntityFields>({
-    idField: 'id',
-    tableName: 'local_memory_test_entities',
-    schema: {
-      id: new UUIDField({
-        columnName: 'id',
-      }),
-      name: new StringField({
-        columnName: 'name',
-      }),
-    },
-    databaseAdapterFlavor: 'postgres',
-    cacheAdapterFlavor: 'local-memory',
-  });
+export const localMemoryTestEntityConfiguration = new EntityConfiguration<
+  LocalMemoryTestEntityFields,
+  'id'
+>({
+  idField: 'id',
+  tableName: 'local_memory_test_entities',
+  schema: {
+    id: new UUIDField({
+      columnName: 'id',
+    }),
+    name: new StringField({
+      columnName: 'name',
+    }),
+  },
+  databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'local-memory',
+});
 
 const queryContextProvider = new StubQueryContextProvider();
 
@@ -140,7 +142,7 @@ const FAKE_ID = 'fake';
 class TestSecondaryLocalMemoryCacheLoader extends EntitySecondaryCacheLoader<
   TestLoadParams,
   LocalMemoryTestEntityFields,
-  string,
+  'id',
   TestViewerContext,
   LocalMemoryTestEntity,
   LocalMemoryTestEntityPrivacyPolicy

--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -6,10 +6,11 @@ import { GenericRedisCacheContext, GenericRedisCacher } from '@expo/entity-cache
  */
 export default class RedisSecondaryEntityCache<
   TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
   TLoadParams,
-> extends GenericSecondaryEntityCache<TFields, TLoadParams> {
+> extends GenericSecondaryEntityCache<TFields, TIDField, TLoadParams> {
   constructor(
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     genericRedisCacheContext: GenericRedisCacheContext,
     constructRedisKey: (params: Readonly<TLoadParams>) => string,
   ) {

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -24,7 +24,7 @@ const FAKE_ID = 'fake';
 class TestSecondaryRedisCacheLoader extends EntitySecondaryCacheLoader<
   TestLoadParams,
   RedisTestEntityFields,
-  string,
+  'id',
   TestViewerContext,
   RedisTestEntity,
   RedisTestEntityPrivacyPolicy

--- a/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
+++ b/packages/entity-secondary-cache-redis/src/testfixtures/RedisTestEntity.ts
@@ -2,11 +2,11 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   EntityPrivacyPolicy,
   ViewerContext,
-  UUIDField,
   StringField,
   EntityConfiguration,
   EntityCompanionDefinition,
   Entity,
+  UUIDField,
 } from '@expo/entity';
 
 export type RedisTestEntityFields = {
@@ -14,10 +14,10 @@ export type RedisTestEntityFields = {
   name: string;
 };
 
-export default class RedisTestEntity extends Entity<RedisTestEntityFields, string, ViewerContext> {
+export default class RedisTestEntity extends Entity<RedisTestEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     RedisTestEntityFields,
-    string,
+    'id',
     ViewerContext,
     RedisTestEntity,
     RedisTestEntityPrivacyPolicy
@@ -32,45 +32,25 @@ export default class RedisTestEntity extends Entity<RedisTestEntityFields, strin
 
 export class RedisTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   RedisTestEntityFields,
-  string,
+  'id',
   ViewerContext,
   RedisTestEntity
 > {
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<
-      RedisTestEntityFields,
-      string,
-      ViewerContext,
-      RedisTestEntity
-    >(),
+    new AlwaysAllowPrivacyPolicyRule<RedisTestEntityFields, 'id', ViewerContext, RedisTestEntity>(),
   ];
 }
 
-export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEntityFields>({
+export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEntityFields, 'id'>({
   idField: 'id',
   tableName: 'redis_test_entities',
   schema: {

--- a/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
@@ -13,9 +13,9 @@ import ViewerContext from './ViewerContext';
  */
 export default class AuthorizationResultBasedEntityAssociationLoader<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields,
 > {
   constructor(
@@ -32,16 +32,18 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
   async loadAssociatedEntityAsync<
     TIdentifyingField extends keyof Pick<TFields, TSelectedFields>,
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -51,7 +53,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
     fieldIdentifyingAssociatedEntity: TIdentifyingField,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -72,8 +74,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
       .getViewerScopedEntityCompanionForClass(associatedEntityClass)
       .getLoaderFactory()
       .forLoad(this.queryContext, { previousValue: null, cascadingDeleteCause: null });
-
-    return (await loader.loadByIDAsync(associatedEntityID as unknown as TAssociatedID)) as Result<
+    return (await loader.loadByIDAsync(associatedEntityID)) as Result<
       null extends TFields[TIdentifyingField] ? TAssociatedEntity | null : TAssociatedEntity
     >;
   }
@@ -88,16 +89,18 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
    */
   async loadManyAssociatedEntitiesAsync<
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -106,7 +109,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
   >(
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -135,16 +138,18 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
    */
   async loadAssociatedEntityByFieldEqualingAsync<
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -154,7 +159,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
     fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -186,16 +191,18 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
    */
   async loadManyAssociatedEntitiesByFieldEqualingAsync<
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -205,7 +212,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
     fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -236,11 +243,11 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2 extends object,
-    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+    TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
-      TID2,
+      TIDField2,
       TViewerContext,
       TEntity2,
       TSelectedFields2
@@ -252,7 +259,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
         TViewerContext,
         TFields,
         TFields2,
-        TID2,
+        TIDField2,
         TEntity2,
         TPrivacyPolicy2,
         TSelectedFields,
@@ -268,21 +275,21 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2 extends object,
-    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+    TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
-      TID2,
+      TIDField2,
       TViewerContext,
       TEntity2,
       TSelectedFields2
     >,
     TFields3 extends object,
-    TID3 extends NonNullable<TFields3[TSelectedFields3]>,
-    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
+    TIDField3 extends keyof NonNullable<Pick<TFields3, TSelectedFields3>>,
+    TEntity3 extends ReadonlyEntity<TFields3, TIDField3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
       TFields3,
-      TID3,
+      TIDField3,
       TViewerContext,
       TEntity3,
       TSelectedFields3
@@ -295,7 +302,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
         TViewerContext,
         TFields,
         TFields2,
-        TID2,
+        TIDField2,
         TEntity2,
         TPrivacyPolicy2,
         TSelectedFields,
@@ -305,7 +312,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
         TViewerContext,
         TFields2,
         TFields3,
-        TID3,
+        TIDField3,
         TEntity3,
         TPrivacyPolicy3,
         TSelectedFields2,
@@ -321,31 +328,31 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2 extends object,
-    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+    TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
-      TID2,
+      TIDField2,
       TViewerContext,
       TEntity2,
       TSelectedFields2
     >,
     TFields3 extends object,
-    TID3 extends NonNullable<TFields3[TSelectedFields3]>,
-    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
+    TIDField3 extends keyof NonNullable<Pick<TFields3, TSelectedFields3>>,
+    TEntity3 extends ReadonlyEntity<TFields3, TIDField3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
       TFields3,
-      TID3,
+      TIDField3,
       TViewerContext,
       TEntity3,
       TSelectedFields3
     >,
     TFields4 extends object,
-    TID4 extends NonNullable<TFields4[TSelectedFields4]>,
-    TEntity4 extends ReadonlyEntity<TFields4, TID4, TViewerContext, TSelectedFields4>,
+    TIDField4 extends keyof NonNullable<Pick<TFields4, TSelectedFields4>>,
+    TEntity4 extends ReadonlyEntity<TFields4, TIDField4, TViewerContext, TSelectedFields4>,
     TPrivacyPolicy4 extends EntityPrivacyPolicy<
       TFields4,
-      TID4,
+      TIDField4,
       TViewerContext,
       TEntity4,
       TSelectedFields4
@@ -359,7 +366,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
         TViewerContext,
         TFields,
         TFields2,
-        TID2,
+        TIDField2,
         TEntity2,
         TPrivacyPolicy2,
         TSelectedFields,
@@ -369,7 +376,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
         TViewerContext,
         TFields2,
         TFields3,
-        TID3,
+        TIDField3,
         TEntity3,
         TPrivacyPolicy3,
         TSelectedFields2,
@@ -379,7 +386,7 @@ export default class AuthorizationResultBasedEntityAssociationLoader<
         TViewerContext,
         TFields3,
         TFields4,
-        TID4,
+        TIDField4,
         TEntity4,
         TPrivacyPolicy4,
         TSelectedFields3,
@@ -448,16 +455,16 @@ export interface EntityLoadThroughDirective<
   TViewerContext extends ViewerContext,
   TFields,
   TAssociatedFields extends object,
-  TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+  TAssociatedIDField extends keyof NonNullable<Pick<TAssociatedFields, TAssociatedSelectedFields>>,
   TAssociatedEntity extends ReadonlyEntity<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedIDField,
     TViewerContext,
     TAssociatedSelectedFields
   >,
   TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedIDField,
     TViewerContext,
     TAssociatedEntity,
     TAssociatedSelectedFields
@@ -470,7 +477,7 @@ export interface EntityLoadThroughDirective<
    */
   associatedEntityClass: IEntityClass<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedIDField,
     TViewerContext,
     TAssociatedEntity,
     TAssociatedPrivacyPolicy,

--- a/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
@@ -29,12 +29,12 @@ import { mapMapAsync } from './utils/collections/maps';
 
 abstract class AuthorizationResultBasedBaseMutator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -45,10 +45,10 @@ abstract class AuthorizationResultBasedBaseMutator<
     protected readonly companionProvider: EntityCompanionProvider,
     protected readonly viewerContext: TViewerContext,
     protected readonly queryContext: EntityQueryContext,
-    protected readonly entityConfiguration: EntityConfiguration<TFields>,
+    protected readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
     protected readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -57,27 +57,27 @@ abstract class AuthorizationResultBasedBaseMutator<
     protected readonly privacyPolicy: TPrivacyPolicy,
     protected readonly mutationValidators: EntityMutationValidator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >[],
     protected readonly mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
     protected readonly entityLoaderFactory: EntityLoaderFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-    protected readonly databaseAdapter: EntityDatabaseAdapter<TFields>,
+    protected readonly databaseAdapter: EntityDatabaseAdapter<TFields, TIDField>,
     protected readonly metricsAdapter: IEntityMetricsAdapter,
   ) {}
 
@@ -90,7 +90,7 @@ abstract class AuthorizationResultBasedBaseMutator<
       if (!isInputValid) {
         throw new EntityInvalidFieldValueError<
           TFields,
-          TID,
+          TIDField,
           TViewerContext,
           TEntity,
           TPrivacyPolicy,
@@ -102,12 +102,18 @@ abstract class AuthorizationResultBasedBaseMutator<
   }
 
   protected async executeMutationValidatorsAsync(
-    validators: EntityMutationValidator<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
+    validators: EntityMutationValidator<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >[],
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
     mutationInfo: EntityValidatorMutationInfo<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -122,11 +128,17 @@ abstract class AuthorizationResultBasedBaseMutator<
 
   protected async executeMutationTriggersAsync(
     triggers:
-      | EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[]
+      | EntityMutationTrigger<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[]
       | undefined,
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
-    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+    mutationInfo: EntityTriggerMutationInfo<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
   ): Promise<void> {
     if (!triggers) {
       return;
@@ -142,14 +154,20 @@ abstract class AuthorizationResultBasedBaseMutator<
     triggers:
       | EntityNonTransactionalMutationTrigger<
           TFields,
-          TID,
+          TIDField,
           TViewerContext,
           TEntity,
           TSelectedFields
         >[]
       | undefined,
     entity: TEntity,
-    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+    mutationInfo: EntityTriggerMutationInfo<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
   ): Promise<void> {
     if (!triggers) {
       return;
@@ -165,12 +183,12 @@ abstract class AuthorizationResultBasedBaseMutator<
  */
 export class AuthorizationResultBasedCreateMutator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -178,7 +196,7 @@ export class AuthorizationResultBasedCreateMutator<
   TSelectedFields extends keyof TFields,
 > extends AuthorizationResultBasedBaseMutator<
   TFields,
-  TID,
+  TIDField,
   TViewerContext,
   TEntity,
   TPrivacyPolicy,
@@ -304,12 +322,12 @@ export class AuthorizationResultBasedCreateMutator<
  */
 export class AuthorizationResultBasedUpdateMutator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -317,7 +335,7 @@ export class AuthorizationResultBasedUpdateMutator<
   TSelectedFields extends keyof TFields,
 > extends AuthorizationResultBasedBaseMutator<
   TFields,
-  TID,
+  TIDField,
   TViewerContext,
   TEntity,
   TPrivacyPolicy,
@@ -331,10 +349,10 @@ export class AuthorizationResultBasedUpdateMutator<
     companionProvider: EntityCompanionProvider,
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -343,27 +361,27 @@ export class AuthorizationResultBasedUpdateMutator<
     privacyPolicy: TPrivacyPolicy,
     mutationValidators: EntityMutationValidator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >[],
     mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
     entityLoaderFactory: EntityLoaderFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-    databaseAdapter: EntityDatabaseAdapter<TFields>,
+    databaseAdapter: EntityDatabaseAdapter<TFields, TIDField>,
     metricsAdapter: IEntityMetricsAdapter,
     originalEntity: TEntity,
   ) {
@@ -538,12 +556,12 @@ export class AuthorizationResultBasedUpdateMutator<
  */
 export class AuthorizationResultBasedDeleteMutator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -551,7 +569,7 @@ export class AuthorizationResultBasedDeleteMutator<
   TSelectedFields extends keyof TFields,
 > extends AuthorizationResultBasedBaseMutator<
   TFields,
-  TID,
+  TIDField,
   TViewerContext,
   TEntity,
   TPrivacyPolicy,
@@ -561,10 +579,10 @@ export class AuthorizationResultBasedDeleteMutator<
     companionProvider: EntityCompanionProvider,
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -573,27 +591,27 @@ export class AuthorizationResultBasedDeleteMutator<
     privacyPolicy: TPrivacyPolicy,
     mutationValidators: EntityMutationValidator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >[],
     mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
     entityLoaderFactory: EntityLoaderFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-    databaseAdapter: EntityDatabaseAdapter<TFields>,
+    databaseAdapter: EntityDatabaseAdapter<TFields, TIDField>,
     metricsAdapter: IEntityMetricsAdapter,
     private readonly entity: TEntity,
   ) {
@@ -751,7 +769,7 @@ export class AuthorizationResultBasedDeleteMutator<
     const companionDefinition = this.companionProvider.getCompanionForEntity(
       entity.constructor as IEntityClass<
         TFields,
-        TID,
+        TIDField,
         TViewerContext,
         TEntity,
         TPrivacyPolicy,

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -7,8 +7,10 @@ import { CacheStatus, CacheLoadResult } from './internal/ReadThroughEntityCache'
 /**
  * A IEntityCacheAdapter that composes other IEntityCacheAdapter instances.
  */
-export default class ComposedEntityCacheAdapter<TFields extends Record<string, any>>
-  implements IEntityCacheAdapter<TFields>
+export default class ComposedEntityCacheAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements IEntityCacheAdapter<TFields, TIDField>
 {
   /**
    * @param cacheAdapters - list of cache adapters to compose in order of precedence.
@@ -16,10 +18,10 @@ export default class ComposedEntityCacheAdapter<TFields extends Record<string, a
    *                        Typically, caches closer to the application should be ordered before caches closer to the database.
    *                        A lower layer cache is closer to the database, while a higher layer cache is closer to the application.
    */
-  constructor(private readonly cacheAdapters: IEntityCacheAdapter<TFields>[]) {}
+  constructor(private readonly cacheAdapters: IEntityCacheAdapter<TFields, TIDField>[]) {}
 
   public async loadManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -90,7 +92,7 @@ export default class ComposedEntityCacheAdapter<TFields extends Record<string, a
   }
 
   public async cacheManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {
@@ -102,7 +104,7 @@ export default class ComposedEntityCacheAdapter<TFields extends Record<string, a
   }
 
   public async cacheDBMissesAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
@@ -114,7 +116,7 @@ export default class ComposedEntityCacheAdapter<TFields extends Record<string, a
   }
 
   public async invalidateManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {

--- a/packages/entity/src/EnforcingEntityAssociationLoader.ts
+++ b/packages/entity/src/EnforcingEntityAssociationLoader.ts
@@ -16,15 +16,15 @@ import { enforceResultsAsync } from './entityUtils';
  */
 export default class EnforcingEntityAssociationLoader<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields,
 > {
   constructor(
     private readonly authorizationResultBasedEntityAssociationLoader: AuthorizationResultBasedEntityAssociationLoader<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -40,16 +40,18 @@ export default class EnforcingEntityAssociationLoader<
   async loadAssociatedEntityAsync<
     TIdentifyingField extends keyof Pick<TFields, TSelectedFields>,
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -59,7 +61,7 @@ export default class EnforcingEntityAssociationLoader<
     fieldIdentifyingAssociatedEntity: TIdentifyingField,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -86,16 +88,18 @@ export default class EnforcingEntityAssociationLoader<
    */
   async loadManyAssociatedEntitiesAsync<
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -104,7 +108,7 @@ export default class EnforcingEntityAssociationLoader<
   >(
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -129,16 +133,18 @@ export default class EnforcingEntityAssociationLoader<
    */
   async loadAssociatedEntityByFieldEqualingAsync<
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -148,7 +154,7 @@ export default class EnforcingEntityAssociationLoader<
     fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -174,16 +180,18 @@ export default class EnforcingEntityAssociationLoader<
    */
   async loadManyAssociatedEntitiesByFieldEqualingAsync<
     TAssociatedFields extends object,
-    TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+    TAssociatedIDField extends keyof NonNullable<
+      Pick<TAssociatedFields, TAssociatedSelectedFields>
+    >,
     TAssociatedEntity extends ReadonlyEntity<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedSelectedFields
     >,
     TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedSelectedFields
@@ -193,7 +201,7 @@ export default class EnforcingEntityAssociationLoader<
     fieldIdentifyingAssociatedEntity: keyof Pick<TFields, TSelectedFields>,
     associatedEntityClass: IEntityClass<
       TAssociatedFields,
-      TAssociatedID,
+      TAssociatedIDField,
       TViewerContext,
       TAssociatedEntity,
       TAssociatedPrivacyPolicy,
@@ -217,11 +225,11 @@ export default class EnforcingEntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2 extends object,
-    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+    TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
-      TID2,
+      TIDField2,
       TViewerContext,
       TEntity2,
       TSelectedFields2
@@ -233,7 +241,7 @@ export default class EnforcingEntityAssociationLoader<
         TViewerContext,
         TFields,
         TFields2,
-        TID2,
+        TIDField2,
         TEntity2,
         TPrivacyPolicy2,
         TSelectedFields,
@@ -249,21 +257,21 @@ export default class EnforcingEntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2 extends object,
-    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+    TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
-      TID2,
+      TIDField2,
       TViewerContext,
       TEntity2,
       TSelectedFields2
     >,
     TFields3 extends object,
-    TID3 extends NonNullable<TFields3[TSelectedFields3]>,
-    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
+    TIDField3 extends keyof NonNullable<Pick<TFields3, TSelectedFields3>>,
+    TEntity3 extends ReadonlyEntity<TFields3, TIDField3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
       TFields3,
-      TID3,
+      TIDField3,
       TViewerContext,
       TEntity3,
       TSelectedFields3
@@ -276,7 +284,7 @@ export default class EnforcingEntityAssociationLoader<
         TViewerContext,
         TFields,
         TFields2,
-        TID2,
+        TIDField2,
         TEntity2,
         TPrivacyPolicy2,
         TSelectedFields,
@@ -286,7 +294,7 @@ export default class EnforcingEntityAssociationLoader<
         TViewerContext,
         TFields2,
         TFields3,
-        TID3,
+        TIDField3,
         TEntity3,
         TPrivacyPolicy3,
         TSelectedFields2,
@@ -302,31 +310,31 @@ export default class EnforcingEntityAssociationLoader<
    */
   async loadAssociatedEntityThroughAsync<
     TFields2 extends object,
-    TID2 extends NonNullable<TFields2[TSelectedFields2]>,
-    TEntity2 extends ReadonlyEntity<TFields2, TID2, TViewerContext, TSelectedFields2>,
+    TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+    TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
     TPrivacyPolicy2 extends EntityPrivacyPolicy<
       TFields2,
-      TID2,
+      TIDField2,
       TViewerContext,
       TEntity2,
       TSelectedFields2
     >,
     TFields3 extends object,
-    TID3 extends NonNullable<TFields3[TSelectedFields3]>,
-    TEntity3 extends ReadonlyEntity<TFields3, TID3, TViewerContext, TSelectedFields3>,
+    TIDField3 extends keyof NonNullable<Pick<TFields3, TSelectedFields3>>,
+    TEntity3 extends ReadonlyEntity<TFields3, TIDField3, TViewerContext, TSelectedFields3>,
     TPrivacyPolicy3 extends EntityPrivacyPolicy<
       TFields3,
-      TID3,
+      TIDField3,
       TViewerContext,
       TEntity3,
       TSelectedFields3
     >,
     TFields4 extends object,
-    TID4 extends NonNullable<TFields4[TSelectedFields4]>,
-    TEntity4 extends ReadonlyEntity<TFields4, TID4, TViewerContext, TSelectedFields4>,
+    TIDField4 extends keyof NonNullable<Pick<TFields4, TSelectedFields4>>,
+    TEntity4 extends ReadonlyEntity<TFields4, TIDField4, TViewerContext, TSelectedFields4>,
     TPrivacyPolicy4 extends EntityPrivacyPolicy<
       TFields4,
-      TID4,
+      TIDField4,
       TViewerContext,
       TEntity4,
       TSelectedFields4
@@ -340,7 +348,7 @@ export default class EnforcingEntityAssociationLoader<
         TViewerContext,
         TFields,
         TFields2,
-        TID2,
+        TIDField2,
         TEntity2,
         TPrivacyPolicy2,
         TSelectedFields,
@@ -350,7 +358,7 @@ export default class EnforcingEntityAssociationLoader<
         TViewerContext,
         TFields2,
         TFields3,
-        TID3,
+        TIDField3,
         TEntity3,
         TPrivacyPolicy3,
         TSelectedFields2,
@@ -360,7 +368,7 @@ export default class EnforcingEntityAssociationLoader<
         TViewerContext,
         TFields3,
         TFields4,
-        TID4,
+        TIDField4,
         TEntity4,
         TPrivacyPolicy4,
         TSelectedFields3,

--- a/packages/entity/src/EnforcingEntityCreator.ts
+++ b/packages/entity/src/EnforcingEntityCreator.ts
@@ -11,12 +11,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class EnforcingEntityCreator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -26,7 +26,7 @@ export default class EnforcingEntityCreator<
   constructor(
     private readonly entityCreator: AuthorizationResultBasedCreateMutator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,

--- a/packages/entity/src/EnforcingEntityDeleter.ts
+++ b/packages/entity/src/EnforcingEntityDeleter.ts
@@ -11,12 +11,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class EnforcingEntityDeleter<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -26,7 +26,7 @@ export default class EnforcingEntityDeleter<
   constructor(
     private readonly entityDeleter: AuthorizationResultBasedDeleteMutator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -19,12 +19,12 @@ import { mapMap } from './utils/collections/maps';
  */
 export default class EnforcingEntityLoader<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -34,7 +34,7 @@ export default class EnforcingEntityLoader<
   constructor(
     private readonly entityLoader: AuthorizationResultBasedEntityLoader<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -176,7 +176,7 @@ export default class EnforcingEntityLoader<
    * @throws EntityNotAuthorizedError when viewer is not authorized to view the returned entity
    * @throws EntityNotFoundError when no entity exists for ID
    */
-  async loadByIDAsync(id: TID): Promise<TEntity> {
+  async loadByIDAsync(id: TFields[TIDField]): Promise<TEntity> {
     const entityResult = await this.entityLoader.loadByIDAsync(id);
     return entityResult.enforceValue();
   }
@@ -188,7 +188,7 @@ export default class EnforcingEntityLoader<
    * @throws EntityNotAuthorizedError when viewer is not authorized to view the returned entity
    * @throws when multiple entities are found matching the condition
    */
-  async loadByIDNullableAsync(id: TID): Promise<TEntity | null> {
+  async loadByIDNullableAsync(id: TFields[TIDField]): Promise<TEntity | null> {
     const entityResult = await this.entityLoader.loadByIDNullableAsync(id);
     return entityResult ? entityResult.enforceValue() : null;
   }
@@ -200,7 +200,9 @@ export default class EnforcingEntityLoader<
    * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
    * @throws EntityNotFoundError when no entity exists for one or more of the IDs
    */
-  async loadManyByIDsAsync(ids: readonly TID[]): Promise<ReadonlyMap<TID, TEntity>> {
+  async loadManyByIDsAsync(
+    ids: readonly TFields[TIDField][],
+  ): Promise<ReadonlyMap<TFields[TIDField], TEntity>> {
     const entityResults = await this.entityLoader.loadManyByIDsAsync(ids);
     return mapMap(entityResults, (result) => result.enforceValue());
   }
@@ -211,7 +213,9 @@ export default class EnforcingEntityLoader<
    * @returns map from ID to nullable corresponding entity
    * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
    */
-  async loadManyByIDsNullableAsync(ids: readonly TID[]): Promise<ReadonlyMap<TID, TEntity | null>> {
+  async loadManyByIDsNullableAsync(
+    ids: readonly TFields[TIDField][],
+  ): Promise<ReadonlyMap<TFields[TIDField], TEntity | null>> {
     const entityResults = await this.entityLoader.loadManyByIDsNullableAsync(ids);
     return mapMap(entityResults, (result) => result?.enforceValue() ?? null);
   }

--- a/packages/entity/src/EnforcingEntityUpdater.ts
+++ b/packages/entity/src/EnforcingEntityUpdater.ts
@@ -11,12 +11,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class EnforcingEntityUpdater<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -26,7 +26,7 @@ export default class EnforcingEntityUpdater<
   constructor(
     private readonly entityUpdater: AuthorizationResultBasedUpdateMutator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -35,10 +35,10 @@ import ViewerContext from './ViewerContext';
  */
 export default abstract class Entity<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields> {
+> extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields> {
   /**
    * Vend mutator for creating a new entity in given query context.
    * @param viewerContext - viewer context of creating user
@@ -47,13 +47,13 @@ export default abstract class Entity<
    */
   static creator<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends Entity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -62,7 +62,7 @@ export default abstract class Entity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -75,7 +75,7 @@ export default abstract class Entity<
       .getQueryContext(),
   ): EnforcingEntityCreator<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -92,13 +92,13 @@ export default abstract class Entity<
    */
   static creatorWithAuthorizationResults<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends Entity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -107,7 +107,7 @@ export default abstract class Entity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -120,7 +120,7 @@ export default abstract class Entity<
       .getQueryContext(),
   ): AuthorizationResultBasedCreateMutator<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -137,12 +137,12 @@ export default abstract class Entity<
    */
   static updater<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends Entity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -151,7 +151,7 @@ export default abstract class Entity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -165,7 +165,7 @@ export default abstract class Entity<
       .getQueryContext(),
   ): EnforcingEntityUpdater<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -182,12 +182,12 @@ export default abstract class Entity<
    */
   static updaterWithAuthorizationResults<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends Entity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -196,7 +196,7 @@ export default abstract class Entity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -210,7 +210,7 @@ export default abstract class Entity<
       .getQueryContext(),
   ): AuthorizationResultBasedUpdateMutator<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -227,12 +227,12 @@ export default abstract class Entity<
    */
   static deleter<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends Entity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -241,7 +241,7 @@ export default abstract class Entity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -255,7 +255,7 @@ export default abstract class Entity<
       .getQueryContext(),
   ): EnforcingEntityDeleter<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -272,12 +272,12 @@ export default abstract class Entity<
    */
   static deleterWithAuthorizationResults<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
-    TMEntity extends Entity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends Entity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -286,7 +286,7 @@ export default abstract class Entity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -300,7 +300,7 @@ export default abstract class Entity<
       .getQueryContext(),
   ): AuthorizationResultBasedDeleteMutator<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -315,12 +315,12 @@ export default abstract class Entity<
  */
 export interface IEntityClass<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -329,7 +329,7 @@ export interface IEntityClass<
 > {
   new (constructorParam: {
     viewerContext: TViewerContext;
-    id: TID;
+    id: TFields[TIDField];
     databaseFields: Readonly<TFields>;
     selectedFields: Readonly<Pick<TFields, TSelectedFields>>;
   }): TEntity;
@@ -341,7 +341,7 @@ export interface IEntityClass<
    */
   defineCompanionDefinition(): EntityCompanionDefinition<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -12,9 +12,9 @@ import ViewerContext from './ViewerContext';
  */
 export default class EntityAssociationLoader<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields,
 > {
   constructor(
@@ -24,7 +24,7 @@ export default class EntityAssociationLoader<
       .getViewerScopedEntityCompanionForClass(
         entity.constructor as IEntityClass<
           TFields,
-          TID,
+          TIDField,
           TViewerContext,
           TEntity,
           any,
@@ -42,7 +42,7 @@ export default class EntityAssociationLoader<
    */
   enforcing(): EnforcingEntityAssociationLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -57,7 +57,7 @@ export default class EntityAssociationLoader<
    */
   withAuthorizationResults(): AuthorizationResultBasedEntityAssociationLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -18,12 +18,12 @@ export interface IPrivacyPolicyClass<TPrivacyPolicy> {
  */
 export default class EntityCompanion<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -34,7 +34,7 @@ export default class EntityCompanion<
 
   private readonly entityLoaderFactory: EntityLoaderFactory<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -42,7 +42,7 @@ export default class EntityCompanion<
   >;
   private readonly entityMutatorFactory: EntityMutatorFactory<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -53,19 +53,19 @@ export default class EntityCompanion<
     public readonly entityCompanionProvider: EntityCompanionProvider,
     public readonly entityCompanionDefinition: EntityCompanionDefinition<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-    private readonly tableDataCoordinator: EntityTableDataCoordinator<TFields>,
+    private readonly tableDataCoordinator: EntityTableDataCoordinator<TFields, TIDField>,
     private readonly metricsAdapter: IEntityMetricsAdapter,
   ) {
     this.privacyPolicy = new entityCompanionDefinition.privacyPolicyClass();
     this.entityLoaderFactory = new EntityLoaderFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -89,7 +89,7 @@ export default class EntityCompanion<
 
   getLoaderFactory(): EntityLoaderFactory<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -100,7 +100,7 @@ export default class EntityCompanion<
 
   getMutatorFactory(): EntityMutatorFactory<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -51,12 +51,12 @@ export interface CacheAdapterFlavorDefinition {
  */
 export interface EntityCompanionDefinition<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -68,7 +68,7 @@ export interface EntityCompanionDefinition<
    */
   readonly entityClass: IEntityClass<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -78,7 +78,7 @@ export interface EntityCompanionDefinition<
   /**
    * The EntityConfiguration for this entity.
    */
-  readonly entityConfiguration: EntityConfiguration<TFields>;
+  readonly entityConfiguration: EntityConfiguration<TFields, TIDField>;
 
   /**
    * The EntityPrivacyPolicy class for this entity.
@@ -90,7 +90,7 @@ export interface EntityCompanionDefinition<
    */
   readonly mutationValidators?: EntityMutationValidator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -101,7 +101,7 @@ export interface EntityCompanionDefinition<
    */
   readonly mutationTriggers?: EntityMutationTriggerConfiguration<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -131,7 +131,7 @@ export default class EntityCompanionProvider {
   > = new Map();
   private readonly companionMap: Map<string, EntityCompanion<any, any, any, any, any, any>> =
     new Map();
-  private readonly tableDataCoordinatorMap: Map<string, EntityTableDataCoordinator<any>> =
+  private readonly tableDataCoordinatorMap: Map<string, EntityTableDataCoordinator<any, any>> =
     new Map();
 
   /**
@@ -168,12 +168,12 @@ export default class EntityCompanionProvider {
    */
   getCompanionForEntity<
     TFields extends Record<string, any>,
-    TID extends NonNullable<TFields[TSelectedFields]>,
+    TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
     TViewerContext extends ViewerContext,
-    TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
     TPrivacyPolicy extends EntityPrivacyPolicy<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -182,13 +182,13 @@ export default class EntityCompanionProvider {
   >(
     entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-  ): EntityCompanion<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
+  ): EntityCompanion<TFields, TIDField, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     const entityCompanionDefinition = computeIfAbsent(
       this.companionDefinitionMap,
       entityClass.name,
@@ -220,10 +220,13 @@ export default class EntityCompanionProvider {
     return entityDatabaseAdapterFlavor.queryContextProvider;
   }
 
-  private getTableDataCoordinatorForEntity<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
+  private getTableDataCoordinatorForEntity<
+    TFields extends Record<string, any>,
+    TIDField extends keyof TFields,
+  >(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     entityClassName: string,
-  ): EntityTableDataCoordinator<TFields> {
+  ): EntityTableDataCoordinator<TFields, TIDField> {
     return computeIfAbsent(this.tableDataCoordinatorMap, entityConfiguration.tableName, () => {
       const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(
         entityConfiguration.databaseAdapterFlavor,

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -44,11 +44,14 @@ export type EntityCompositeFieldValue<
 /**
  * Helper class to validate and store composite field information.
  */
-export class CompositeFieldInfo<TFields extends Record<string, any>> {
+export class CompositeFieldInfo<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
   private readonly compositeFieldInfoMap: ReadonlyMap<
     SerializedCompositeFieldHolder,
     {
-      compositeFieldHolder: CompositeFieldHolder<TFields>;
+      compositeFieldHolder: CompositeFieldHolder<TFields, TIDField>;
       cache: boolean;
     }
   >;
@@ -75,12 +78,12 @@ export class CompositeFieldInfo<TFields extends Record<string, any>> {
 
   public getCompositeFieldHolderForCompositeField(
     compositeField: EntityCompositeField<TFields>,
-  ): CompositeFieldHolder<TFields> | undefined {
+  ): CompositeFieldHolder<TFields, TIDField> | undefined {
     return this.compositeFieldInfoMap.get(new CompositeFieldHolder(compositeField).serialize())
       ?.compositeFieldHolder;
   }
 
-  public getAllCompositeFieldHolders(): readonly CompositeFieldHolder<TFields>[] {
+  public getAllCompositeFieldHolders(): readonly CompositeFieldHolder<TFields, TIDField>[] {
     return Array.from(this.compositeFieldInfoMap.values()).map((v) => v.compositeFieldHolder);
   }
 
@@ -100,11 +103,14 @@ export class CompositeFieldInfo<TFields extends Record<string, any>> {
  * The data storage configuration for a type of Entity. Contains information relating to IDs,
  * cachable fields, field mappings, and types of cache and database adapter.
  */
-export default class EntityConfiguration<TFields extends Record<string, any>> {
+export default class EntityConfiguration<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
   readonly idField: keyof TFields;
   readonly tableName: string;
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
-  readonly compositeFieldInfo: CompositeFieldInfo<TFields>;
+  readonly compositeFieldInfo: CompositeFieldInfo<TFields, TIDField>;
   readonly cacheKeyVersion: number;
 
   readonly inboundEdges: IEntityClass<any, any, any, any, any, any>[];
@@ -128,7 +134,7 @@ export default class EntityConfiguration<TFields extends Record<string, any>> {
     /**
      * The field used to identify this entity. Must be a unique field in the table.
      */
-    idField: keyof TFields;
+    idField: TIDField;
 
     /**
      * The name of the table where entities of this type are stored.
@@ -175,7 +181,7 @@ export default class EntityConfiguration<TFields extends Record<string, any>> {
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups
-    EntityConfiguration.validateSchema(schema);
+    EntityConfiguration.validateSchema<TFields>(schema);
     this.schema = new Map(Object.entries(schema));
 
     this.cacheableKeys = EntityConfiguration.computeCacheableKeys(this.schema);
@@ -186,7 +192,9 @@ export default class EntityConfiguration<TFields extends Record<string, any>> {
     this.dbToEntityFieldsKeyMapping = invertMap(this.entityToDBFieldsKeyMapping);
   }
 
-  private static validateSchema<TFields extends Record<string, any>>(schema: TFields): void {
+  private static validateSchema<TFields extends Record<string, any>>(
+    schema: Record<keyof TFields, EntityFieldDefinition<any>>,
+  ): void {
     const disallowedFieldsKeys = Object.getOwnPropertyNames(Object.prototype);
     for (const disallowedFieldsKey of disallowedFieldsKeys) {
       if (Object.hasOwn(schema, disallowedFieldsKey)) {

--- a/packages/entity/src/EntityCreator.ts
+++ b/packages/entity/src/EntityCreator.ts
@@ -11,13 +11,13 @@ import ViewerContext from './ViewerContext';
  */
 export default class EntityCreator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TViewerContext2 extends TViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -29,7 +29,7 @@ export default class EntityCreator<
     private readonly queryContext: EntityQueryContext,
     private readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -43,7 +43,7 @@ export default class EntityCreator<
    */
   enforcing(): EnforcingEntityCreator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -59,7 +59,7 @@ export default class EntityCreator<
    */
   withAuthorizationResults(): AuthorizationResultBasedCreateMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -117,10 +117,13 @@ export interface TableQuerySelectionModifiersWithOrderByRaw extends TableQuerySe
  * handles all entity field transformation. Subclasses are responsible for
  * implementing database-specific logic for a type of database.
  */
-export default abstract class EntityDatabaseAdapter<TFields extends Record<string, any>> {
+export default abstract class EntityDatabaseAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
   private readonly fieldTransformerMap: FieldTransformerMap;
 
-  constructor(private readonly entityConfiguration: EntityConfiguration<TFields>) {
+  constructor(private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>) {
     this.fieldTransformerMap = this.getFieldTransformerMap();
   }
 
@@ -140,7 +143,7 @@ export default abstract class EntityDatabaseAdapter<TFields extends Record<strin
    * @returns map from value to objects that match the query for that value
    */
   async fetchManyWhereAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(

--- a/packages/entity/src/EntityDeleter.ts
+++ b/packages/entity/src/EntityDeleter.ts
@@ -11,12 +11,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class EntityDeleter<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -28,7 +28,7 @@ export default class EntityDeleter<
     private readonly queryContext: EntityQueryContext,
     private readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -42,7 +42,7 @@ export default class EntityDeleter<
    */
   enforcing(): EnforcingEntityDeleter<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -58,7 +58,7 @@ export default class EntityDeleter<
    */
   withAuthorizationResults(): AuthorizationResultBasedDeleteMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -71,16 +71,16 @@ export enum EntityEdgeDeletionAuthorizationInferenceBehavior {
 export interface EntityAssociationDefinition<
   TViewerContext extends ViewerContext,
   TAssociatedFields extends object,
-  TAssociatedID extends NonNullable<TAssociatedFields[TAssociatedSelectedFields]>,
+  TAssociatedIDField extends keyof NonNullable<Pick<TAssociatedFields, TAssociatedSelectedFields>>,
   TAssociatedEntity extends ReadonlyEntity<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedIDField,
     TViewerContext,
     TAssociatedSelectedFields
   >,
   TAssociatedPrivacyPolicy extends EntityPrivacyPolicy<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedIDField,
     TViewerContext,
     TAssociatedEntity,
     TAssociatedSelectedFields
@@ -92,7 +92,7 @@ export interface EntityAssociationDefinition<
    */
   associatedEntityClass: IEntityClass<
     TAssociatedFields,
-    TAssociatedID,
+    TAssociatedIDField,
     TViewerContext,
     TAssociatedEntity,
     TAssociatedPrivacyPolicy,

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -13,13 +13,13 @@ import ViewerContext from './ViewerContext';
  */
 export default class EntityLoader<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TViewerContext2 extends TViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -31,7 +31,7 @@ export default class EntityLoader<
     private readonly queryContext: EntityQueryContext,
     private readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -46,7 +46,7 @@ export default class EntityLoader<
    */
   enforcing(): EnforcingEntityLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -62,7 +62,7 @@ export default class EntityLoader<
    */
   withAuthorizationResults(): AuthorizationResultBasedEntityLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -80,7 +80,7 @@ export default class EntityLoader<
    */
   public utils(): EntityLoaderUtils<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -13,12 +13,12 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  */
 export default class EntityLoaderFactory<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -28,13 +28,13 @@ export default class EntityLoaderFactory<
   constructor(
     private readonly entityCompanion: EntityCompanion<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-    private readonly dataManager: EntityDataManager<TFields>,
+    private readonly dataManager: EntityDataManager<TFields, TIDField>,
     protected readonly metricsAdapter: IEntityMetricsAdapter,
   ) {}
 
@@ -48,14 +48,14 @@ export default class EntityLoaderFactory<
     queryContext: EntityQueryContext,
     privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
   ): AuthorizationResultBasedEntityLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityLoaderUtils.ts
+++ b/packages/entity/src/EntityLoaderUtils.ts
@@ -19,12 +19,12 @@ import { mapMapAsync } from './utils/collections/maps';
  */
 export default class EntityLoaderUtils<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -36,15 +36,15 @@ export default class EntityLoaderUtils<
     private readonly queryContext: EntityQueryContext,
     private readonly privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
     private readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -52,7 +52,7 @@ export default class EntityLoaderUtils<
     >,
     private readonly entitySelectedFields: TSelectedFields[] | undefined,
     private readonly privacyPolicy: TPrivacyPolicy,
-    private readonly dataManager: EntityDataManager<TFields>,
+    private readonly dataManager: EntityDataManager<TFields, TIDField>,
     protected readonly metricsAdapter: IEntityMetricsAdapter,
   ) {}
 
@@ -69,7 +69,7 @@ export default class EntityLoaderUtils<
           return null;
         }
         return [
-          new SingleFieldHolder<TFields, typeof fieldName>(fieldName),
+          new SingleFieldHolder<TFields, TIDField, typeof fieldName>(fieldName),
           new SingleFieldValueHolder(value),
         ] as const;
       })
@@ -115,7 +115,7 @@ export default class EntityLoaderUtils<
     const selectedFields = pick(fieldsObject, entitySelectedFields);
     return new this.entityClass({
       viewerContext: this.viewerContext,
-      id: id as TID,
+      id: id as TFields[TIDField],
       databaseFields: fieldsObject,
       selectedFields,
     });

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -9,9 +9,9 @@ export enum EntityMutationType {
 
 export type EntityValidatorMutationInfo<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > =
   | {
@@ -40,9 +40,9 @@ export type EntityCascadingDeletionInfo = {
 
 export type EntityTriggerMutationInfo<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > =
   | {

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -8,47 +8,83 @@ import ViewerContext from './ViewerContext';
  */
 export default interface EntityMutationTriggerConfiguration<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   /**
    * Trigger set that runs within the transaction but before the entity is created in the database.
    */
-  beforeCreate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeCreate?: EntityMutationTrigger<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[];
   /**
    * Trigger set that runs within the transaction but after the entity is created in the database and cache is invalidated.
    */
-  afterCreate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  afterCreate?: EntityMutationTrigger<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[];
 
   /**
    * Trigger set that runs within the transaction but before the entity is updated in the database.
    */
-  beforeUpdate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeUpdate?: EntityMutationTrigger<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[];
   /**
    * Trigger set that runs within the transaction but after the entity is updated in the database and cache is invalidated.
    */
-  afterUpdate?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  afterUpdate?: EntityMutationTrigger<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[];
 
   /**
    * Trigger set that runs within the transaction but before the entity is deleted from the database.
    */
-  beforeDelete?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeDelete?: EntityMutationTrigger<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[];
   /**
    * Trigger set that runs within the transaction but after the entity is deleted from the database and cache is invalidated.
    */
-  afterDelete?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  afterDelete?: EntityMutationTrigger<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >[];
 
   /**
    * Trigger set that runs within the transaction but before the entity is created, updated, or deleted.
    */
-  beforeAll?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  beforeAll?: EntityMutationTrigger<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[];
   /**
    * Trigger set that runs within the transaction but after the entity is created in, updated in, or deleted from
    * the database and the cache is invalidated.
    */
-  afterAll?: EntityMutationTrigger<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+  afterAll?: EntityMutationTrigger<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[];
 
   /**
    * Trigger set that runs after committing the mutation transaction. If the call to the mutation is wrapped in a transaction, these
@@ -56,7 +92,7 @@ export default interface EntityMutationTriggerConfiguration<
    */
   afterCommit?: EntityNonTransactionalMutationTrigger<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -69,16 +105,22 @@ export default interface EntityMutationTriggerConfiguration<
  */
 export abstract class EntityMutationTrigger<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   abstract executeAsync(
     viewerContext: TViewerContext,
     queryContext: EntityTransactionalQueryContext,
     entity: TEntity,
-    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+    mutationInfo: EntityTriggerMutationInfo<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
   ): Promise<void>;
 }
 
@@ -88,14 +130,20 @@ export abstract class EntityMutationTrigger<
  */
 export abstract class EntityNonTransactionalMutationTrigger<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   abstract executeAsync(
     viewerContext: TViewerContext,
     entity: TEntity,
-    mutationInfo: EntityTriggerMutationInfo<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+    mutationInfo: EntityTriggerMutationInfo<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
   ): Promise<void>;
 }

--- a/packages/entity/src/EntityMutationValidator.ts
+++ b/packages/entity/src/EntityMutationValidator.ts
@@ -9,9 +9,9 @@ import ViewerContext from './ViewerContext';
  */
 export default abstract class EntityMutationValidator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   abstract executeAsync(
@@ -20,7 +20,7 @@ export default abstract class EntityMutationValidator<
     entity: TEntity,
     mutationInfo: EntityValidatorMutationInfo<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -20,12 +20,12 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  */
 export default class EntityMutatorFactory<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -34,10 +34,10 @@ export default class EntityMutatorFactory<
 > {
   constructor(
     private readonly entityCompanionProvider: EntityCompanionProvider,
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
     private readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -46,27 +46,27 @@ export default class EntityMutatorFactory<
     private readonly privacyPolicy: TPrivacyPolicy,
     private readonly mutationValidators: EntityMutationValidator<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >[],
     private readonly mutationTriggers: EntityMutationTriggerConfiguration<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
     private readonly entityLoaderFactory: EntityLoaderFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
       TSelectedFields
     >,
-    private readonly databaseAdapter: EntityDatabaseAdapter<TFields>,
+    private readonly databaseAdapter: EntityDatabaseAdapter<TFields, TIDField>,
     private readonly metricsAdapter: IEntityMetricsAdapter,
   ) {}
 
@@ -81,7 +81,7 @@ export default class EntityMutatorFactory<
     queryContext: EntityQueryContext,
   ): AuthorizationResultBasedCreateMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -113,7 +113,7 @@ export default class EntityMutatorFactory<
     queryContext: EntityQueryContext,
   ): AuthorizationResultBasedUpdateMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -145,7 +145,7 @@ export default class EntityMutatorFactory<
     queryContext: EntityQueryContext,
   ): AuthorizationResultBasedDeleteMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -13,9 +13,9 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from './rules/PrivacyPolicyRu
  */
 export type EntityPrivacyPolicyEvaluationContext<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > = {
   /**
@@ -54,9 +54,9 @@ export enum EntityPrivacyPolicyEvaluationMode {
 
 export type EntityPrivacyPolicyEvaluator<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > =
   | {
@@ -65,13 +65,25 @@ export type EntityPrivacyPolicyEvaluator<
   | {
       mode: EntityPrivacyPolicyEvaluationMode.DRY_RUN;
       denyHandler: (
-        error: EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+        error: EntityNotAuthorizedError<
+          TFields,
+          TIDField,
+          TViewerContext,
+          TEntity,
+          TSelectedFields
+        >,
       ) => void;
     }
   | {
       mode: EntityPrivacyPolicyEvaluationMode.ENFORCE_AND_LOG;
       denyHandler: (
-        error: EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+        error: EntityNotAuthorizedError<
+          TFields,
+          TIDField,
+          TViewerContext,
+          TEntity,
+          TSelectedFields
+        >,
       ) => void;
     };
 
@@ -105,35 +117,35 @@ export enum EntityAuthorizationAction {
  */
 export default abstract class EntityPrivacyPolicy<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   protected readonly createRules: readonly PrivacyPolicyRule<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >[] = [];
   protected readonly readRules: readonly PrivacyPolicyRule<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >[] = [];
   protected readonly updateRules: readonly PrivacyPolicyRule<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >[] = [];
   protected readonly deleteRules: readonly PrivacyPolicyRule<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -149,7 +161,7 @@ export default abstract class EntityPrivacyPolicy<
    */
   protected getPrivacyPolicyEvaluator(
     _viewerContext: TViewerContext,
-  ): EntityPrivacyPolicyEvaluator<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+  ): EntityPrivacyPolicyEvaluator<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
     return {
       mode: EntityPrivacyPolicyEvaluationMode.ENFORCE,
     };
@@ -168,7 +180,7 @@ export default abstract class EntityPrivacyPolicy<
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -200,7 +212,7 @@ export default abstract class EntityPrivacyPolicy<
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -232,7 +244,7 @@ export default abstract class EntityPrivacyPolicy<
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -264,7 +276,7 @@ export default abstract class EntityPrivacyPolicy<
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -284,12 +296,18 @@ export default abstract class EntityPrivacyPolicy<
   }
 
   private async authorizeForRulesetAsync(
-    ruleset: readonly PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
+    ruleset: readonly PrivacyPolicyRule<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >[],
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -393,12 +411,18 @@ export default abstract class EntityPrivacyPolicy<
   }
 
   private async authorizeForRulesetInnerAsync(
-    ruleset: readonly PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
+    ruleset: readonly PrivacyPolicyRule<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >[],
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -418,7 +442,7 @@ export default abstract class EntityPrivacyPolicy<
         case RuleEvaluationResult.DENY:
           throw new EntityNotAuthorizedError<
             TFields,
-            TID,
+            TIDField,
             TViewerContext,
             TEntity,
             TSelectedFields
@@ -434,7 +458,7 @@ export default abstract class EntityPrivacyPolicy<
       }
     }
 
-    throw new EntityNotAuthorizedError<TFields, TID, TViewerContext, TEntity, TSelectedFields>(
+    throw new EntityNotAuthorizedError<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(
       entity,
       viewerContext,
       action,

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -46,12 +46,12 @@ export interface ISecondaryEntityCache<TFields extends Record<string, any>, TLoa
 export default abstract class EntitySecondaryCacheLoader<
   TLoadParams,
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -62,7 +62,7 @@ export default abstract class EntitySecondaryCacheLoader<
     private readonly secondaryEntityCache: ISecondaryEntityCache<TFields, TLoadParams>,
     protected readonly entityLoader: AuthorizationResultBasedEntityLoader<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,

--- a/packages/entity/src/EntityUpdater.ts
+++ b/packages/entity/src/EntityUpdater.ts
@@ -11,12 +11,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class EntityUpdater<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -28,7 +28,7 @@ export default class EntityUpdater<
     private readonly queryContext: EntityQueryContext,
     private readonly entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -42,7 +42,7 @@ export default class EntityUpdater<
    */
   enforcing(): EnforcingEntityUpdater<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -58,7 +58,7 @@ export default class EntityUpdater<
    */
   withAuthorizationResults(): AuthorizationResultBasedUpdateMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/GenericEntityCacheAdapter.ts
+++ b/packages/entity/src/GenericEntityCacheAdapter.ts
@@ -9,13 +9,15 @@ import { mapKeys } from './utils/collections/maps';
 /**
  * A standard IEntityCacheAdapter that coordinates caching through an IEntityGenericCacher.
  */
-export default class GenericEntityCacheAdapter<TFields extends Record<string, any>>
-  implements IEntityCacheAdapter<TFields>
+export default class GenericEntityCacheAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements IEntityCacheAdapter<TFields, TIDField>
 {
-  constructor(private readonly genericCacher: IEntityGenericCacher<TFields>) {}
+  constructor(private readonly genericCacher: IEntityGenericCacher<TFields, TIDField>) {}
 
   public async loadManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -43,7 +45,7 @@ export default class GenericEntityCacheAdapter<TFields extends Record<string, an
   }
 
   public async cacheManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {
@@ -53,7 +55,7 @@ export default class GenericEntityCacheAdapter<TFields extends Record<string, an
   }
 
   public async cacheDBMissesAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
@@ -63,7 +65,7 @@ export default class GenericEntityCacheAdapter<TFields extends Record<string, an
   }
 
   public async invalidateManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {

--- a/packages/entity/src/GenericSecondaryEntityCache.ts
+++ b/packages/entity/src/GenericSecondaryEntityCache.ts
@@ -12,11 +12,12 @@ import { filterMap, zipToMap } from './utils/collections/maps';
  */
 export default abstract class GenericSecondaryEntityCache<
   TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
   TLoadParams,
 > implements ISecondaryEntityCache<TFields, TLoadParams>
 {
   constructor(
-    protected readonly cacher: IEntityGenericCacher<TFields>,
+    protected readonly cacher: IEntityGenericCacher<TFields, TIDField>,
     protected readonly constructCacheKey: (params: Readonly<TLoadParams>) => string,
   ) {}
 

--- a/packages/entity/src/IEntityCacheAdapter.ts
+++ b/packages/entity/src/IEntityCacheAdapter.ts
@@ -5,7 +5,10 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
  * A cache adapter is an interface by which objects can be
  * cached, fetched from cache, and removed from cache (invalidated).
  */
-export default interface IEntityCacheAdapter<TFields extends Record<string, any>> {
+export default interface IEntityCacheAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
   /**
    * Load many objects from cache.
    * @param key - load key to load
@@ -13,7 +16,7 @@ export default interface IEntityCacheAdapter<TFields extends Record<string, any>
    * @returns map from all load values to a CacheLoadResult for that value
    */
   loadManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -27,7 +30,7 @@ export default interface IEntityCacheAdapter<TFields extends Record<string, any>
    * @param objectMap - map from load value to object to cache for the key
    */
   cacheManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -42,7 +45,7 @@ export default interface IEntityCacheAdapter<TFields extends Record<string, any>
    *                 in the cache and not found in the DB.
    */
   cacheDBMissesAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -56,7 +59,7 @@ export default interface IEntityCacheAdapter<TFields extends Record<string, any>
    * @param values - load values to be invalidated for the key
    */
   invalidateManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(

--- a/packages/entity/src/IEntityCacheAdapterProvider.ts
+++ b/packages/entity/src/IEntityCacheAdapterProvider.ts
@@ -9,7 +9,7 @@ export default interface IEntityCacheAdapterProvider {
   /**
    * Vend a cache adapter for an entity configuration.
    */
-  getCacheAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): IEntityCacheAdapter<TFields>;
+  getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): IEntityCacheAdapter<TFields, TIDField>;
 }

--- a/packages/entity/src/IEntityDatabaseAdapterProvider.ts
+++ b/packages/entity/src/IEntityDatabaseAdapterProvider.ts
@@ -9,7 +9,7 @@ export default interface IEntityDatabaseAdapterProvider {
   /**
    * Vend a database adapter.
    */
-  getDatabaseAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): EntityDatabaseAdapter<TFields>;
+  getDatabaseAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): EntityDatabaseAdapter<TFields, TIDField>;
 }

--- a/packages/entity/src/IEntityGenericCacher.ts
+++ b/packages/entity/src/IEntityGenericCacher.ts
@@ -5,7 +5,10 @@ import { CacheLoadResult } from './internal/ReadThroughEntityCache';
  * A generic cacher stores and loads key-value pairs. It also supports negative caching - it stores the absence
  * of keys that don't exist in the backing datastore. It is also responsible for cache key creation.
  */
-export default interface IEntityGenericCacher<TFields extends Record<string, any>> {
+export default interface IEntityGenericCacher<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
   /**
    * Load many keys from the cache. Return info in a format that is useful for read-through caching and
    * negative caching.
@@ -43,7 +46,7 @@ export default interface IEntityGenericCacher<TFields extends Record<string, any
    * @param value - load value of the cache key
    */
   makeCacheKeyForStorage<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -60,7 +63,7 @@ export default interface IEntityGenericCacher<TFields extends Record<string, any
    * @param values - load values of the cache key
    */
   makeCacheKeysForInvalidation<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -22,12 +22,12 @@ import ViewerContext from './ViewerContext';
  */
 export default abstract class ReadonlyEntity<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   private readonly viewerContext: TViewerContext;
-  private readonly id: TID;
+  private readonly id: TFields[TIDField];
   private readonly databaseFields: Readonly<TFields>;
   private readonly selectedFields: Readonly<Pick<TFields, TSelectedFields>>;
 
@@ -52,7 +52,7 @@ export default abstract class ReadonlyEntity<
     selectedFields,
   }: {
     viewerContext: TViewerContext;
-    id: TID;
+    id: TFields[TIDField];
     databaseFields: Readonly<TFields>;
     selectedFields: Readonly<Pick<TFields, TSelectedFields>>;
   }) {
@@ -82,7 +82,7 @@ export default abstract class ReadonlyEntity<
   /**
    * @returns the ID of this entity
    */
-  getID(): TID {
+  getID(): TFields[TIDField] {
     return this.id;
   }
 
@@ -91,8 +91,8 @@ export default abstract class ReadonlyEntity<
    */
   associationLoader(
     queryContext?: EntityQueryContext,
-  ): EnforcingEntityAssociationLoader<TFields, TID, TViewerContext, this, TSelectedFields> {
-    return new EntityAssociationLoader<TFields, TID, TViewerContext, this, TSelectedFields>(
+  ): EnforcingEntityAssociationLoader<TFields, TIDField, TViewerContext, this, TSelectedFields> {
+    return new EntityAssociationLoader<TFields, TIDField, TViewerContext, this, TSelectedFields>(
       this,
       queryContext,
     ).enforcing();
@@ -105,12 +105,12 @@ export default abstract class ReadonlyEntity<
     queryContext?: EntityQueryContext,
   ): AuthorizationResultBasedEntityAssociationLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     this,
     TSelectedFields
   > {
-    return new EntityAssociationLoader<TFields, TID, TViewerContext, this, TSelectedFields>(
+    return new EntityAssociationLoader<TFields, TIDField, TViewerContext, this, TSelectedFields>(
       this,
       queryContext,
     ).withAuthorizationResults();
@@ -148,13 +148,13 @@ export default abstract class ReadonlyEntity<
    */
   static loader<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -163,7 +163,7 @@ export default abstract class ReadonlyEntity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -176,7 +176,7 @@ export default abstract class ReadonlyEntity<
       .getQueryContext(),
   ): EnforcingEntityLoader<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -192,13 +192,13 @@ export default abstract class ReadonlyEntity<
    */
   static loaderWithAuthorizationResults<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -207,7 +207,7 @@ export default abstract class ReadonlyEntity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -220,7 +220,7 @@ export default abstract class ReadonlyEntity<
       .getQueryContext(),
   ): AuthorizationResultBasedEntityLoader<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,
@@ -236,13 +236,13 @@ export default abstract class ReadonlyEntity<
    */
   static loaderUtils<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
     TMViewerContext2 extends TMViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -251,7 +251,7 @@ export default abstract class ReadonlyEntity<
   >(
     this: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -264,7 +264,7 @@ export default abstract class ReadonlyEntity<
       .getQueryContext(),
   ): EntityLoaderUtils<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -32,12 +32,12 @@ export default class ViewerContext {
 
   getViewerScopedEntityCompanionForClass<
     TMFields extends object,
-    TMID extends NonNullable<TMFields[TMSelectedFields]>,
+    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMID, TMViewerContext, TMSelectedFields>,
+    TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMSelectedFields
@@ -46,7 +46,7 @@ export default class ViewerContext {
   >(
     entityClass: IEntityClass<
       TMFields,
-      TMID,
+      TMIDField,
       TMViewerContext,
       TMEntity,
       TMPrivacyPolicy,
@@ -54,7 +54,7 @@ export default class ViewerContext {
     >,
   ): ViewerScopedEntityCompanion<
     TMFields,
-    TMID,
+    TMIDField,
     TMViewerContext,
     TMEntity,
     TMPrivacyPolicy,

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -13,12 +13,12 @@ import IEntityMetricsAdapter from './metrics/IEntityMetricsAdapter';
  */
 export default class ViewerScopedEntityCompanion<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -28,7 +28,7 @@ export default class ViewerScopedEntityCompanion<
   constructor(
     public readonly entityCompanion: EntityCompanion<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -42,7 +42,7 @@ export default class ViewerScopedEntityCompanion<
    */
   getLoaderFactory(): ViewerScopedEntityLoaderFactory<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -59,7 +59,7 @@ export default class ViewerScopedEntityCompanion<
    */
   getMutatorFactory(): ViewerScopedEntityMutatorFactory<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -22,12 +22,12 @@ export default class ViewerScopedEntityCompanionProvider {
    */
   getViewerScopedCompanionForEntity<
     TFields extends Record<string, any>,
-    TID extends NonNullable<TFields[TSelectedFields]>,
+    TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
     TViewerContext extends ViewerContext,
-    TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+    TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
     TPrivacyPolicy extends EntityPrivacyPolicy<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
@@ -36,7 +36,7 @@ export default class ViewerScopedEntityCompanionProvider {
   >(
     entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -44,7 +44,7 @@ export default class ViewerScopedEntityCompanionProvider {
     >,
   ): ViewerScopedEntityCompanion<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -10,12 +10,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class ViewerScopedEntityLoaderFactory<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -25,7 +25,7 @@ export default class ViewerScopedEntityLoaderFactory<
   constructor(
     private readonly entityLoaderFactory: EntityLoaderFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -38,14 +38,14 @@ export default class ViewerScopedEntityLoaderFactory<
     queryContext: EntityQueryContext,
     privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields
     >,
   ): AuthorizationResultBasedEntityLoader<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -14,12 +14,12 @@ import ViewerContext from './ViewerContext';
  */
 export default class ViewerScopedEntityMutatorFactory<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -29,7 +29,7 @@ export default class ViewerScopedEntityMutatorFactory<
   constructor(
     private readonly entityMutatorFactory: EntityMutatorFactory<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
@@ -42,7 +42,7 @@ export default class ViewerScopedEntityMutatorFactory<
     queryContext: EntityQueryContext,
   ): AuthorizationResultBasedCreateMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -56,7 +56,7 @@ export default class ViewerScopedEntityMutatorFactory<
     queryContext: EntityQueryContext,
   ): AuthorizationResultBasedUpdateMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,
@@ -70,7 +70,7 @@ export default class ViewerScopedEntityMutatorFactory<
     queryContext: EntityQueryContext,
   ): AuthorizationResultBasedDeleteMutator<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TPrivacyPolicy,

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
@@ -22,12 +22,13 @@ export type TestFields = {
 
 export type TestFieldSelection = keyof TestFields;
 
-export const testEntityConfiguration = new EntityConfiguration<TestFields>({
+export const testEntityConfiguration = new EntityConfiguration<TestFields, 'id'>({
   idField: 'id',
   tableName: 'test_entity_should_not_write_to_db',
   schema: {
     id: new StringField({
       columnName: 'id',
+      cache: false,
     }),
   },
   databaseAdapterFlavor: 'postgres',
@@ -36,7 +37,7 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields>({
 
 export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   TestFields,
-  string,
+  'id',
   ViewerContext,
   TestEntity,
   TestFieldSelection
@@ -44,7 +45,7 @@ export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestFields,
-      string,
+      'id',
       ViewerContext,
       TestEntity,
       TestFieldSelection
@@ -53,7 +54,7 @@ export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestFields,
-      string,
+      'id',
       ViewerContext,
       TestEntity,
       TestFieldSelection
@@ -62,7 +63,7 @@ export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestFields,
-      string,
+      'id',
       ViewerContext,
       TestEntity,
       TestFieldSelection
@@ -71,7 +72,7 @@ export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestFields,
-      string,
+      'id',
       ViewerContext,
       TestEntity,
       TestFieldSelection
@@ -84,7 +85,7 @@ const ID_SENTINEL_THROW_ERROR = 'throw_error';
 
 export default class TestEntity extends Entity<
   TestFields,
-  string,
+  'id',
   ViewerContext,
   TestFieldSelection
 > {
@@ -105,7 +106,7 @@ export default class TestEntity extends Entity<
 
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy,
@@ -127,7 +128,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
         mock<
           EntityPrivacyPolicyEvaluationContext<
             TestFields,
-            string,
+            'id',
             ViewerContext,
             TestEntity,
             TestFieldSelection
@@ -137,7 +138,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
 
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'id'>(
       testEntityConfiguration,
       StubDatabaseAdapter.convertFieldObjectsToDataStore(
         testEntityConfiguration,

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -34,14 +34,21 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
 
     const id1 = uuidv4();
     const id2 = uuidv4();
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
       testEntityConfiguration,
       StubDatabaseAdapter.convertFieldObjectsToDataStore(
         testEntityConfiguration,
@@ -153,7 +160,14 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
@@ -162,7 +176,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const id2 = uuidv4();
     const id3 = uuidv4();
     const id4 = uuidv4();
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
       testEntityConfiguration,
       StubDatabaseAdapter.convertFieldObjectsToDataStore(
         testEntityConfiguration,
@@ -312,7 +326,14 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
@@ -320,7 +341,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const id1 = uuidv4();
     const id2 = uuidv4();
     const id3 = uuidv4();
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
       testEntityConfiguration,
       StubDatabaseAdapter.convertFieldObjectsToDataStore(
         testEntityConfiguration,
@@ -422,7 +443,14 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
@@ -430,7 +458,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const id1 = uuidv4();
     const id2 = uuidv4();
     const id3 = uuidv4();
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
       testEntityConfiguration,
       StubDatabaseAdapter.convertFieldObjectsToDataStore(
         testEntityConfiguration,
@@ -529,12 +557,19 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
 
-    const dataManagerMock = mock<EntityDataManager<TestFields>>(EntityDataManager);
+    const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>(EntityDataManager);
     when(
       dataManagerMock.loadManyByRawWhereClauseAsync(
         queryContext,
@@ -597,13 +632,20 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
 
     const id1 = uuidv4();
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
       testEntityConfiguration,
       StubDatabaseAdapter.convertFieldObjectsToDataStore(
         testEntityConfiguration,
@@ -669,12 +711,19 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock<EntityDataManager<TestFields>>();
+    const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
     const dataManagerInstance = instance(dataManagerMock);
 
     const id1 = uuidv4();
@@ -714,23 +763,25 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       dataManagerMock.invalidateKeyValuePairsAsync(
         deepEqualEntityAware([
           [
-            new SingleFieldHolder<TestFields, 'customIdField'>('customIdField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
             new SingleFieldValueHolder<TestFields, 'customIdField'>(id1),
           ],
           [
-            new SingleFieldHolder<TestFields, 'testIndexedField'>('testIndexedField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+              'testIndexedField',
+            ),
             new SingleFieldValueHolder<TestFields, 'testIndexedField'>('h1'),
           ],
           [
-            new SingleFieldHolder<TestFields, 'intField'>('intField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'intField'>('intField'),
             new SingleFieldValueHolder<TestFields, 'intField'>(5),
           ],
           [
-            new SingleFieldHolder<TestFields, 'stringField'>('stringField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
             new SingleFieldValueHolder<TestFields, 'stringField'>('huh'),
           ],
           [
-            new SingleFieldHolder<TestFields, 'dateField'>('dateField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'dateField'>('dateField'),
             new SingleFieldValueHolder<TestFields, 'dateField'>(date),
           ],
           [
@@ -750,12 +801,19 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock<EntityDataManager<TestFields>>();
+    const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
     const dataManagerInstance = instance(dataManagerMock);
 
     const id1 = uuidv4();
@@ -798,23 +856,25 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       dataManagerMock.invalidateKeyValuePairsAsync(
         deepEqualEntityAware([
           [
-            new SingleFieldHolder<TestFields, 'customIdField'>('customIdField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
             new SingleFieldValueHolder<TestFields, 'customIdField'>(id1),
           ],
           [
-            new SingleFieldHolder<TestFields, 'testIndexedField'>('testIndexedField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+              'testIndexedField',
+            ),
             new SingleFieldValueHolder<TestFields, 'testIndexedField'>('h1'),
           ],
           [
-            new SingleFieldHolder<TestFields, 'intField'>('intField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'intField'>('intField'),
             new SingleFieldValueHolder<TestFields, 'intField'>(5),
           ],
           [
-            new SingleFieldHolder<TestFields, 'stringField'>('stringField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
             new SingleFieldValueHolder<TestFields, 'stringField'>('huh'),
           ],
           [
-            new SingleFieldHolder<TestFields, 'dateField'>('dateField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'dateField'>('dateField'),
             new SingleFieldValueHolder<TestFields, 'dateField'>(date),
           ],
           [
@@ -834,12 +894,19 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
     const privacyPolicyMock = mock(TestEntityPrivacyPolicy);
-    const dataManagerMock = mock<EntityDataManager<TestFields>>();
+    const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
 
     const id1 = uuidv4();
     when(dataManagerMock.loadManyEqualingAsync(anything(), anything(), anything())).thenResolve(
@@ -904,12 +971,19 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const viewerContext = instance(mock(ViewerContext));
     const privacyPolicyEvaluationContext =
       instance(
-        mock<EntityPrivacyPolicyEvaluationContext<TestFields, string, ViewerContext, TestEntity>>(),
+        mock<
+          EntityPrivacyPolicyEvaluationContext<
+            TestFields,
+            'customIdField',
+            ViewerContext,
+            TestEntity
+          >
+        >(),
       );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
     const queryContext = new StubQueryContextProvider().getQueryContext();
     const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
-    const dataManagerMock = mock<EntityDataManager<TestFields>>();
+    const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
 
     const error = new Error();
 

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -33,17 +33,17 @@ type BlahFields = {
   ownerID: string;
 };
 
-class BlahEntity extends Entity<BlahFields, string, TestUserViewerContext> {
+class BlahEntity extends Entity<BlahFields, 'id', TestUserViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
-    string,
+    'id',
     TestUserViewerContext,
     BlahEntity,
     BlahEntityPrivacyPolicy
   > {
     return {
       entityClass: BlahEntity,
-      entityConfiguration: new EntityConfiguration<BlahFields>({
+      entityConfiguration: new EntityConfiguration<BlahFields, 'id'>({
         idField: 'id',
         tableName: 'blah_table',
         schema: {
@@ -65,7 +65,7 @@ class BlahEntity extends Entity<BlahFields, string, TestUserViewerContext> {
 
 class DenyIfNotOwnerPrivacyPolicyRule extends PrivacyPolicyRule<
   BlahFields,
-  string,
+  'id',
   TestUserViewerContext,
   BlahEntity
 > {
@@ -74,7 +74,7 @@ class DenyIfNotOwnerPrivacyPolicyRule extends PrivacyPolicyRule<
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext<
       BlahFields,
-      string,
+      'id',
       TestUserViewerContext,
       BlahEntity
     >,
@@ -89,24 +89,24 @@ class DenyIfNotOwnerPrivacyPolicyRule extends PrivacyPolicyRule<
 
 class BlahEntityPrivacyPolicy extends EntityPrivacyPolicy<
   BlahFields,
-  string,
+  'id',
   ViewerContext,
   BlahEntity
 > {
   protected override readonly createRules = [
     new DenyIfNotOwnerPrivacyPolicyRule(),
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly readRules = [
     new DenyIfNotOwnerPrivacyPolicyRule(),
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly updateRules = [
     new DenyIfNotOwnerPrivacyPolicyRule(),
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysDenyPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysDenyPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
 }
 

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -19,7 +19,7 @@ describe(EntityCompanion, () => {
   it('correctly instantiates mutator and loader factories', () => {
     const entityCompanionProvider = instance(mock<EntityCompanionProvider>());
 
-    const tableDataCoordinatorMock = mock<EntityTableDataCoordinator<TestMTFields>>();
+    const tableDataCoordinatorMock = mock<EntityTableDataCoordinator<TestMTFields, 'id'>>();
     when(tableDataCoordinatorMock.entityConfiguration).thenReturn(testEntityMTConfiguration);
 
     const companion = new EntityCompanion(
@@ -35,7 +35,7 @@ describe(EntityCompanion, () => {
   it('correctly merges local and global mutation triggers', () => {
     const globalMutationTriggers: EntityMutationTriggerConfiguration<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers,
       keyof TestMTFields
@@ -53,7 +53,7 @@ describe(EntityCompanion, () => {
       globalMutationTriggers,
     );
 
-    const tableDataCoordinatorMock = mock<EntityTableDataCoordinator<TestMTFields>>();
+    const tableDataCoordinatorMock = mock<EntityTableDataCoordinator<TestMTFields, 'id'>>();
     when(tableDataCoordinatorMock.entityConfiguration).thenReturn(testEntityMTConfiguration);
 
     const companion = new EntityCompanion(

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -10,7 +10,7 @@ type BlahFields = {
   hello: string;
 };
 
-const blahConfiguration = new EntityConfiguration<BlahFields>({
+const blahConfiguration = new EntityConfiguration<BlahFields, 'hello'>({
   idField: 'hello',
   tableName: 'wat',
   schema: {
@@ -22,10 +22,10 @@ const blahConfiguration = new EntityConfiguration<BlahFields>({
   cacheAdapterFlavor: 'redis',
 });
 
-class Blah1Entity extends Entity<BlahFields, string, ViewerContext> {
+class Blah1Entity extends Entity<BlahFields, 'hello', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
-    string,
+    'hello',
     ViewerContext,
     Blah1Entity,
     NoOpTest1PrivacyPolicy
@@ -38,10 +38,10 @@ class Blah1Entity extends Entity<BlahFields, string, ViewerContext> {
   }
 }
 
-class Blah2Entity extends Entity<BlahFields, string, ViewerContext> {
+class Blah2Entity extends Entity<BlahFields, 'hello', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
-    string,
+    'hello',
     ViewerContext,
     Blah2Entity,
     NoOpTest2PrivacyPolicy
@@ -56,13 +56,13 @@ class Blah2Entity extends Entity<BlahFields, string, ViewerContext> {
 
 class NoOpTest1PrivacyPolicy extends EntityPrivacyPolicy<
   BlahFields,
-  string,
+  'hello',
   ViewerContext,
   Blah1Entity
 > {}
 class NoOpTest2PrivacyPolicy extends EntityPrivacyPolicy<
   BlahFields,
-  string,
+  'hello',
   ViewerContext,
   Blah2Entity
 > {}

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -1,5 +1,5 @@
 import EntityConfiguration from '../EntityConfiguration';
-import { UUIDField, StringField } from '../EntityFields';
+import { StringField, UUIDField } from '../EntityFields';
 import { CompositeFieldHolder } from '../internal/CompositeFieldHolder';
 
 describe(EntityConfiguration, () => {
@@ -14,7 +14,7 @@ describe(EntityConfiguration, () => {
       id: string;
     };
 
-    const blahEntityConfiguration = new EntityConfiguration<BlahT>({
+    const blahEntityConfiguration = new EntityConfiguration<BlahT, 'id'>({
       idField: 'id',
       tableName: 'blah_table',
       schema: {
@@ -71,7 +71,7 @@ describe(EntityConfiguration, () => {
     it('validates composite fields', () => {
       expect(
         () =>
-          new EntityConfiguration<BlahT>({
+          new EntityConfiguration<BlahT, 'id'>({
             idField: 'id',
             tableName: 'blah_table',
             schema: {
@@ -94,7 +94,7 @@ describe(EntityConfiguration, () => {
 
       expect(
         () =>
-          new EntityConfiguration<BlahT>({
+          new EntityConfiguration<BlahT, 'id'>({
             idField: 'id',
             tableName: 'blah_table',
             schema: {
@@ -118,7 +118,7 @@ describe(EntityConfiguration, () => {
 
     describe('cache key version', () => {
       it('defaults to 0', () => {
-        const entityConfiguration = new EntityConfiguration<Blah2T>({
+        const entityConfiguration = new EntityConfiguration<Blah2T, 'id'>({
           idField: 'id',
           tableName: 'blah',
           schema: {
@@ -133,7 +133,7 @@ describe(EntityConfiguration, () => {
       });
 
       it('sets to custom version', () => {
-        const entityConfiguration = new EntityConfiguration<Blah2T>({
+        const entityConfiguration = new EntityConfiguration<Blah2T, 'id'>({
           idField: 'id',
           tableName: 'blah',
           schema: {
@@ -168,7 +168,7 @@ describe(EntityConfiguration, () => {
       ])('disallows %p as field key', (keyName) => {
         expect(
           () =>
-            new EntityConfiguration<any>({
+            new EntityConfiguration<any, 'id'>({
               idField: 'id',
               tableName: 'blah_table',
               schema: {

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -10,7 +10,7 @@ import { FieldTransformerMap } from '../internal/EntityFieldTransformationUtils'
 import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
 import { TestFields, testEntityConfiguration } from '../testfixtures/TestEntity';
 
-class TestEntityDatabaseAdapter extends EntityDatabaseAdapter<TestFields> {
+class TestEntityDatabaseAdapter extends EntityDatabaseAdapter<TestFields, 'customIdField'> {
   private readonly fetchResults: object[];
   private readonly insertResults: object[];
   private readonly updateResults: object[];
@@ -138,7 +138,7 @@ describe(EntityDatabaseAdapter, () => {
       });
       const result = await adapter.fetchManyWhereAsync(
         queryContext,
-        new CompositeFieldHolder<TestFields>(['intField', 'stringField']),
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['intField', 'stringField']),
         [
           new CompositeFieldValueHolder({ intField: 1, stringField: 'hello' }),
           new CompositeFieldValueHolder({ intField: 2, stringField: 'wat' }),
@@ -203,7 +203,7 @@ describe(EntityDatabaseAdapter, () => {
       await expect(
         adapter.fetchManyWhereAsync(
           queryContext,
-          new CompositeFieldHolder<TestFields>(['intField', 'stringField']),
+          new CompositeFieldHolder<TestFields, 'customIdField'>(['intField', 'stringField']),
           [new CompositeFieldValueHolder({ intField: 1, stringField: 'hello' })],
         ),
       ).rejects.toThrow(
@@ -219,7 +219,7 @@ describe(EntityDatabaseAdapter, () => {
       await expect(
         adapter.fetchManyWhereAsync(
           queryContext,
-          new CompositeFieldHolder<TestFields>(['intField', 'stringField']),
+          new CompositeFieldHolder<TestFields, 'customIdField'>(['intField', 'stringField']),
           [new CompositeFieldValueHolder({ intField: 1, stringField: 'hello' })],
         ),
       ).rejects.toThrow(

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -74,7 +74,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class AlwaysAllowPrivacyPolicyRuleThatRecords extends PrivacyPolicyRule<
     any,
-    string,
+    'id',
     TestViewerContext,
     any,
     any
@@ -88,7 +88,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _queryContext: EntityQueryContext,
       evaluationContext: EntityPrivacyPolicyEvaluationContext<
         any,
-        string,
+        'id',
         TestViewerContext,
         any,
         any
@@ -106,7 +106,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
     any,
-    string,
+    'id',
     TestViewerContext,
     any,
     any
@@ -127,7 +127,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class ParentCheckInfoDeletionTrigger extends EntityMutationTrigger<
     ParentFields,
-    string,
+    'id',
     TestViewerContext,
     ParentEntity
   > {
@@ -135,12 +135,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _viewerContext: TestViewerContext,
       _queryContext: EntityTransactionalQueryContext,
       _entity: ParentEntity,
-      mutationInfo: EntityTriggerMutationInfo<
-        ParentFields,
-        string,
-        TestViewerContext,
-        ParentEntity
-      >,
+      mutationInfo: EntityTriggerMutationInfo<ParentFields, 'id', TestViewerContext, ParentEntity>,
     ): Promise<void> {
       invariant(mutationInfo.type === EntityMutationType.DELETE, 'invalid EntityMutationType');
       if (mutationInfo.cascadingDeleteCause !== null) {
@@ -153,7 +148,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class ParentCheckInfoUpdateTrigger extends EntityMutationTrigger<
     ParentFields,
-    string,
+    'id',
     TestViewerContext,
     ParentEntity
   > {
@@ -161,12 +156,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _viewerContext: TestViewerContext,
       _queryContext: EntityTransactionalQueryContext,
       _entity: ParentEntity,
-      mutationInfo: EntityTriggerMutationInfo<
-        ParentFields,
-        string,
-        TestViewerContext,
-        ParentEntity
-      >,
+      mutationInfo: EntityTriggerMutationInfo<ParentFields, 'id', TestViewerContext, ParentEntity>,
     ): Promise<void> {
       invariant(mutationInfo.type === EntityMutationType.UPDATE, 'invalid EntityMutationType');
       if (mutationInfo.cascadingDeleteCause !== null) {
@@ -179,7 +169,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class ChildCheckInfoDeletionTrigger extends EntityMutationTrigger<
     ChildFields,
-    string,
+    'id',
     TestViewerContext,
     ChildEntity
   > {
@@ -187,7 +177,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _viewerContext: TestViewerContext,
       _queryContext: EntityTransactionalQueryContext,
       _entity: ChildEntity,
-      mutationInfo: EntityTriggerMutationInfo<ChildFields, string, TestViewerContext, ChildEntity>,
+      mutationInfo: EntityTriggerMutationInfo<ChildFields, 'id', TestViewerContext, ChildEntity>,
     ): Promise<void> {
       invariant(mutationInfo.type === EntityMutationType.DELETE, 'invalid EntityMutationType');
       if (mutationInfo.cascadingDeleteCause === null) {
@@ -211,7 +201,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class ChildCheckInfoUpdateTrigger extends EntityMutationTrigger<
     ChildFields,
-    string,
+    'id',
     TestViewerContext,
     ChildEntity
   > {
@@ -219,7 +209,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _viewerContext: TestViewerContext,
       _queryContext: EntityTransactionalQueryContext,
       _entity: ChildEntity,
-      mutationInfo: EntityTriggerMutationInfo<ChildFields, string, TestViewerContext, ChildEntity>,
+      mutationInfo: EntityTriggerMutationInfo<ChildFields, 'id', TestViewerContext, ChildEntity>,
     ): Promise<void> {
       invariant(mutationInfo.type === EntityMutationType.UPDATE, 'invalid EntityMutationType');
       if (mutationInfo.cascadingDeleteCause === null) {
@@ -243,7 +233,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class GrandChildCheckInfoDeletionTrigger extends EntityMutationTrigger<
     GrandChildFields,
-    string,
+    'id',
     TestViewerContext,
     GrandChildEntity
   > {
@@ -253,7 +243,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _entity: GrandChildEntity,
       mutationInfo: EntityTriggerMutationInfo<
         GrandChildFields,
-        string,
+        'id',
         TestViewerContext,
         GrandChildEntity
       >,
@@ -294,7 +284,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
 
   class GrandChildCheckInfoUpdateTrigger extends EntityMutationTrigger<
     GrandChildFields,
-    string,
+    'id',
     TestViewerContext,
     GrandChildEntity
   > {
@@ -304,7 +294,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
       _entity: GrandChildEntity,
       mutationInfo: EntityTriggerMutationInfo<
         GrandChildFields,
-        string,
+        'id',
         TestViewerContext,
         GrandChildEntity
       >,
@@ -343,10 +333,10 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     }
   }
 
-  class OtherEntity extends Entity<OtherFields, string, TestViewerContext> {
+  class OtherEntity extends Entity<OtherFields, 'id', TestViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       OtherFields,
-      string,
+      'id',
       TestViewerContext,
       OtherEntity,
       TestEntityPrivacyPolicy
@@ -359,10 +349,10 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     }
   }
 
-  class ParentEntity extends Entity<ParentFields, string, TestViewerContext> {
+  class ParentEntity extends Entity<ParentFields, 'id', TestViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       ParentFields,
-      string,
+      'id',
       TestViewerContext,
       ParentEntity,
       TestEntityPrivacyPolicy
@@ -382,10 +372,10 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     }
   }
 
-  class ChildEntity extends Entity<ChildFields, string, TestViewerContext> {
+  class ChildEntity extends Entity<ChildFields, 'id', TestViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       ChildFields,
-      string,
+      'id',
       TestViewerContext,
       ChildEntity,
       TestEntityPrivacyPolicy
@@ -405,10 +395,10 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     }
   }
 
-  class GrandChildEntity extends Entity<GrandChildFields, string, TestViewerContext> {
+  class GrandChildEntity extends Entity<GrandChildFields, 'id', TestViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       GrandChildFields,
-      string,
+      'id',
       TestViewerContext,
       GrandChildEntity,
       TestEntityPrivacyPolicy
@@ -428,7 +418,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     }
   }
 
-  const otherEntityConfiguration = new EntityConfiguration<OtherFields>({
+  const otherEntityConfiguration = new EntityConfiguration<OtherFields, 'id'>({
     idField: 'id',
     tableName: 'others',
     schema: {
@@ -441,7 +431,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     cacheAdapterFlavor: 'redis',
   });
 
-  const parentEntityConfiguration = new EntityConfiguration<ParentFields>({
+  const parentEntityConfiguration = new EntityConfiguration<ParentFields, 'id'>({
     idField: 'id',
     tableName: 'parents',
     inboundEdges: [ChildEntity],
@@ -455,7 +445,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     cacheAdapterFlavor: 'redis',
   });
 
-  const childEntityConfiguration = new EntityConfiguration<ChildFields>({
+  const childEntityConfiguration = new EntityConfiguration<ChildFields, 'id'>({
     idField: 'id',
     tableName: 'children',
     inboundEdges: [GrandChildEntity],
@@ -485,7 +475,7 @@ const makeEntityClasses = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => 
     cacheAdapterFlavor: 'redis',
   });
 
-  const grandChildEntityConfiguration = new EntityConfiguration<GrandChildFields>({
+  const grandChildEntityConfiguration = new EntityConfiguration<GrandChildFields, 'id'>({
     idField: 'id',
     tableName: 'grandchildren',
     schema: {
@@ -775,7 +765,10 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
 
       const childCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
         'entityCompanion'
-      ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
+      ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<
+        ChildFields,
+        'id'
+      >;
       const childCachedBefore = await childCacheAdapter.loadManyAsync(
         new SingleFieldHolder('parent_id'),
         [new SingleFieldValueHolder(parent.getID())],
@@ -788,7 +781,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         GrandChildEntity,
       )['entityCompanion']['tableDataCoordinator'][
         'cacheAdapter'
-      ] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
+      ] as InMemoryFullCacheStubCacheAdapter<ChildFields, 'id'>;
       const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync(
         new SingleFieldHolder('parent_id'),
         [new SingleFieldValueHolder(child.getID())],
@@ -922,7 +915,10 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
 
       const childCacheAdapter = viewerContext.getViewerScopedEntityCompanionForClass(ChildEntity)[
         'entityCompanion'
-      ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
+      ]['tableDataCoordinator']['cacheAdapter'] as InMemoryFullCacheStubCacheAdapter<
+        ChildFields,
+        'id'
+      >;
       const childCachedBefore = await childCacheAdapter.loadManyAsync(
         new SingleFieldHolder('parent_id'),
         [new SingleFieldValueHolder(parent.getID())],
@@ -935,7 +931,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         GrandChildEntity,
       )['entityCompanion']['tableDataCoordinator'][
         'cacheAdapter'
-      ] as InMemoryFullCacheStubCacheAdapter<ChildFields>;
+      ] as InMemoryFullCacheStubCacheAdapter<ChildFields, 'id'>;
       const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync(
         new SingleFieldHolder('parent_id'),
         [new SingleFieldValueHolder(child.getID())],

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -16,35 +16,35 @@ type BlahFields = {
 
 class BlahEntityPrivacyPolicy extends EntityPrivacyPolicy<
   BlahFields,
-  string,
+  'id',
   ViewerContext,
   BlahEntity
 > {
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
 }
 
-class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
+class BlahEntity extends Entity<BlahFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity,
     BlahEntityPrivacyPolicy
   > {
     return {
       entityClass: BlahEntity,
-      entityConfiguration: new EntityConfiguration<BlahFields>({
+      entityConfiguration: new EntityConfiguration<BlahFields, 'id'>({
         idField: 'id',
         tableName: 'blah_table',
         schema: {
@@ -66,14 +66,14 @@ class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
 
 class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutationTrigger<
   BlahFields,
-  string,
+  'id',
   ViewerContext,
   BlahEntity
 > {
   async executeAsync(
     viewerContext: ViewerContext,
     entity: BlahEntity,
-    mutationInfo: EntityTriggerMutationInfo<BlahFields, string, ViewerContext, BlahEntity>,
+    mutationInfo: EntityTriggerMutationInfo<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): Promise<void> {
     if (mutationInfo.type === EntityMutationType.DELETE) {
       const entityLoaded = await BlahEntity.loader(viewerContext).loadByIDNullableAsync(

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -54,7 +54,7 @@ import StubQueryContextProvider from '../utils/testing/StubQueryContextProvider'
 
 class TestMutationTrigger extends EntityMutationTrigger<
   TestFields,
-  string,
+  'customIdField',
   ViewerContext,
   TestEntity,
   keyof TestFields
@@ -65,7 +65,7 @@ class TestMutationTrigger extends EntityMutationTrigger<
     _entity: TestEntity,
     _mutationInfo: EntityTriggerMutationInfo<
       TestFields,
-      string,
+      'customIdField',
       ViewerContext,
       TestEntity,
       keyof TestFields
@@ -75,7 +75,7 @@ class TestMutationTrigger extends EntityMutationTrigger<
 
 class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutationTrigger<
   TestFields,
-  string,
+  'customIdField',
   ViewerContext,
   TestEntity,
   keyof TestFields
@@ -86,12 +86,18 @@ class TestNonTransactionalMutationTrigger extends EntityNonTransactionalMutation
 const setUpMutationValidatorSpies = (
   mutationValidators: EntityMutationValidator<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
   >[],
-): EntityMutationValidator<TestFields, string, ViewerContext, TestEntity, keyof TestFields>[] => {
+): EntityMutationValidator<
+  TestFields,
+  'customIdField',
+  ViewerContext,
+  TestEntity,
+  keyof TestFields
+>[] => {
   return mutationValidators.map((validator) => spy(validator));
 };
 
@@ -99,7 +105,7 @@ const verifyValidatorCounts = (
   viewerContext: ViewerContext,
   mutationValidatorSpies: EntityMutationValidator<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
@@ -107,7 +113,7 @@ const verifyValidatorCounts = (
   expectedCalls: number,
   mutationInfo: EntityValidatorMutationInfo<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
@@ -128,14 +134,14 @@ const verifyValidatorCounts = (
 const setUpMutationTriggerSpies = (
   mutationTriggers: EntityMutationTriggerConfiguration<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
   >,
 ): EntityMutationTriggerConfiguration<
   TestFields,
-  string,
+  'customIdField',
   ViewerContext,
   TestEntity,
   keyof TestFields
@@ -157,7 +163,7 @@ const verifyTriggerCounts = (
   viewerContext: ViewerContext,
   mutationTriggerSpies: EntityMutationTriggerConfiguration<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
@@ -166,7 +172,7 @@ const verifyTriggerCounts = (
     keyof Pick<
       EntityMutationTriggerConfiguration<
         TestFields,
-        string,
+        'customIdField',
         ViewerContext,
         TestEntity,
         keyof TestFields
@@ -182,7 +188,7 @@ const verifyTriggerCounts = (
   >,
   mutationInfo: EntityTriggerMutationInfo<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
@@ -243,7 +249,7 @@ const createEntityMutatorFactory = (
   privacyPolicy: TestEntityPrivacyPolicy;
   entityLoaderFactory: EntityLoaderFactory<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy,
@@ -251,7 +257,7 @@ const createEntityMutatorFactory = (
   >;
   entityMutatorFactory: EntityMutatorFactory<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy
@@ -259,14 +265,14 @@ const createEntityMutatorFactory = (
   metricsAdapter: IEntityMetricsAdapter;
   mutationValidators: EntityMutationValidator<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
   >[];
   mutationTriggers: EntityMutationTriggerConfiguration<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
@@ -274,14 +280,14 @@ const createEntityMutatorFactory = (
 } => {
   const mutationValidators: EntityMutationValidator<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
   >[] = [new TestMutationTrigger()];
   const mutationTriggers: EntityMutationTriggerConfiguration<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     keyof TestFields
@@ -296,7 +302,7 @@ const createEntityMutatorFactory = (
     afterAll: [new TestMutationTrigger()],
     afterCommit: [new TestNonTransactionalMutationTrigger()],
   };
-  const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+  const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
     testEntityConfiguration,
     StubDatabaseAdapter.convertFieldObjectsToDataStore(
       testEntityConfiguration,
@@ -304,16 +310,19 @@ const createEntityMutatorFactory = (
     ),
   );
   const customStubDatabaseAdapterProvider: IEntityDatabaseAdapterProvider = {
-    getDatabaseAdapter<TFields extends Record<string, any>>(
-      _entityConfiguration: EntityConfiguration<TFields>,
-    ): EntityDatabaseAdapter<TFields> {
-      return databaseAdapter as any as EntityDatabaseAdapter<TFields>;
+    getDatabaseAdapter<TFields extends Record<'customIdField', any>>(
+      _entityConfiguration: EntityConfiguration<TFields, 'customIdField'>,
+    ): EntityDatabaseAdapter<TFields, 'customIdField'> {
+      return databaseAdapter as any as EntityDatabaseAdapter<TFields, 'customIdField'>;
     },
   };
   const metricsAdapter = new NoOpEntityMetricsAdapter();
   const cacheAdapterProvider = new NoCacheStubCacheAdapterProvider();
   const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
-  const entityCache = new ReadThroughEntityCache<TestFields>(testEntityConfiguration, cacheAdapter);
+  const entityCache = new ReadThroughEntityCache<TestFields, 'customIdField'>(
+    testEntityConfiguration,
+    cacheAdapter,
+  );
 
   const queryContextProvider = new StubQueryContextProvider();
   const companionProvider = new EntityCompanionProvider(
@@ -545,7 +554,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -669,7 +678,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -741,7 +750,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -801,7 +810,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -854,7 +863,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -902,7 +911,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -954,7 +963,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -1010,7 +1019,7 @@ describe(EntityMutatorFactory, () => {
           mock<
             EntityPrivacyPolicyEvaluationContext<
               TestFields,
-              string,
+              'customIdField',
               ViewerContext,
               TestEntity,
               keyof TestFields
@@ -1057,7 +1066,7 @@ describe(EntityMutatorFactory, () => {
         mock<
           EntityPrivacyPolicyEvaluationContext<
             TestFields,
-            string,
+            'customIdField',
             ViewerContext,
             TestEntity,
             keyof TestFields
@@ -1161,7 +1170,7 @@ describe(EntityMutatorFactory, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = new StubQueryContextProvider().getQueryContext();
     const privacyPolicyMock = mock(SimpleTestEntityPrivacyPolicy);
-    const databaseAdapter = instance(mock<EntityDatabaseAdapter<SimpleTestFields>>());
+    const databaseAdapter = instance(mock<EntityDatabaseAdapter<SimpleTestFields, 'id'>>());
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
 
     const id1 = uuidv4();
@@ -1179,7 +1188,7 @@ describe(EntityMutatorFactory, () => {
     const entityLoaderMock = mock<
       AuthorizationResultBasedEntityLoader<
         SimpleTestFields,
-        string,
+        'id',
         ViewerContext,
         SimpleTestEntity,
         SimpleTestEntityPrivacyPolicy,
@@ -1190,7 +1199,7 @@ describe(EntityMutatorFactory, () => {
       mock<
         EntityLoaderUtils<
           SimpleTestFields,
-          string,
+          'id',
           ViewerContext,
           SimpleTestEntity,
           SimpleTestEntityPrivacyPolicy,
@@ -1205,7 +1214,7 @@ describe(EntityMutatorFactory, () => {
       mock<
         EntityLoaderFactory<
           SimpleTestFields,
-          string,
+          'id',
           ViewerContext,
           SimpleTestEntity,
           SimpleTestEntityPrivacyPolicy,
@@ -1296,7 +1305,7 @@ describe(EntityMutatorFactory, () => {
     const viewerContext = instance(mock(ViewerContext));
     const queryContext = new StubQueryContextProvider().getQueryContext();
     const privacyPolicy = instance(mock(SimpleTestEntityPrivacyPolicy));
-    const databaseAdapterMock = mock<EntityDatabaseAdapter<SimpleTestFields>>();
+    const databaseAdapterMock = mock<EntityDatabaseAdapter<SimpleTestFields, 'id'>>();
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
 
     const id1 = uuidv4();
@@ -1314,7 +1323,7 @@ describe(EntityMutatorFactory, () => {
     const entityLoaderMock = mock<
       AuthorizationResultBasedEntityLoader<
         SimpleTestFields,
-        string,
+        'id',
         ViewerContext,
         SimpleTestEntity,
         SimpleTestEntityPrivacyPolicy,
@@ -1325,7 +1334,7 @@ describe(EntityMutatorFactory, () => {
       mock<
         EntityLoaderUtils<
           SimpleTestFields,
-          string,
+          'id',
           ViewerContext,
           SimpleTestEntity,
           SimpleTestEntityPrivacyPolicy,
@@ -1340,7 +1349,7 @@ describe(EntityMutatorFactory, () => {
       mock<
         EntityLoaderFactory<
           SimpleTestFields,
-          string,
+          'id',
           ViewerContext,
           SimpleTestEntity,
           SimpleTestEntityPrivacyPolicy,

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -25,17 +25,17 @@ type BlahFields = {
   id: string;
 };
 
-class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
+class BlahEntity extends Entity<BlahFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity,
     any
   > {
     return {
       entityClass: BlahEntity,
-      entityConfiguration: new EntityConfiguration<BlahFields>({
+      entityConfiguration: new EntityConfiguration<BlahFields, 'id'>({
         idField: 'id',
         tableName: 'blah_table',
         schema: {
@@ -51,30 +51,30 @@ class BlahEntity extends Entity<BlahFields, string, ViewerContext> {
   }
 }
 
-class AlwaysDenyPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
+class AlwaysDenyPolicy extends EntityPrivacyPolicy<BlahFields, 'id', ViewerContext, BlahEntity> {
   protected override readonly createRules = [
-    new AlwaysDenyPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysDenyPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly readRules = [
-    new AlwaysDenyPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysDenyPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysDenyPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysDenyPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysDenyPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysDenyPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
 }
 
 class DryRunAlwaysDenyPolicy extends AlwaysDenyPolicy {
   // public method for test spying
   public denyHandler(
-    _error: EntityNotAuthorizedError<BlahFields, string, ViewerContext, BlahEntity>,
+    _error: EntityNotAuthorizedError<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): void {}
 
   protected override getPrivacyPolicyEvaluator(): EntityPrivacyPolicyEvaluator<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity
   > {
@@ -88,12 +88,12 @@ class DryRunAlwaysDenyPolicy extends AlwaysDenyPolicy {
 class LoggingEnforceAlwaysDenyPolicy extends AlwaysDenyPolicy {
   // public method for test spying
   public denyHandler(
-    _error: EntityNotAuthorizedError<BlahFields, string, ViewerContext, BlahEntity>,
+    _error: EntityNotAuthorizedError<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): void {}
 
   protected override getPrivacyPolicyEvaluator(): EntityPrivacyPolicyEvaluator<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity
   > {
@@ -104,30 +104,30 @@ class LoggingEnforceAlwaysDenyPolicy extends AlwaysDenyPolicy {
   }
 }
 
-class AlwaysAllowPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
+class AlwaysAllowPolicy extends EntityPrivacyPolicy<BlahFields, 'id', ViewerContext, BlahEntity> {
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
 }
 
 class DryRunAlwaysAllowPolicy extends AlwaysAllowPolicy {
   // public method for test spying
   public denyHandler(
-    _error: EntityNotAuthorizedError<BlahFields, string, ViewerContext, BlahEntity>,
+    _error: EntityNotAuthorizedError<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): void {}
 
   protected override getPrivacyPolicyEvaluator(): EntityPrivacyPolicyEvaluator<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity
   > {
@@ -141,12 +141,12 @@ class DryRunAlwaysAllowPolicy extends AlwaysAllowPolicy {
 class LoggingEnforceAlwaysAllowPolicy extends AlwaysAllowPolicy {
   // public method for test spying
   public denyHandler(
-    _error: EntityNotAuthorizedError<BlahFields, string, ViewerContext, BlahEntity>,
+    _error: EntityNotAuthorizedError<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): void {}
 
   protected override getPrivacyPolicyEvaluator(): EntityPrivacyPolicyEvaluator<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity
   > {
@@ -157,24 +157,24 @@ class LoggingEnforceAlwaysAllowPolicy extends AlwaysAllowPolicy {
   }
 }
 
-class SkipAllPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
+class SkipAllPolicy extends EntityPrivacyPolicy<BlahFields, 'id', ViewerContext, BlahEntity> {
   protected override readonly createRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly readRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
 }
 
 class InvalidCreateRuleResultPolicy extends EntityPrivacyPolicy<
   BlahFields,
-  string,
+  'id',
   ViewerContext,
   BlahEntity
 > {
@@ -186,19 +186,19 @@ class InvalidCreateRuleResultPolicy extends EntityPrivacyPolicy<
     },
   ];
   protected override readonly readRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysSkipPrivacyPolicyRule<BlahFields, string, ViewerContext, BlahEntity>(),
+    new AlwaysSkipPrivacyPolicyRule<BlahFields, 'id', ViewerContext, BlahEntity>(),
   ];
 }
 
 class AlwaysThrowPrivacyPolicyRule extends PrivacyPolicyRule<
   BlahFields,
-  string,
+  'id',
   ViewerContext,
   BlahEntity
 > {
@@ -207,7 +207,7 @@ class AlwaysThrowPrivacyPolicyRule extends PrivacyPolicyRule<
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext<
       BlahFields,
-      string,
+      'id',
       ViewerContext,
       BlahEntity
     >,
@@ -217,7 +217,7 @@ class AlwaysThrowPrivacyPolicyRule extends PrivacyPolicyRule<
   }
 }
 
-class ThrowAllPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
+class ThrowAllPolicy extends EntityPrivacyPolicy<BlahFields, 'id', ViewerContext, BlahEntity> {
   protected override readonly createRules = [new AlwaysThrowPrivacyPolicyRule()];
   protected override readonly readRules = [new AlwaysThrowPrivacyPolicyRule()];
   protected override readonly updateRules = [new AlwaysThrowPrivacyPolicyRule()];
@@ -227,12 +227,12 @@ class ThrowAllPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerConte
 class DryRunThrowAllPolicy extends ThrowAllPolicy {
   // public method for test spying
   public denyHandler(
-    _error: EntityNotAuthorizedError<BlahFields, string, ViewerContext, BlahEntity>,
+    _error: EntityNotAuthorizedError<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): void {}
 
   protected override getPrivacyPolicyEvaluator(): EntityPrivacyPolicyEvaluator<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity
   > {
@@ -246,12 +246,12 @@ class DryRunThrowAllPolicy extends ThrowAllPolicy {
 class LoggingEnforceThrowAllPolicy extends ThrowAllPolicy {
   // public method for test spying
   public denyHandler(
-    _error: EntityNotAuthorizedError<BlahFields, string, ViewerContext, BlahEntity>,
+    _error: EntityNotAuthorizedError<BlahFields, 'id', ViewerContext, BlahEntity>,
   ): void {}
 
   protected override getPrivacyPolicyEvaluator(): EntityPrivacyPolicyEvaluator<
     BlahFields,
-    string,
+    'id',
     ViewerContext,
     BlahEntity
   > {
@@ -262,7 +262,7 @@ class LoggingEnforceThrowAllPolicy extends ThrowAllPolicy {
   }
 }
 
-class EmptyPolicy extends EntityPrivacyPolicy<BlahFields, string, ViewerContext, BlahEntity> {
+class EmptyPolicy extends EntityPrivacyPolicy<BlahFields, 'id', ViewerContext, BlahEntity> {
   protected override readonly createRules = [];
   protected override readonly readRules = [];
   protected override readonly updateRules = [];
@@ -276,9 +276,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -315,9 +313,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -353,9 +349,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -392,9 +386,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -421,9 +413,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -460,9 +450,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -492,9 +480,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -536,9 +522,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -580,9 +564,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -618,9 +600,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -663,9 +643,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);
@@ -707,9 +685,7 @@ describe(EntityPrivacyPolicy, () => {
       const queryContext = instance(mock(EntityQueryContext));
       const privacyPolicyEvaluationContext =
         instance(
-          mock<
-            EntityPrivacyPolicyEvaluationContext<BlahFields, string, ViewerContext, BlahEntity>
-          >(),
+          mock<EntityPrivacyPolicyEvaluationContext<BlahFields, 'id', ViewerContext, BlahEntity>>(),
         );
       const metricsAdapterMock = mock<IEntityMetricsAdapter>();
       const metricsAdapter = instance(metricsAdapterMock);

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -14,7 +14,7 @@ type TestLoadParams = { id: string };
 class TestSecondaryRedisCacheLoader extends EntitySecondaryCacheLoader<
   TestLoadParams,
   SimpleTestFields,
-  string,
+  'id',
   ViewerContext,
   SimpleTestEntity,
   SimpleTestEntityPrivacyPolicy

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -18,31 +18,31 @@ interface CategoryFields {
 
 class CategoryPrivacyPolicy extends EntityPrivacyPolicy<
   CategoryFields,
-  string,
+  'id',
   TestViewerContext,
   any,
   any
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, 'id', TestViewerContext, any, any>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, 'id', TestViewerContext, any, any>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, 'id', TestViewerContext, any, any>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<CategoryFields, string, TestViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<CategoryFields, 'id', TestViewerContext, any, any>(),
   ];
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
-  class CategoryEntity extends Entity<CategoryFields, string, TestViewerContext> {
+  class CategoryEntity extends Entity<CategoryFields, 'id', TestViewerContext> {
     static defineCompanionDefinition(): EntityCompanionDefinition<
       CategoryFields,
-      string,
+      'id',
       TestViewerContext,
       CategoryEntity,
       CategoryPrivacyPolicy
@@ -55,7 +55,7 @@ const makeEntityClass = (edgeDeletionBehavior: EntityEdgeDeletionBehavior) => {
     }
   }
 
-  const categoryEntityConfiguration = new EntityConfiguration<CategoryFields>({
+  const categoryEntityConfiguration = new EntityConfiguration<CategoryFields, 'id'>({
     idField: 'id',
     tableName: 'categories',
     inboundEdges: [CategoryEntity],
@@ -246,7 +246,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
       CategoryEntity,
     )['entityCompanion']['tableDataCoordinator'][
       'cacheAdapter'
-    ] as InMemoryFullCacheStubCacheAdapter<CategoryFields>;
+    ] as InMemoryFullCacheStubCacheAdapter<CategoryFields, 'id'>;
     const subCategoryCachedBefore = await categoryCacheAdapter.loadManyAsync(
       new SingleFieldHolder('parent_category_id'),
       [new SingleFieldValueHolder(parentCategory.getID())],
@@ -325,7 +325,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
       CategoryEntity,
     )['entityCompanion']['tableDataCoordinator'][
       'cacheAdapter'
-    ] as InMemoryFullCacheStubCacheAdapter<CategoryFields>;
+    ] as InMemoryFullCacheStubCacheAdapter<CategoryFields, 'id'>;
     const categoriesCachedBefore = await categoryCacheAdapter.loadManyAsync(
       new SingleFieldHolder('parent_category_id'),
       [

--- a/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
@@ -17,7 +17,7 @@ type BlahFields = {
 describe(GenericEntityCacheAdapter, () => {
   describe('loadManyAsync', () => {
     it('returns appropriate cache results', async () => {
-      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields>>();
+      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
           deepEqualEntityAware(new SingleFieldHolder('id')),
@@ -57,12 +57,12 @@ describe(GenericEntityCacheAdapter, () => {
     });
 
     it('returns empty map when passed empty array of load values', async () => {
-      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields>>();
+      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(mockGenericCacher.loadManyAsync(deepEqual([]))).thenResolve(new Map([]));
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
       const results = await cacheAdapter.loadManyAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [] as SingleFieldValueHolder<BlahFields, 'id'>[],
       );
       expect(results).toEqual(new SingleFieldValueHolderMap(new Map()));
@@ -71,7 +71,7 @@ describe(GenericEntityCacheAdapter, () => {
 
   describe('cacheManyAsync', () => {
     it('correctly caches all objects', async () => {
-      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields>>();
+      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
           deepEqualEntityAware(new SingleFieldHolder('id')),
@@ -95,7 +95,7 @@ describe(GenericEntityCacheAdapter, () => {
 
   describe('cacheDBMissesAsync', () => {
     it('correctly caches misses', async () => {
-      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields>>();
+      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
           deepEqualEntityAware(new SingleFieldHolder('id')),
@@ -116,7 +116,7 @@ describe(GenericEntityCacheAdapter, () => {
 
   describe('invalidateManyAsync', () => {
     it('invalidates correctly', async () => {
-      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields>>();
+      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeysForInvalidation(
           deepEqualEntityAware(new SingleFieldHolder('id')),
@@ -135,7 +135,7 @@ describe(GenericEntityCacheAdapter, () => {
     });
 
     it('returns when passed empty array of fieldValues', async () => {
-      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields>>();
+      const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeysForInvalidation(
           deepEqualEntityAware(new SingleFieldHolder('id')),
@@ -147,7 +147,7 @@ describe(GenericEntityCacheAdapter, () => {
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
       await cacheAdapter.invalidateManyAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [] as SingleFieldValueHolder<BlahFields, 'id'>[],
       );
 

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
@@ -14,7 +14,7 @@ describe(ViewerScopedEntityCompanion, () => {
       mock<
         EntityCompanion<
           TestFields,
-          string,
+          'customIdField',
           ViewerContext,
           TestEntity,
           TestEntityPrivacyPolicy,

--- a/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
@@ -12,13 +12,19 @@ describe(ViewerScopedEntityMutatorFactory, () => {
     const queryContext = instance(mock(EntityQueryContext));
     const baseMutatorFactory =
       mock<
-        EntityMutatorFactory<TestFields, string, ViewerContext, TestEntity, TestEntityPrivacyPolicy>
+        EntityMutatorFactory<
+          TestFields,
+          'customIdField',
+          ViewerContext,
+          TestEntity,
+          TestEntityPrivacyPolicy
+        >
       >(EntityMutatorFactory);
     const baseMutatorFactoryInstance = instance(baseMutatorFactory);
 
     const viewerScopedEntityLoader = new ViewerScopedEntityMutatorFactory<
       TestFields,
-      string,
+      'customIdField',
       ViewerContext,
       TestEntity,
       TestEntityPrivacyPolicy,

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -1,7 +1,7 @@
 import Entity from '../../Entity';
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
-import { UUIDField, StringField, StrictEnumField } from '../../EntityFields';
+import { StringField, StrictEnumField, UUIDField } from '../../EntityFields';
 import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
 import ViewerContext from '../../ViewerContext';
 import { successfulResults, failedResults } from '../../entityUtils';
@@ -83,7 +83,7 @@ interface TestFields {
 type OneTestFields = 'id' | 'entity_type' | 'common_other_field';
 type TwoTestFields = 'id' | 'other_field' | 'entity_type' | 'common_other_field';
 
-const testEntityConfiguration = new EntityConfiguration<TestFields>({
+const testEntityConfiguration = new EntityConfiguration<TestFields, 'id'>({
   idField: 'id',
   tableName: 'entities',
   schema: {
@@ -106,22 +106,22 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
   cacheAdapterFlavor: 'redis',
 });
 
-class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, 'id', ViewerContext, any, any> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
 }
 
-class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {
+class OneTestEntity extends Entity<TestFields, 'id', ViewerContext, OneTestFields> {
   constructor(constructorParams: {
     viewerContext: ViewerContext;
     id: string;
@@ -136,7 +136,7 @@ class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFie
 
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     OneTestEntity,
     TestEntityPrivacyPolicy,
@@ -151,7 +151,7 @@ class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFie
   }
 }
 
-class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFields> {
+class TwoTestEntity extends Entity<TestFields, 'id', ViewerContext, TwoTestFields> {
   constructor(constructorParams: {
     viewerContext: ViewerContext;
     id: string;
@@ -166,7 +166,7 @@ class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFie
 
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     TwoTestEntity,
     TestEntityPrivacyPolicy,

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -1,7 +1,7 @@
 import Entity from '../../Entity';
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';
-import { UUIDField, StringField } from '../../EntityFields';
+import { StringField, UUIDField } from '../../EntityFields';
 import EntityPrivacyPolicy from '../../EntityPrivacyPolicy';
 import ViewerContext from '../../ViewerContext';
 import AlwaysAllowPrivacyPolicyRule from '../../rules/AlwaysAllowPrivacyPolicyRule';
@@ -90,7 +90,7 @@ interface TestFields {
 type OneTestFields = 'id' | 'fake_field';
 type TwoTestFields = 'id' | 'other_field' | 'fake_field';
 
-const testEntityConfiguration = new EntityConfiguration<TestFields>({
+const testEntityConfiguration = new EntityConfiguration<TestFields, 'id'>({
   idField: 'id',
   tableName: 'entities',
   schema: {
@@ -111,25 +111,25 @@ const testEntityConfiguration = new EntityConfiguration<TestFields>({
   cacheAdapterFlavor: 'redis',
 });
 
-class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, string, ViewerContext, any, any> {
+class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<any, 'id', ViewerContext, any, any> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<any, string, ViewerContext, any, any>(),
+    new AlwaysAllowPrivacyPolicyRule<any, 'id', ViewerContext, any, any>(),
   ];
 }
 
-class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFields> {
+class OneTestEntity extends Entity<TestFields, 'id', ViewerContext, OneTestFields> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     OneTestEntity,
     TestEntityPrivacyPolicy,
@@ -144,10 +144,10 @@ class OneTestEntity extends Entity<TestFields, string, ViewerContext, OneTestFie
   }
 }
 
-class TwoTestEntity extends Entity<TestFields, string, ViewerContext, TwoTestFields> {
+class TwoTestEntity extends Entity<TestFields, 'id', ViewerContext, TwoTestFields> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'id',
     ViewerContext,
     TwoTestEntity,
     TestEntityPrivacyPolicy,

--- a/packages/entity/src/errors/EntityInvalidFieldValueError.ts
+++ b/packages/entity/src/errors/EntityInvalidFieldValueError.ts
@@ -6,12 +6,12 @@ import ViewerContext from '../ViewerContext';
 
 export default class EntityInvalidFieldValueError<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -25,7 +25,7 @@ export default class EntityInvalidFieldValueError<
   constructor(
     entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,

--- a/packages/entity/src/errors/EntityNotAuthorizedError.ts
+++ b/packages/entity/src/errors/EntityNotAuthorizedError.ts
@@ -5,9 +5,9 @@ import ViewerContext from '../ViewerContext';
 
 export default class EntityNotAuthorizedError<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > extends EntityError {
   public readonly state = EntityErrorState.PERMANENT;

--- a/packages/entity/src/errors/EntityNotFoundError.ts
+++ b/packages/entity/src/errors/EntityNotFoundError.ts
@@ -6,12 +6,12 @@ import ViewerContext from '../ViewerContext';
 
 export default class EntityNotFoundError<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -25,7 +25,7 @@ export default class EntityNotFoundError<
   constructor(
     entityClass: IEntityClass<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,

--- a/packages/entity/src/internal/CompositeFieldHolder.ts
+++ b/packages/entity/src/internal/CompositeFieldHolder.ts
@@ -22,10 +22,13 @@ export type SerializedCompositeFieldHolder = string & {
  * A load key that represents a composite field (set of fieldName) on an entity.
  * Must be defined in the entity configuration composite field definition.
  */
-export class CompositeFieldHolder<TFields extends Record<string, any>>
-  implements
+export class CompositeFieldHolder<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements
     IEntityLoadKey<
       TFields,
+      TIDField,
       SerializedCompositeFieldValueHolder,
       CompositeFieldValueHolder<TFields, EntityCompositeField<TFields>>
     >
@@ -58,11 +61,13 @@ export class CompositeFieldHolder<TFields extends Record<string, any>>
     return JSON.stringify(this.compositeField) as SerializedCompositeFieldHolder;
   }
 
-  isCacheable(entityConfiguration: EntityConfiguration<TFields>): boolean {
+  isCacheable(entityConfiguration: EntityConfiguration<TFields, TIDField>): boolean {
     return entityConfiguration.compositeFieldInfo.canCacheCompositeField(this.compositeField);
   }
 
-  getDatabaseColumns(entityConfiguration: EntityConfiguration<TFields>): readonly string[] {
+  getDatabaseColumns(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): readonly string[] {
     return this.compositeField.map((fieldName) =>
       getDatabaseFieldForEntityField(entityConfiguration, fieldName),
     );
@@ -81,7 +86,7 @@ export class CompositeFieldHolder<TFields extends Record<string, any>>
   }
 
   createCacheKeyPartsForLoadValue(
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     value: CompositeFieldValueHolder<TFields, EntityCompositeField<TFields>>,
   ): readonly string[] {
     const columnNames = this.compositeField.map((fieldName) => {

--- a/packages/entity/src/internal/EntityFieldTransformationUtils.ts
+++ b/packages/entity/src/internal/EntityFieldTransformationUtils.ts
@@ -20,8 +20,11 @@ export interface FieldTransformer<T> {
  */
 export type FieldTransformerMap = Map<string, FieldTransformer<any>>;
 
-export const getDatabaseFieldForEntityField = <TFields extends Record<string, any>>(
-  entityConfiguration: EntityConfiguration<TFields>,
+export const getDatabaseFieldForEntityField = <
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+>(
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   entityField: keyof TFields,
 ): string => {
   const databaseField = entityConfiguration.entityToDBFieldsKeyMapping.get(entityField);
@@ -29,8 +32,11 @@ export const getDatabaseFieldForEntityField = <TFields extends Record<string, an
   return databaseField;
 };
 
-export const transformDatabaseObjectToFields = <TFields extends Record<string, any>>(
-  entityConfiguration: EntityConfiguration<TFields>,
+export const transformDatabaseObjectToFields = <
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+>(
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   databaseObject: { [key: string]: any },
 ): Readonly<TFields> => {
@@ -50,8 +56,11 @@ export const transformDatabaseObjectToFields = <TFields extends Record<string, a
   return fields;
 };
 
-export const transformFieldsToDatabaseObject = <TFields extends Record<string, any>>(
-  entityConfiguration: EntityConfiguration<TFields>,
+export const transformFieldsToDatabaseObject = <
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+>(
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   fields: Readonly<Partial<TFields>>,
 ): object => {
@@ -70,8 +79,11 @@ export const transformFieldsToDatabaseObject = <TFields extends Record<string, a
   return databaseObject;
 };
 
-export const transformCacheObjectToFields = <TFields extends Record<string, any>>(
-  entityConfiguration: EntityConfiguration<TFields>,
+export const transformCacheObjectToFields = <
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+>(
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   cacheObject: { [key: string]: any },
 ): Readonly<TFields> => {
@@ -88,8 +100,11 @@ export const transformCacheObjectToFields = <TFields extends Record<string, any>
   return fields;
 };
 
-export const transformFieldsToCacheObject = <TFields extends Record<string, any>>(
-  entityConfiguration: EntityConfiguration<TFields>,
+export const transformFieldsToCacheObject = <
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+>(
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   fields: Readonly<Partial<TFields>>,
 ): object => {
@@ -109,8 +124,9 @@ export const transformFieldsToCacheObject = <TFields extends Record<string, any>
 const maybeTransformDatabaseValueToFieldValue = <
   TFields extends Record<string, any>,
   N extends keyof TFields,
+  TIDField extends keyof TFields,
 >(
-  entityConfiguration: EntityConfiguration<TFields>,
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
   value: any,
@@ -126,8 +142,9 @@ const maybeTransformDatabaseValueToFieldValue = <
 const maybeTransformFieldValueToDatabaseValue = <
   TFields extends Record<string, any>,
   N extends keyof TFields,
+  TIDField extends keyof TFields,
 >(
-  entityConfiguration: EntityConfiguration<TFields>,
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
   value: TFields[N],
@@ -141,8 +158,9 @@ const maybeTransformFieldValueToDatabaseValue = <
 const maybeTransformCacheValueToFieldValue = <
   TFields extends Record<string, any>,
   N extends keyof TFields,
+  TIDField extends keyof TFields,
 >(
-  entityConfiguration: EntityConfiguration<TFields>,
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
   value: any,
@@ -160,8 +178,9 @@ const maybeTransformCacheValueToFieldValue = <
 const maybeTransformFieldValueToCacheValue = <
   TFields extends Record<string, any>,
   N extends keyof TFields,
+  TIDField extends keyof TFields,
 >(
-  entityConfiguration: EntityConfiguration<TFields>,
+  entityConfiguration: EntityConfiguration<TFields, TIDField>,
   fieldTransformerMap: FieldTransformerMap,
   fieldName: N,
   value: TFields[N],

--- a/packages/entity/src/internal/EntityLoadInterfaces.ts
+++ b/packages/entity/src/internal/EntityLoadInterfaces.ts
@@ -22,6 +22,7 @@ export enum EntityLoadMethodType {
  */
 export interface IEntityLoadKey<
   TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
   TSerializedLoadValue,
   TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
 > {
@@ -40,7 +41,7 @@ export interface IEntityLoadKey<
    * @param entityConfiguration - The entity configuration to check.
    * @returns Boolean indicating whether this key is cacheable.
    */
-  isCacheable(entityConfiguration: EntityConfiguration<TFields>): boolean;
+  isCacheable(entityConfiguration: EntityConfiguration<TFields, TIDField>): boolean;
 
   /**
    * Creates cache key parts for this key and a load value given an entity configuration.
@@ -51,7 +52,7 @@ export interface IEntityLoadKey<
    * @returns An object containing the cache key type and parts.
    */
   createCacheKeyPartsForLoadValue(
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     value: TLoadValue,
   ): readonly string[];
 
@@ -93,7 +94,9 @@ export interface IEntityLoadKey<
    * @param entityConfiguration - The entity configuration.
    * @returns An array of database column names.
    */
-  getDatabaseColumns(entityConfiguration: EntityConfiguration<TFields>): readonly string[];
+  getDatabaseColumns(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): readonly string[];
 
   /**
    * Get the database values corresponding to the database columns for this key for a load value.
@@ -133,7 +136,8 @@ export abstract class LoadValueMap<
  */
 export type LoadPair<
   TFields extends Record<string, any>,
-  TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+  TIDField extends keyof TFields,
+  TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
   TSerializedLoadValue,
   TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
 > = readonly [TLoadKey, TLoadValue];

--- a/packages/entity/src/internal/EntityTableDataCoordinator.ts
+++ b/packages/entity/src/internal/EntityTableDataCoordinator.ts
@@ -13,13 +13,16 @@ import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
  * table. Note that one instance is shared amongst all entities that read from
  * the table to ensure cross-entity data consistency.
  */
-export default class EntityTableDataCoordinator<TFields extends Record<string, any>> {
-  readonly databaseAdapter: EntityDatabaseAdapter<TFields>;
-  readonly cacheAdapter: IEntityCacheAdapter<TFields>;
-  readonly dataManager: EntityDataManager<TFields>;
+export default class EntityTableDataCoordinator<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
+  readonly databaseAdapter: EntityDatabaseAdapter<TFields, TIDField>;
+  readonly cacheAdapter: IEntityCacheAdapter<TFields, TIDField>;
+  readonly dataManager: EntityDataManager<TFields, TIDField>;
 
   constructor(
-    readonly entityConfiguration: EntityConfiguration<TFields>,
+    readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
     databaseAdapterProvider: IEntityDatabaseAdapterProvider,
     cacheAdapterProvider: IEntityCacheAdapterProvider,
     private readonly queryContextProvider: EntityQueryContextProvider,

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -27,14 +27,17 @@ export type CacheLoadResult<TFields extends Record<string, any>> =
  * A read-through entity cache is responsible for coordinating EntityDatabaseAdapter and
  * EntityCacheAdapter within the EntityDataManager.
  */
-export default class ReadThroughEntityCache<TFields extends Record<string, any>> {
+export default class ReadThroughEntityCache<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> {
   constructor(
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
-    private readonly entityCacheAdapter: IEntityCacheAdapter<TFields>,
+    private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
+    private readonly entityCacheAdapter: IEntityCacheAdapter<TFields, TIDField>,
   ) {}
 
   private isLoadKeyCacheable<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey): boolean {
@@ -58,7 +61,7 @@ export default class ReadThroughEntityCache<TFields extends Record<string, any>>
    * @returns map from value to objects that match the query for that value
    */
   public async readManyThroughAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -140,7 +143,7 @@ export default class ReadThroughEntityCache<TFields extends Record<string, any>>
    * @param values - load values to be invalidated for key
    */
   public async invalidateManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {

--- a/packages/entity/src/internal/SingleFieldHolder.ts
+++ b/packages/entity/src/internal/SingleFieldHolder.ts
@@ -12,8 +12,12 @@ import {
 /**
  * A load key that represents a single field (fieldName) on an entity.
  */
-export class SingleFieldHolder<TFields extends Record<string, any>, N extends keyof TFields>
-  implements IEntityLoadKey<TFields, NonNullable<TFields[N]>, SingleFieldValueHolder<TFields, N>>
+export class SingleFieldHolder<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+  N extends keyof TFields,
+> implements
+    IEntityLoadKey<TFields, TIDField, NonNullable<TFields[N]>, SingleFieldValueHolder<TFields, N>>
 {
   constructor(public readonly fieldName: N) {}
 
@@ -21,11 +25,11 @@ export class SingleFieldHolder<TFields extends Record<string, any>, N extends ke
     return `SingleField(${String(this.fieldName)})`;
   }
 
-  public isCacheable(entityConfiguration: EntityConfiguration<TFields>): boolean {
+  public isCacheable(entityConfiguration: EntityConfiguration<TFields, TIDField>): boolean {
     return entityConfiguration.cacheableKeys.has(this.fieldName);
   }
 
-  public getDatabaseColumns(entityConfiguration: EntityConfiguration<TFields>): string[] {
+  public getDatabaseColumns(entityConfiguration: EntityConfiguration<TFields, TIDField>): string[] {
     return [getDatabaseFieldForEntityField(entityConfiguration, this.fieldName)];
   }
 
@@ -42,7 +46,7 @@ export class SingleFieldHolder<TFields extends Record<string, any>, N extends ke
   }
 
   createCacheKeyPartsForLoadValue(
-    entityConfiguration: EntityConfiguration<TFields>,
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
     value: SingleFieldValueHolder<TFields, N>,
   ): readonly string[] {
     const columnName = entityConfiguration.entityToDBFieldsKeyMapping.get(this.fieldName);

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -70,7 +70,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new NoCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -118,7 +121,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -166,7 +172,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -214,7 +223,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -254,7 +266,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -298,7 +313,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -346,7 +364,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -394,7 +415,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -435,7 +459,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -476,7 +503,7 @@ describe(EntityDataManager, () => {
   });
 
   it('handles DB errors as expected', async () => {
-    const databaseAdapterMock = mock<EntityDatabaseAdapter<TestFields>>();
+    const databaseAdapterMock = mock<EntityDatabaseAdapter<TestFields, 'customIdField'>>();
     when(databaseAdapterMock.fetchManyWhereAsync(anything(), anything(), anything())).thenReject(
       new Error('DB query failed'),
     );
@@ -512,7 +539,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -696,7 +726,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new NoCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -732,7 +765,10 @@ describe(EntityDataManager, () => {
       testEntityConfiguration,
       objects,
     );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields>(testEntityConfiguration, dataStore);
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
     const cacheAdapterProvider = new NoCacheStubCacheAdapterProvider();
     const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
     const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
@@ -748,7 +784,10 @@ describe(EntityDataManager, () => {
     await expect(
       entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new CompositeFieldHolder<TestFields>(['nullableField', 'testIndexedField']),
+        new CompositeFieldHolder<TestFields, 'customIdField'>([
+          'nullableField',
+          'testIndexedField',
+        ]),
         [
           new CompositeFieldValueHolder({
             nullableField: null as any,
@@ -763,7 +802,10 @@ describe(EntityDataManager, () => {
     await expect(
       entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new CompositeFieldHolder<TestFields>(['nullableField', 'testIndexedField']),
+        new CompositeFieldHolder<TestFields, 'customIdField'>([
+          'nullableField',
+          'testIndexedField',
+        ]),
         [
           new CompositeFieldValueHolder({
             nullableField: undefined as any,

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -1,5 +1,5 @@
 import EntityConfiguration from '../../EntityConfiguration';
-import { UUIDField, StringField } from '../../EntityFields';
+import { StringField, UUIDField } from '../../EntityFields';
 import {
   getDatabaseFieldForEntityField,
   transformDatabaseObjectToFields,
@@ -16,7 +16,7 @@ type BlahT = {
   transformWrite: string;
 };
 
-const blahEntityConfiguration = new EntityConfiguration<BlahT>({
+const blahEntityConfiguration = new EntityConfiguration<BlahT, 'id'>({
   idField: 'id',
   tableName: 'blah_table',
   schema: {

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -15,8 +15,8 @@ type BlahFields = {
   id: string;
 };
 
-const makeEntityConfiguration = (cacheIdField: boolean): EntityConfiguration<BlahFields> =>
-  new EntityConfiguration<BlahFields>({
+const makeEntityConfiguration = (cacheIdField: boolean): EntityConfiguration<BlahFields, 'id'> =>
+  new EntityConfiguration<BlahFields, 'id'>({
     idField: 'id',
     tableName: 'blah',
     schema: {
@@ -65,7 +65,7 @@ const createFetcherNonUnique =
 describe(ReadThroughEntityCache, () => {
   describe('readManyThroughAsync', () => {
     it('fetches from DB upon cache miss and caches the result', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher(['wat', 'who']);
@@ -88,7 +88,7 @@ describe(ReadThroughEntityCache, () => {
       );
 
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [
           new SingleFieldValueHolder<BlahFields, 'id'>('wat'),
           new SingleFieldValueHolder<BlahFields, 'id'>('who'),
@@ -120,7 +120,7 @@ describe(ReadThroughEntityCache, () => {
       ).once();
       verify(
         cacheAdapterMock.cacheDBMissesAsync(
-          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id'>('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([] as SingleFieldValueHolder<BlahFields, 'id'>[]),
         ),
       ).once();
@@ -135,7 +135,7 @@ describe(ReadThroughEntityCache, () => {
     });
 
     it('does not fetch from the DB or cache results when all cache fetches are hits', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher(['wat', 'who']);
@@ -156,7 +156,7 @@ describe(ReadThroughEntityCache, () => {
       );
 
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [
           new SingleFieldValueHolder<BlahFields, 'id'>('wat'),
           new SingleFieldValueHolder<BlahFields, 'id'>('who'),
@@ -188,7 +188,7 @@ describe(ReadThroughEntityCache, () => {
       ).never();
       verify(
         cacheAdapterMock.cacheDBMissesAsync(
-          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id'>('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([] as SingleFieldValueHolder<BlahFields, 'id'>[]),
         ),
       ).never();
@@ -203,7 +203,7 @@ describe(ReadThroughEntityCache, () => {
     });
 
     it('negatively caches db misses', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
 
@@ -222,7 +222,7 @@ describe(ReadThroughEntityCache, () => {
       );
 
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [new SingleFieldValueHolder<BlahFields, 'id'>('why')],
         fetcher,
       );
@@ -249,7 +249,7 @@ describe(ReadThroughEntityCache, () => {
     });
 
     it('does not return or fetch negatively cached results from DB', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher([]);
@@ -266,7 +266,7 @@ describe(ReadThroughEntityCache, () => {
       );
 
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [new SingleFieldValueHolder<BlahFields, 'id'>('why')],
         fetcher,
       );
@@ -282,7 +282,7 @@ describe(ReadThroughEntityCache, () => {
     });
 
     it('does a mix and match of hit, miss, and negative', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createIdFetcher(['wat', 'who', 'why']);
@@ -309,7 +309,7 @@ describe(ReadThroughEntityCache, () => {
       );
 
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [
           new SingleFieldValueHolder<BlahFields, 'id'>('wat'),
           new SingleFieldValueHolder<BlahFields, 'id'>('who'),
@@ -359,12 +359,12 @@ describe(ReadThroughEntityCache, () => {
     });
 
     it('does not call into cache for field that is not cacheable', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(false), cacheAdapter);
       const fetcher = createIdFetcher(['wat']);
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [new SingleFieldValueHolder<BlahFields, 'id'>('wat')],
         fetcher,
       );
@@ -379,7 +379,7 @@ describe(ReadThroughEntityCache, () => {
     it('does not cache when DB returns multiple objects for what is supposed to be unique and returns empty', async () => {
       const consoleSpy = jest.spyOn(console, 'warn');
 
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       const fetcher = createFetcherNonUnique(['wat', 'who']);
@@ -402,7 +402,7 @@ describe(ReadThroughEntityCache, () => {
       );
 
       const result = await entityCache.readManyThroughAsync(
-        new SingleFieldHolder<BlahFields, 'id'>('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         [
           new SingleFieldValueHolder<BlahFields, 'id'>('wat'),
           new SingleFieldValueHolder<BlahFields, 'id'>('who'),
@@ -432,7 +432,7 @@ describe(ReadThroughEntityCache, () => {
       ).never();
       verify(
         cacheAdapterMock.cacheDBMissesAsync(
-          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id'>('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([] as SingleFieldValueHolder<BlahFields, 'id'>[]),
         ),
       ).once();
@@ -449,7 +449,7 @@ describe(ReadThroughEntityCache, () => {
 
   describe('invalidateManyAsync', () => {
     it('calls cache adapter invalidate', async () => {
-      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields>>();
+      const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
       await entityCache.invalidateManyAsync(new SingleFieldHolder('id'), [

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -9,17 +9,17 @@ import ViewerContext from '../ViewerContext';
  */
 export default class AlwaysAllowPrivacyPolicyRule<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -9,17 +9,17 @@ import ViewerContext from '../ViewerContext';
  */
 export default class AlwaysDenyPrivacyPolicyRule<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -9,17 +9,17 @@ import ViewerContext from '../ViewerContext';
  */
 export default class AlwaysSkipPrivacyPolicyRule<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   async evaluateAsync(
     _viewerContext: TViewerContext,
     _queryContext: EntityQueryContext,
     _evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -38,9 +38,9 @@ export enum RuleEvaluationResult {
  */
 export default abstract class PrivacyPolicyRule<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 > {
   abstract evaluateAsync(
@@ -48,7 +48,7 @@ export default abstract class PrivacyPolicyRule<
     queryContext: EntityQueryContext,
     evaluationContext: EntityPrivacyPolicyEvaluationContext<
       TFields,
-      TID,
+      TIDField,
       TViewerContext,
       TEntity,
       TSelectedFields

--- a/packages/entity/src/testfixtures/DateIDTestEntity.ts
+++ b/packages/entity/src/testfixtures/DateIDTestEntity.ts
@@ -10,7 +10,7 @@ export type DateIDTestFields = {
   id: Date;
 };
 
-export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestFields>({
+export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestFields, 'id'>({
   idField: 'id',
   tableName: 'simple_test_entity_should_not_write_to_db',
   schema: {
@@ -24,28 +24,28 @@ export const dateIDTestEntityConfiguration = new EntityConfiguration<DateIDTestF
 
 export class DateIDTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   DateIDTestFields,
-  Date,
+  'id',
   ViewerContext,
   DateIDTestEntity
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, Date, ViewerContext, DateIDTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, 'id', ViewerContext, DateIDTestEntity>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, Date, ViewerContext, DateIDTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, 'id', ViewerContext, DateIDTestEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, Date, ViewerContext, DateIDTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, 'id', ViewerContext, DateIDTestEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, Date, ViewerContext, DateIDTestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<DateIDTestFields, 'id', ViewerContext, DateIDTestEntity>(),
   ];
 }
 
-export default class DateIDTestEntity extends Entity<DateIDTestFields, Date, ViewerContext> {
+export default class DateIDTestEntity extends Entity<DateIDTestFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     DateIDTestFields,
-    Date,
+    'id',
     ViewerContext,
     DateIDTestEntity,
     DateIDTestEntityPrivacyPolicy

--- a/packages/entity/src/testfixtures/SimpleTestEntity.ts
+++ b/packages/entity/src/testfixtures/SimpleTestEntity.ts
@@ -12,7 +12,7 @@ export type SimpleTestFields = {
 
 export type SimpleTestFieldSelection = keyof SimpleTestFields;
 
-export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestFields>({
+export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestFields, 'id'>({
   idField: 'id',
   tableName: 'simple_test_entity_should_not_write_to_db',
   schema: {
@@ -26,7 +26,7 @@ export const simpleTestEntityConfiguration = new EntityConfiguration<SimpleTestF
 
 export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   SimpleTestFields,
-  string,
+  'id',
   ViewerContext,
   SimpleTestEntity,
   SimpleTestFieldSelection
@@ -34,7 +34,7 @@ export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       SimpleTestFields,
-      string,
+      'id',
       ViewerContext,
       SimpleTestEntity,
       SimpleTestFieldSelection
@@ -43,7 +43,7 @@ export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       SimpleTestFields,
-      string,
+      'id',
       ViewerContext,
       SimpleTestEntity,
       SimpleTestFieldSelection
@@ -52,7 +52,7 @@ export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       SimpleTestFields,
-      string,
+      'id',
       ViewerContext,
       SimpleTestEntity,
       SimpleTestFieldSelection
@@ -61,7 +61,7 @@ export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       SimpleTestFields,
-      string,
+      'id',
       ViewerContext,
       SimpleTestEntity,
       SimpleTestFieldSelection
@@ -71,13 +71,13 @@ export class SimpleTestEntityPrivacyPolicy extends EntityPrivacyPolicy<
 
 export default class SimpleTestEntity extends Entity<
   SimpleTestFields,
-  string,
+  'id',
   ViewerContext,
   SimpleTestFieldSelection
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     SimpleTestFields,
-    string,
+    'id',
     ViewerContext,
     SimpleTestEntity,
     SimpleTestEntityPrivacyPolicy,

--- a/packages/entity/src/testfixtures/TestEntity.ts
+++ b/packages/entity/src/testfixtures/TestEntity.ts
@@ -3,7 +3,7 @@ import { result, Result } from '@expo/results';
 import Entity from '../Entity';
 import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';
-import { UUIDField, StringField, DateField, IntField } from '../EntityFields';
+import { StringField, DateField, IntField, UUIDField } from '../EntityFields';
 import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
 import ViewerContext from '../ViewerContext';
 import AlwaysAllowPrivacyPolicyRule from '../rules/AlwaysAllowPrivacyPolicyRule';
@@ -17,7 +17,7 @@ export type TestFields = {
   nullableField: string | null;
 };
 
-export const testEntityConfiguration = new EntityConfiguration<TestFields>({
+export const testEntityConfiguration = new EntityConfiguration<TestFields, 'customIdField'>({
   idField: 'customIdField',
   tableName: 'test_entity_should_not_write_to_db',
   schema: {
@@ -44,7 +44,7 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields>({
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
   compositeFieldDefinitions: [
-    { compositeField: ['stringField', 'intField'] },
+    { compositeField: ['stringField', 'intField'], cache: false },
     { compositeField: ['stringField', 'testIndexedField'], cache: true },
     { compositeField: ['nullableField', 'testIndexedField'], cache: true },
   ],
@@ -52,28 +52,28 @@ export const testEntityConfiguration = new EntityConfiguration<TestFields>({
 
 export class TestEntityPrivacyPolicy extends EntityPrivacyPolicy<
   TestFields,
-  string,
+  'customIdField',
   ViewerContext,
   TestEntity
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<TestFields, string, ViewerContext, TestEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity>(),
   ];
 }
 
-export default class TestEntity extends Entity<TestFields, string, ViewerContext> {
+export default class TestEntity extends Entity<TestFields, 'customIdField', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestFields,
-    string,
+    'customIdField',
     ViewerContext,
     TestEntity,
     TestEntityPrivacyPolicy

--- a/packages/entity/src/testfixtures/TestEntity2.ts
+++ b/packages/entity/src/testfixtures/TestEntity2.ts
@@ -11,7 +11,7 @@ export type Test2Fields = {
   foreignKey: string;
 };
 
-export const testEntity2Configuration = new EntityConfiguration<Test2Fields>({
+export const testEntity2Configuration = new EntityConfiguration<Test2Fields, 'id'>({
   idField: 'id',
   tableName: 'test_entity_should_not_write_to_db_2',
   schema: {
@@ -28,28 +28,28 @@ export const testEntity2Configuration = new EntityConfiguration<Test2Fields>({
 
 export class TestEntity2PrivacyPolicy extends EntityPrivacyPolicy<
   Test2Fields,
-  string,
+  'id',
   ViewerContext,
   TestEntity2
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<Test2Fields, string, ViewerContext, TestEntity2>(),
+    new AlwaysAllowPrivacyPolicyRule<Test2Fields, 'id', ViewerContext, TestEntity2>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<Test2Fields, string, ViewerContext, TestEntity2>(),
+    new AlwaysAllowPrivacyPolicyRule<Test2Fields, 'id', ViewerContext, TestEntity2>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<Test2Fields, string, ViewerContext, TestEntity2>(),
+    new AlwaysAllowPrivacyPolicyRule<Test2Fields, 'id', ViewerContext, TestEntity2>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<Test2Fields, string, ViewerContext, TestEntity2>(),
+    new AlwaysAllowPrivacyPolicyRule<Test2Fields, 'id', ViewerContext, TestEntity2>(),
   ];
 }
 
-export default class TestEntity2 extends Entity<Test2Fields, string, ViewerContext> {
+export default class TestEntity2 extends Entity<Test2Fields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     Test2Fields,
-    string,
+    'id',
     ViewerContext,
     TestEntity2,
     TestEntity2PrivacyPolicy

--- a/packages/entity/src/testfixtures/TestEntityNumberKey.ts
+++ b/packages/entity/src/testfixtures/TestEntityNumberKey.ts
@@ -10,7 +10,7 @@ export type NumberKeyFields = {
   id: number;
 };
 
-export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFields>({
+export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFields, 'id'>({
   idField: 'id',
   tableName: 'simple_test_entity_should_not_write_to_db',
   schema: {
@@ -24,28 +24,28 @@ export const numberKeyEntityConfiguration = new EntityConfiguration<NumberKeyFie
 
 export class NumberKeyPrivacyPolicy extends EntityPrivacyPolicy<
   NumberKeyFields,
-  number,
+  'id',
   ViewerContext,
   NumberKeyEntity
 > {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, number, ViewerContext, NumberKeyEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, 'id', ViewerContext, NumberKeyEntity>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, number, ViewerContext, NumberKeyEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, 'id', ViewerContext, NumberKeyEntity>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, number, ViewerContext, NumberKeyEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, 'id', ViewerContext, NumberKeyEntity>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, number, ViewerContext, NumberKeyEntity>(),
+    new AlwaysAllowPrivacyPolicyRule<NumberKeyFields, 'id', ViewerContext, NumberKeyEntity>(),
   ];
 }
 
-export default class NumberKeyEntity extends Entity<NumberKeyFields, number, ViewerContext> {
+export default class NumberKeyEntity extends Entity<NumberKeyFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     NumberKeyFields,
-    number,
+    'id',
     ViewerContext,
     NumberKeyEntity,
     NumberKeyPrivacyPolicy

--- a/packages/entity/src/testfixtures/TestEntityWithMutationTriggers.ts
+++ b/packages/entity/src/testfixtures/TestEntityWithMutationTriggers.ts
@@ -17,7 +17,7 @@ export type TestMTFields = {
   stringField: string;
 };
 
-export const testEntityMTConfiguration = new EntityConfiguration<TestMTFields>({
+export const testEntityMTConfiguration = new EntityConfiguration<TestMTFields, 'id'>({
   idField: 'id',
   tableName: 'test_entity_should_not_write_to_db_3',
   schema: {
@@ -34,14 +34,14 @@ export const testEntityMTConfiguration = new EntityConfiguration<TestMTFields>({
 
 export class TestEntityMTPrivacyPolicy extends EntityPrivacyPolicy<
   TestMTFields,
-  string,
+  'id',
   ViewerContext,
   TestEntityWithMutationTriggers
 > {
   protected override readonly readRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers
     >(),
@@ -49,7 +49,7 @@ export class TestEntityMTPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly createRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers
     >(),
@@ -57,7 +57,7 @@ export class TestEntityMTPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly updateRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers
     >(),
@@ -65,7 +65,7 @@ export class TestEntityMTPrivacyPolicy extends EntityPrivacyPolicy<
   protected override readonly deleteRules = [
     new AlwaysAllowPrivacyPolicyRule<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers
     >(),
@@ -74,7 +74,7 @@ export class TestEntityMTPrivacyPolicy extends EntityPrivacyPolicy<
 
 export class TestMutationTrigger extends EntityMutationTrigger<
   TestMTFields,
-  string,
+  'id',
   ViewerContext,
   TestEntityWithMutationTriggers,
   keyof TestMTFields
@@ -92,7 +92,7 @@ export class TestMutationTrigger extends EntityMutationTrigger<
     _entity: TestEntityWithMutationTriggers,
     _mutationInfo: EntityTriggerMutationInfo<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers,
       keyof TestMTFields
@@ -102,7 +102,7 @@ export class TestMutationTrigger extends EntityMutationTrigger<
 
 export class NonTransactionalTestMutationTrigger extends EntityNonTransactionalMutationTrigger<
   TestMTFields,
-  string,
+  'id',
   ViewerContext,
   TestEntityWithMutationTriggers,
   keyof TestMTFields
@@ -119,7 +119,7 @@ export class NonTransactionalTestMutationTrigger extends EntityNonTransactionalM
     _entity: TestEntityWithMutationTriggers,
     _mutationInfo: EntityTriggerMutationInfo<
       TestMTFields,
-      string,
+      'id',
       ViewerContext,
       TestEntityWithMutationTriggers,
       keyof TestMTFields
@@ -132,12 +132,12 @@ export class NonTransactionalTestMutationTrigger extends EntityNonTransactionalM
  */
 export default class TestEntityWithMutationTriggers extends Entity<
   TestMTFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestMTFields,
-    string,
+    'id',
     ViewerContext,
     TestEntityWithMutationTriggers,
     TestEntityMTPrivacyPolicy

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -44,19 +44,26 @@ export type EntityPrivacyEvaluationResult =
  */
 export async function canViewerUpdateAsync<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
   sourceEntity: TEntity,
   queryContext: EntityQueryContext = sourceEntity
     .getViewerContext()
@@ -84,19 +91,26 @@ export async function canViewerUpdateAsync<
  */
 export async function getCanViewerUpdateResultAsync<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
   sourceEntity: TEntity,
   queryContext: EntityQueryContext = sourceEntity
     .getViewerContext()
@@ -114,19 +128,26 @@ export async function getCanViewerUpdateResultAsync<
 
 async function canViewerUpdateInternalAsync<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
   sourceEntity: TEntity,
   cascadingDeleteCause: EntityCascadingDeletionInfo | null,
   queryContext: EntityQueryContext,
@@ -166,19 +187,26 @@ async function canViewerUpdateInternalAsync<
  */
 export async function canViewerDeleteAsync<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
   sourceEntity: TEntity,
   queryContext: EntityQueryContext = sourceEntity
     .getViewerContext()
@@ -206,19 +234,26 @@ export async function canViewerDeleteAsync<
  */
 export async function getCanViewerDeleteResultAsync<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
   sourceEntity: TEntity,
   queryContext: EntityQueryContext = sourceEntity
     .getViewerContext()
@@ -236,19 +271,26 @@ export async function getCanViewerDeleteResultAsync<
 
 async function canViewerDeleteInternalAsync<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends Entity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends Entity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  entityClass: IEntityClass<TFields, TID, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields>,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
   sourceEntity: TEntity,
   cascadingDeleteCause: EntityCascadingDeletionInfo | null,
   queryContext: EntityQueryContext,

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -296,54 +296,54 @@ type TestEntityThrowOtherErrorFields = {
 };
 
 class DenyUpdateEntityPrivacyPolicy<
-  TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TFields extends Record<'id', any>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends EntityPrivacyPolicy<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysDenyPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysDenyPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
 }
 
 class DenyDeleteEntityPrivacyPolicy<
-  TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TFields extends Record<'id', any>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends EntityPrivacyPolicy<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysDenyPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysDenyPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
 }
 
 class ThrowOtherErrorEntityPrivacyPolicy<
-  TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TFields extends Record<'id', any>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends EntityPrivacyPolicy<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   protected override readonly readRules = [
     {
       async evaluateAsync(
@@ -351,7 +351,7 @@ class ThrowOtherErrorEntityPrivacyPolicy<
         _queryContext: EntityQueryContext,
         evaluationContext: EntityPrivacyPolicyEvaluationContext<
           TFields,
-          TID,
+          TIDField,
           TViewerContext,
           TEntity,
           TSelectedFields
@@ -364,10 +364,10 @@ class ThrowOtherErrorEntityPrivacyPolicy<
         return RuleEvaluationResult.SKIP;
       },
     },
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly updateRules = [
     {
@@ -386,12 +386,12 @@ class ThrowOtherErrorEntityPrivacyPolicy<
 }
 
 class DenyReadEntityPrivacyPolicy<
-  TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TFields extends Record<'id', any>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends EntityPrivacyPolicy<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   protected override readonly readRules = [
     {
       async evaluateAsync(
@@ -399,7 +399,7 @@ class DenyReadEntityPrivacyPolicy<
         queryContext: EntityQueryContext,
         evaluationContext: EntityPrivacyPolicyEvaluationContext<
           TFields,
-          TID,
+          TIDField,
           TViewerContext,
           TEntity,
           TSelectedFields
@@ -416,32 +416,32 @@ class DenyReadEntityPrivacyPolicy<
     },
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
 }
 
-class LeafDenyUpdateEntity extends Entity<TestLeafDenyUpdateFields, string, ViewerContext> {
+class LeafDenyUpdateEntity extends Entity<TestLeafDenyUpdateFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestLeafDenyUpdateFields,
-    string,
+    'id',
     ViewerContext,
     LeafDenyUpdateEntity,
     DenyUpdateEntityPrivacyPolicy<
       TestLeafDenyUpdateFields,
-      string,
+      'id',
       ViewerContext,
       LeafDenyUpdateEntity
     >
   > {
     return {
       entityClass: LeafDenyUpdateEntity,
-      entityConfiguration: new EntityConfiguration<TestLeafDenyUpdateFields>({
+      entityConfiguration: new EntityConfiguration<TestLeafDenyUpdateFields, 'id'>({
         idField: 'id',
         tableName: 'leaf_1',
         schema: {
@@ -481,22 +481,22 @@ class LeafDenyUpdateEntity extends Entity<TestLeafDenyUpdateFields, string, View
   }
 }
 
-class LeafDenyDeleteEntity extends Entity<TestLeafDenyDeleteFields, string, ViewerContext> {
+class LeafDenyDeleteEntity extends Entity<TestLeafDenyDeleteFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestLeafDenyDeleteFields,
-    string,
+    'id',
     ViewerContext,
     LeafDenyDeleteEntity,
     DenyDeleteEntityPrivacyPolicy<
       TestLeafDenyDeleteFields,
-      string,
+      'id',
       ViewerContext,
       LeafDenyDeleteEntity
     >
   > {
     return {
       entityClass: LeafDenyDeleteEntity,
-      entityConfiguration: new EntityConfiguration<TestLeafDenyDeleteFields>({
+      entityConfiguration: new EntityConfiguration<TestLeafDenyDeleteFields, 'id'>({
         idField: 'id',
         tableName: 'leaf_2',
         schema: {
@@ -528,17 +528,17 @@ class LeafDenyDeleteEntity extends Entity<TestLeafDenyDeleteFields, string, View
   }
 }
 
-class LeafDenyReadEntity extends Entity<TestLeafDenyReadFields, string, ViewerContext> {
+class LeafDenyReadEntity extends Entity<TestLeafDenyReadFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestLeafDenyReadFields,
-    string,
+    'id',
     ViewerContext,
     LeafDenyReadEntity,
-    DenyReadEntityPrivacyPolicy<TestLeafDenyReadFields, string, ViewerContext, LeafDenyReadEntity>
+    DenyReadEntityPrivacyPolicy<TestLeafDenyReadFields, 'id', ViewerContext, LeafDenyReadEntity>
   > {
     return {
       entityClass: LeafDenyReadEntity,
-      entityConfiguration: new EntityConfiguration<TestLeafDenyReadFields>({
+      entityConfiguration: new EntityConfiguration<TestLeafDenyReadFields, 'id'>({
         idField: 'id',
         tableName: 'leaf_4',
         inboundEdges: [],
@@ -563,22 +563,17 @@ class LeafDenyReadEntity extends Entity<TestLeafDenyReadFields, string, ViewerCo
   }
 }
 
-class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, ViewerContext> {
+class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestEntityFields,
-    string,
+    'id',
     ViewerContext,
     SimpleTestDenyUpdateEntity,
-    DenyUpdateEntityPrivacyPolicy<
-      TestEntityFields,
-      string,
-      ViewerContext,
-      SimpleTestDenyUpdateEntity
-    >
+    DenyUpdateEntityPrivacyPolicy<TestEntityFields, 'id', ViewerContext, SimpleTestDenyUpdateEntity>
   > {
     return {
       entityClass: SimpleTestDenyUpdateEntity,
-      entityConfiguration: new EntityConfiguration<TestEntityFields>({
+      entityConfiguration: new EntityConfiguration<TestEntityFields, 'id'>({
         idField: 'id',
         tableName: 'blah',
         inboundEdges: [
@@ -600,22 +595,17 @@ class SimpleTestDenyUpdateEntity extends Entity<TestEntityFields, string, Viewer
   }
 }
 
-class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, ViewerContext> {
+class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestEntityFields,
-    string,
+    'id',
     ViewerContext,
     SimpleTestDenyDeleteEntity,
-    DenyDeleteEntityPrivacyPolicy<
-      TestEntityFields,
-      string,
-      ViewerContext,
-      SimpleTestDenyDeleteEntity
-    >
+    DenyDeleteEntityPrivacyPolicy<TestEntityFields, 'id', ViewerContext, SimpleTestDenyDeleteEntity>
   > {
     return {
       entityClass: SimpleTestDenyDeleteEntity,
-      entityConfiguration: new EntityConfiguration<TestEntityFields>({
+      entityConfiguration: new EntityConfiguration<TestEntityFields, 'id'>({
         idField: 'id',
         tableName: 'blah_2',
         inboundEdges: [
@@ -639,24 +629,24 @@ class SimpleTestDenyDeleteEntity extends Entity<TestEntityFields, string, Viewer
 
 class SimpleTestThrowOtherErrorEntity extends Entity<
   TestEntityThrowOtherErrorFields,
-  string,
+  'id',
   ViewerContext
 > {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestEntityThrowOtherErrorFields,
-    string,
+    'id',
     ViewerContext,
     SimpleTestThrowOtherErrorEntity,
     ThrowOtherErrorEntityPrivacyPolicy<
       TestEntityThrowOtherErrorFields,
-      string,
+      'id',
       ViewerContext,
       SimpleTestThrowOtherErrorEntity
     >
   > {
     return {
       entityClass: SimpleTestThrowOtherErrorEntity,
-      entityConfiguration: new EntityConfiguration<TestEntityThrowOtherErrorFields>({
+      entityConfiguration: new EntityConfiguration<TestEntityThrowOtherErrorFields, 'id'>({
         idField: 'id',
         tableName: 'blah_3',
         inboundEdges: [],

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -98,36 +98,36 @@ type TestLeafEntityFields = {
 
 class AlwaysAllowEntityPrivacyPolicy<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityPrivacyPolicy<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+> extends EntityPrivacyPolicy<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   protected override readonly readRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly createRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly updateRules = [
-    new AlwaysDenyPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysDenyPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
   protected override readonly deleteRules = [
-    new AlwaysAllowPrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>(),
+    new AlwaysAllowPrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>(),
   ];
 }
 
-class TestEntity extends Entity<TestEntityFields, string, ViewerContext> {
+class TestEntity extends Entity<TestEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestEntityFields,
-    string,
+    'id',
     ViewerContext,
     TestEntity,
-    AlwaysAllowEntityPrivacyPolicy<TestEntityFields, string, ViewerContext, TestEntity>
+    AlwaysAllowEntityPrivacyPolicy<TestEntityFields, 'id', ViewerContext, TestEntity>
   > {
     return {
       entityClass: TestEntity,
-      entityConfiguration: new EntityConfiguration<TestEntityFields>({
+      entityConfiguration: new EntityConfiguration<TestEntityFields, 'id'>({
         idField: 'id',
         tableName: 'blah',
         inboundEdges: [TestLeafEntity, TestLeafLookupByFieldEntity, TestLeafNoInferenceEntity],
@@ -144,17 +144,17 @@ class TestEntity extends Entity<TestEntityFields, string, ViewerContext> {
   }
 }
 
-class TestLeafEntity extends Entity<TestLeafEntityFields, string, ViewerContext> {
+class TestLeafEntity extends Entity<TestLeafEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestLeafEntityFields,
-    string,
+    'id',
     ViewerContext,
     TestLeafEntity,
-    AlwaysAllowEntityPrivacyPolicy<TestLeafEntityFields, string, ViewerContext, TestLeafEntity>
+    AlwaysAllowEntityPrivacyPolicy<TestLeafEntityFields, 'id', ViewerContext, TestLeafEntity>
   > {
     return {
       entityClass: TestLeafEntity,
-      entityConfiguration: new EntityConfiguration<TestLeafEntityFields>({
+      entityConfiguration: new EntityConfiguration<TestLeafEntityFields, 'id'>({
         idField: 'id',
         tableName: 'blah_2',
         schema: {
@@ -179,22 +179,23 @@ class TestLeafEntity extends Entity<TestLeafEntityFields, string, ViewerContext>
   }
 }
 
-class TestLeafLookupByFieldEntity extends Entity<TestLeafEntityFields, string, ViewerContext> {
+class TestLeafLookupByFieldEntity extends Entity<TestLeafEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestLeafEntityFields,
-    string,
+    'id',
     ViewerContext,
     TestLeafEntity,
-    AlwaysAllowEntityPrivacyPolicy<TestLeafEntityFields, string, ViewerContext, TestLeafEntity>
+    AlwaysAllowEntityPrivacyPolicy<TestLeafEntityFields, 'id', ViewerContext, TestLeafEntity>
   > {
     return {
       entityClass: TestLeafEntity,
-      entityConfiguration: new EntityConfiguration<TestLeafEntityFields>({
+      entityConfiguration: new EntityConfiguration<TestLeafEntityFields, 'id'>({
         idField: 'id',
         tableName: 'blah_4',
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           test_entity_id: new UUIDField({
             columnName: 'test_entity_id',
@@ -215,27 +216,28 @@ class TestLeafLookupByFieldEntity extends Entity<TestLeafEntityFields, string, V
   }
 }
 
-class TestLeafNoInferenceEntity extends Entity<TestLeafEntityFields, string, ViewerContext> {
+class TestLeafNoInferenceEntity extends Entity<TestLeafEntityFields, 'id', ViewerContext> {
   static defineCompanionDefinition(): EntityCompanionDefinition<
     TestLeafEntityFields,
-    string,
+    'id',
     ViewerContext,
     TestLeafNoInferenceEntity,
     AlwaysAllowEntityPrivacyPolicy<
       TestLeafEntityFields,
-      string,
+      'id',
       ViewerContext,
       TestLeafNoInferenceEntity
     >
   > {
     return {
       entityClass: TestLeafNoInferenceEntity,
-      entityConfiguration: new EntityConfiguration<TestLeafEntityFields>({
+      entityConfiguration: new EntityConfiguration<TestLeafEntityFields, 'id'>({
         idField: 'id',
         tableName: 'blah_3',
         schema: {
           id: new UUIDField({
             columnName: 'custom_id',
+            cache: false,
           }),
           test_entity_id: new UUIDField({
             columnName: 'test_entity_id',

--- a/packages/entity/src/utils/mergeEntityMutationTriggerConfigurations.ts
+++ b/packages/entity/src/utils/mergeEntityMutationTriggerConfigurations.ts
@@ -8,19 +8,19 @@ function nonNullish<TValue>(value: TValue | null | undefined): value is NonNulla
 
 export function mergeEntityMutationTriggerConfigurations<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields,
 >(
   ...mutationTriggerConfigurations: EntityMutationTriggerConfiguration<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
   >[]
-): EntityMutationTriggerConfiguration<TFields, TID, TViewerContext, TEntity, TSelectedFields> {
+): EntityMutationTriggerConfiguration<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
   const merged = {
     beforeCreate: mutationTriggerConfigurations.flatMap((c) => c.beforeCreate).filter(nonNullish),
     afterCreate: mutationTriggerConfigurations.flatMap((c) => c.afterCreate).filter(nonNullish),

--- a/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/testing/PrivacyPolicyRuleTestUtils.ts
@@ -6,16 +6,16 @@ import PrivacyPolicyRule, { RuleEvaluationResult } from '../../rules/PrivacyPoli
 
 export interface Case<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields,
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
   evaluationContext: EntityPrivacyPolicyEvaluationContext<
     TFields,
-    TID,
+    TIDField,
     TViewerContext,
     TEntity,
     TSelectedFields
@@ -25,31 +25,31 @@ export interface Case<
 
 export type CaseMap<
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields,
-> = Map<string, () => Promise<Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>>>;
+> = Map<string, () => Promise<Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>>>;
 
 /**
  * Useful for defining test cases that have async preconditions.
  */
 export const describePrivacyPolicyRuleWithAsyncTestCase = <
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+  privacyPolicyRule: PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>,
   {
     allowCases = new Map(),
     skipCases = new Map(),
     denyCases = new Map(),
   }: {
-    allowCases?: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
-    skipCases?: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
-    denyCases?: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>;
+    allowCases?: CaseMap<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>;
+    skipCases?: CaseMap<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>;
+    denyCases?: CaseMap<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>;
   },
 ): void => {
   describe(privacyPolicyRule.constructor.name, () => {
@@ -96,29 +96,29 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
  */
 export const describePrivacyPolicyRule = <
   TFields extends Record<string, any>,
-  TID extends NonNullable<TFields[TSelectedFields]>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
-  TEntity extends ReadonlyEntity<TFields, TID, TViewerContext, TSelectedFields>,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TSelectedFields extends keyof TFields = keyof TFields,
 >(
-  privacyPolicyRule: PrivacyPolicyRule<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+  privacyPolicyRule: PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>,
   {
     allowCases = [],
     skipCases = [],
     denyCases = [],
   }: {
-    allowCases?: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
-    skipCases?: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
-    denyCases?: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[];
+    allowCases?: Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[];
+    skipCases?: Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[];
+    denyCases?: Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[];
   },
 ): void => {
   const makeCasesMap = (
-    cases: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>[],
-  ): CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields> =>
+    cases: Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>[],
+  ): CaseMap<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> =>
     cases.reduce(
       (
-        acc: CaseMap<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
-        testCase: Case<TFields, TID, TViewerContext, TEntity, TSelectedFields>,
+        acc: CaseMap<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>,
+        testCase: Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>,
         index,
       ) => {
         acc.set(`case ${index}`, async () => testCase);

--- a/packages/entity/src/utils/testing/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/testing/StubCacheAdapter.ts
@@ -7,18 +7,20 @@ import { IEntityLoadKey, IEntityLoadValue } from '../../internal/EntityLoadInter
 import { CacheStatus, CacheLoadResult } from '../../internal/ReadThroughEntityCache';
 
 export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
-  getCacheAdapter<TFields extends Record<string, any>>(
-    _entityConfiguration: EntityConfiguration<TFields>,
-  ): IEntityCacheAdapter<TFields> {
+  getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    _entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): IEntityCacheAdapter<TFields, TIDField> {
     return new NoCacheStubCacheAdapter();
   }
 }
 
-export class NoCacheStubCacheAdapter<TFields extends Record<string, any>>
-  implements IEntityCacheAdapter<TFields>
+export class NoCacheStubCacheAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements IEntityCacheAdapter<TFields, TIDField>
 {
   public async loadManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -34,19 +36,19 @@ export class NoCacheStubCacheAdapter<TFields extends Record<string, any>>
   }
 
   public async cacheManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(_key: TLoadKey, _objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {}
 
   public async cacheDBMissesAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(_key: TLoadKey, _values: readonly TLoadValue[]): Promise<void> {}
 
   public async invalidateManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(_key: TLoadKey, _values: readonly TLoadValue[]): Promise<void> {}
@@ -59,9 +61,9 @@ export const DOES_NOT_EXIST = Symbol('inMemoryCacheDoesNotExistValue');
 export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
   private readonly cache: Map<string, Readonly<object> | typeof DOES_NOT_EXIST> = new Map();
 
-  getCacheAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): IEntityCacheAdapter<TFields> {
+  getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): IEntityCacheAdapter<TFields, TIDField> {
     return new InMemoryFullCacheStubCacheAdapter(
       entityConfiguration,
       this.cache as Map<string, Readonly<TFields>>,
@@ -69,16 +71,18 @@ export class InMemoryFullCacheStubCacheAdapterProvider implements IEntityCacheAd
   }
 }
 
-export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, any>>
-  implements IEntityCacheAdapter<TFields>
+export class InMemoryFullCacheStubCacheAdapter<
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> implements IEntityCacheAdapter<TFields, TIDField>
 {
   constructor(
-    private readonly entityConfiguration: EntityConfiguration<TFields>,
+    private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
     private readonly cache: Map<string, Readonly<TFields> | typeof DOES_NOT_EXIST>,
   ) {}
 
   public async loadManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(
@@ -111,7 +115,7 @@ export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, an
   }
 
   public async cacheManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, objectMap: ReadonlyMap<TLoadValue, Readonly<TFields>>): Promise<void> {
@@ -122,7 +126,7 @@ export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, an
   }
 
   public async cacheDBMissesAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
@@ -133,7 +137,7 @@ export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, an
   }
 
   public async invalidateManyAsync<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, values: readonly TLoadValue[]): Promise<void> {
@@ -144,7 +148,7 @@ export class InMemoryFullCacheStubCacheAdapter<TFields extends Record<string, an
   }
 
   private createCacheKey<
-    TLoadKey extends IEntityLoadKey<TFields, TSerializedLoadValue, TLoadValue>,
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue): string {

--- a/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapter.ts
@@ -17,18 +17,22 @@ import {
 import { computeIfAbsent, mapMap } from '../collections/maps';
 
 export default class StubDatabaseAdapter<
-  T extends Record<string, any>,
-> extends EntityDatabaseAdapter<T> {
+  TFields extends Record<string, any>,
+  TIDField extends keyof TFields,
+> extends EntityDatabaseAdapter<TFields, TIDField> {
   constructor(
-    private readonly entityConfiguration2: EntityConfiguration<T>,
+    private readonly entityConfiguration2: EntityConfiguration<TFields, TIDField>,
     private readonly dataStore: Map<string, Readonly<{ [key: string]: any }>[]>,
   ) {
     super(entityConfiguration2);
   }
 
-  public static convertFieldObjectsToDataStore<T extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<T>,
-    dataStore: Map<string, Readonly<T>[]>,
+  public static convertFieldObjectsToDataStore<
+    TFields extends Record<string, any>,
+    TIDField extends keyof TFields,
+  >(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+    dataStore: Map<string, Readonly<TFields>[]>,
   ): Map<string, Readonly<{ [key: string]: any }>[]> {
     return mapMap(dataStore, (objectsForTable) =>
       objectsForTable.map((objectForTable) =>

--- a/packages/entity/src/utils/testing/StubDatabaseAdapterProvider.ts
+++ b/packages/entity/src/utils/testing/StubDatabaseAdapterProvider.ts
@@ -6,9 +6,9 @@ import IEntityDatabaseAdapterProvider from '../../IEntityDatabaseAdapterProvider
 export default class StubDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
   private readonly objectCollection = new Map();
 
-  getDatabaseAdapter<TFields extends Record<string, any>>(
-    entityConfiguration: EntityConfiguration<TFields>,
-  ): EntityDatabaseAdapter<TFields> {
+  getDatabaseAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+    entityConfiguration: EntityConfiguration<TFields, TIDField>,
+  ): EntityDatabaseAdapter<TFields, TIDField> {
     return new StubDatabaseAdapter(entityConfiguration, this.objectCollection);
   }
 }

--- a/packages/entity/src/utils/testing/__tests__/StubCacheAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubCacheAdapter-test.ts
@@ -19,7 +19,7 @@ import {
 describe(NoCacheStubCacheAdapter, () => {
   describe('loadManyAsync', () => {
     it('should return a map of CacheLoadResult with status CacheStatus.MISS for all single values', async () => {
-      const adapter = new NoCacheStubCacheAdapter<TestFields>();
+      const adapter = new NoCacheStubCacheAdapter<TestFields, 'customIdField'>();
       const result = await adapter.loadManyAsync(new SingleFieldHolder('stringField'), [
         new SingleFieldValueHolder('huh'),
       ]);
@@ -31,9 +31,9 @@ describe(NoCacheStubCacheAdapter, () => {
     });
 
     it('should return a map of CacheLoadResult with status CacheStatus.MISS for all composite values', async () => {
-      const adapter = new NoCacheStubCacheAdapter<TestFields>();
+      const adapter = new NoCacheStubCacheAdapter<TestFields, 'customIdField'>();
       const result = await adapter.loadManyAsync(
-        new CompositeFieldHolder<TestFields>(['stringField', 'intField']),
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
         [new CompositeFieldValueHolder({ stringField: 'huh', intField: 42 })],
       );
       expect(result).toEqual(

--- a/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity/src/utils/testing/__tests__/StubDatabaseAdapter-test.ts
@@ -26,7 +26,7 @@ describe(StubDatabaseAdapter, () => {
   describe('fetchManyWhereAsync', () => {
     it('fetches many where single', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -66,7 +66,7 @@ describe(StubDatabaseAdapter, () => {
 
     it('fetches many where composite', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -98,7 +98,7 @@ describe(StubDatabaseAdapter, () => {
 
       const results = await databaseAdapter.fetchManyWhereAsync(
         queryContext,
-        new CompositeFieldHolder<TestFields>(['stringField', 'intField']),
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
         [new CompositeFieldValueHolder({ stringField: 'huh', intField: 5 })],
       );
       expect(
@@ -107,7 +107,7 @@ describe(StubDatabaseAdapter, () => {
 
       const results2 = await databaseAdapter.fetchManyWhereAsync(
         queryContext,
-        new CompositeFieldHolder<TestFields>(['stringField', 'intField']),
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
         [new CompositeFieldValueHolder({ stringField: 'not-in-db', intField: 5 })],
       );
       expect(
@@ -119,7 +119,7 @@ describe(StubDatabaseAdapter, () => {
   describe('fetchManyByFieldEqualityConjunctionAsync', () => {
     it('supports conjuntions and query modifiers', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -187,7 +187,7 @@ describe(StubDatabaseAdapter, () => {
 
     it('supports multiple order bys', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -253,7 +253,7 @@ describe(StubDatabaseAdapter, () => {
 
     it('supports null field values', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -330,7 +330,7 @@ describe(StubDatabaseAdapter, () => {
   describe('fetchManyByRawWhereClauseAsync', () => {
     it('throws because it is unsupported', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         new Map(),
       );
@@ -343,7 +343,7 @@ describe(StubDatabaseAdapter, () => {
   describe('insertAsync', () => {
     it('inserts a record', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         new Map(),
       );
@@ -367,7 +367,7 @@ describe(StubDatabaseAdapter, () => {
       });
 
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         new Map(),
       );
@@ -383,7 +383,7 @@ describe(StubDatabaseAdapter, () => {
   describe('updateAsync', () => {
     it('updates a record', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -415,7 +415,7 @@ describe(StubDatabaseAdapter, () => {
 
     it('throws error when empty update to match common DBMS behavior', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -445,7 +445,7 @@ describe(StubDatabaseAdapter, () => {
   describe('deleteAsync', () => {
     it('deletes an object', async () => {
       const queryContext = instance(mock(EntityQueryContext));
-      const databaseAdapter = new StubDatabaseAdapter<TestFields>(
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
         testEntityConfiguration,
         StubDatabaseAdapter.convertFieldObjectsToDataStore(
           testEntityConfiguration,
@@ -477,21 +477,21 @@ describe(StubDatabaseAdapter, () => {
 
   it('supports string and number IDs', async () => {
     const queryContext = instance(mock(EntityQueryContext));
-    const databaseAdapter1 = new StubDatabaseAdapter<SimpleTestFields>(
+    const databaseAdapter1 = new StubDatabaseAdapter<SimpleTestFields, 'id'>(
       simpleTestEntityConfiguration,
       new Map(),
     );
     const insertedObject1 = await databaseAdapter1.insertAsync(queryContext, {});
     expect(typeof insertedObject1.id).toBe('string');
 
-    const databaseAdapter2 = new StubDatabaseAdapter<NumberKeyFields>(
+    const databaseAdapter2 = new StubDatabaseAdapter<NumberKeyFields, 'id'>(
       numberKeyEntityConfiguration,
       new Map(),
     );
     const insertedObject2 = await databaseAdapter2.insertAsync(queryContext, {});
     expect(typeof insertedObject2.id).toBe('number');
 
-    const databaseAdapter3 = new StubDatabaseAdapter<DateIDTestFields>(
+    const databaseAdapter3 = new StubDatabaseAdapter<DateIDTestFields, 'id'>(
       dateIDTestEntityConfiguration,
       new Map(),
     );


### PR DESCRIPTION
# Why

In preparation for #276, this just switches the `TID` generic to `TIDField`. This allows us to get more information out of the same concept since we can derive TID from TIDField (`TFields[TIDField]`).

This somewhat alleviates the concern in #273 by replacing an existing generic parameter with another rather than adding yet another one. (net neutral in terms of number of generics that need to be specified for an entity)

# How

Do a bunch of find/replace and rely upon tsc to inform where updates are needed.

# Test Plan

`tsc`