### PR TITLE
chore: separate out build tsconfig

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,6 +3,9 @@
     "tsc": {
       "dependsOn": ["^clean", "clean", "^tsc"]
     },
+    "build": {
+      "dependsOn": ["^clean", "clean", "^build"]
+    },
     "test": {
       "dependsOn": ["^tsc"]
     },

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
   ],
   "scripts": {
     "tsc": "lerna run tsc",
+    "build": "lerna run build",
     "clean": "lerna run clean",
     "lint": "lerna run lint",
     "lint-fix": "lerna run lint-fix",
     "test": "lerna run test",
     "integration": "./resources/run-with-docker lerna run integration-no-setup",
-    "prepack": "lerna run tsc",
+    "prepack": "lerna run build",
     "ctix": "lerna run ctix",
-    "typedoc": "yarn tsc && typedoc"
+    "typedoc": "yarn build && typedoc"
   },
   "devDependencies": {
     "lerna": "^8.2.1",

--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-cache-adapter-local-memory/tsconfig.build.json
+++ b/packages/entity-cache-adapter-local-memory/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-cache-adapter-local-memory/tsconfig.json
+++ b/packages/entity-cache-adapter-local-memory/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"]
 }

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-cache-adapter-redis/tsconfig.build.json
+++ b/packages/entity-cache-adapter-redis/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-cache-adapter-redis/tsconfig.json
+++ b/packages/entity-cache-adapter-redis/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"]
 }

--- a/packages/entity-codemod/package.json
+++ b/packages/entity-codemod/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-codemod/tsconfig.build.json
+++ b/packages/entity-codemod/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "exclude": ["**/__testfixtures__/**"]
+}

--- a/packages/entity-codemod/tsconfig.json
+++ b/packages/entity-codemod/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"],
-  "exclude": ["**/__testfixtures__/**"]
+  "exclude": ["**/__testfixtures__/**"],
 }

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-database-adapter-knex/tsconfig.build.json
+++ b/packages/entity-database-adapter-knex/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-database-adapter-knex/tsconfig.json
+++ b/packages/entity-database-adapter-knex/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"]
 }

--- a/packages/entity-example/package.json
+++ b/packages/entity-example/package.json
@@ -5,6 +5,7 @@
   "description": "An example integration of the @expo/entity framework",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-example/tsconfig.build.json
+++ b/packages/entity-example/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-example/tsconfig.json
+++ b/packages/entity-example/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-  },
   "include": ["src"]
 }

--- a/packages/entity-full-integration-tests/package.json
+++ b/packages/entity-full-integration-tests/package.json
@@ -5,6 +5,7 @@
   "description": "Full redis and knex integration tests for the entity framework",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-full-integration-tests/src/index.ts
+++ b/packages/entity-full-integration-tests/src/index.ts
@@ -1,0 +1,1 @@
+// placeholder file to fix tsc

--- a/packages/entity-full-integration-tests/tsconfig.build.json
+++ b/packages/entity-full-integration-tests/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "noEmit": true,
-  },
+  }
 }

--- a/packages/entity-ip-address-field/README.md
+++ b/packages/entity-ip-address-field/README.md
@@ -1,3 +1,0 @@
-# @expo/entity-ip-address-field
-
-A package containing the IP address EntityField definitions for @expo/entity. Supports addresses with either IPv4 or IPv6 syntax.

--- a/packages/entity-ip-address-field/package.json
+++ b/packages/entity-ip-address-field/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-ip-address-field/tsconfig.build.json
+++ b/packages/entity-ip-address-field/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-ip-address-field/tsconfig.json
+++ b/packages/entity-ip-address-field/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"]
 }

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-secondary-cache-local-memory/tsconfig.build.json
+++ b/packages/entity-secondary-cache-local-memory/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-secondary-cache-local-memory/tsconfig.json
+++ b/packages/entity-secondary-cache-local-memory/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"]
 }

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-secondary-cache-redis/tsconfig.build.json
+++ b/packages/entity-secondary-cache-redis/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-secondary-cache-redis/tsconfig.json
+++ b/packages/entity-secondary-cache-redis/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
   "include": ["src"]
 }

--- a/packages/entity-testing-utils/package.json
+++ b/packages/entity-testing-utils/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity-testing-utils/src/__tests__/FileConsistentcyWithEntity-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/FileConsistentcyWithEntity-test.ts
@@ -2,48 +2,24 @@ import { readFile } from 'fs/promises';
 import path from 'path';
 
 it.each([
-  {
-    localPath: 'src/createUnitTestEntityCompanionProvider.ts',
-    entityPath: 'src/utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts',
-  },
-  {
-    localPath: 'src/describeFieldTestCase.ts',
-    entityPath: 'src/utils/__testfixtures__/describeFieldTestCase.ts',
-  },
-  {
-    localPath: 'src/PrivacyPolicyRuleTestUtils.ts',
-    entityPath: 'src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts',
-  },
-  {
-    localPath: 'src/StubCacheAdapter.ts',
-    entityPath: 'src/utils/__testfixtures__/StubCacheAdapter.ts',
-  },
-  {
-    localPath: 'src/StubDatabaseAdapter.ts',
-    entityPath: 'src/utils/__testfixtures__/StubDatabaseAdapter.ts',
-  },
-  {
-    localPath: 'src/StubDatabaseAdapterProvider.ts',
-    entityPath: 'src/utils/__testfixtures__/StubDatabaseAdapterProvider.ts',
-  },
-  {
-    localPath: 'src/StubQueryContextProvider.ts',
-    entityPath: 'src/utils/__testfixtures__/StubQueryContextProvider.ts',
-  },
-  {
-    localPath: 'src/TSMockitoExtensions.ts',
-    entityPath: 'src/internal/__tests__/TSMockitoExtensions.ts',
-  },
-])('$localPath the same as in @expo/entity', async ({ localPath, entityPath }) => {
+  'createUnitTestEntityCompanionProvider',
+  'describeFieldTestCase',
+  'PrivacyPolicyRuleTestUtils',
+  'StubCacheAdapter',
+  'StubDatabaseAdapter',
+  'StubDatabaseAdapterProvider',
+  'StubQueryContextProvider',
+  'TSMockitoExtensions',
+])('$localPath the same as in @expo/entity', async (fileName) => {
   // There isn't a great way to have TSMockitoExtensions in a shared package since it circularly depends on entity itself,
   // and entity would want to use it for testing. Therefore, we duplicate it and ensure it stays in sync.
 
   const fileContentsFromEntity = await readFile(
-    path.resolve(__dirname, `../../../entity/${entityPath}`),
+    path.resolve(__dirname, `../../../entity/src/utils/__testfixtures__/${fileName}.ts`),
     'utf-8',
   );
   const fileContentsFromEntityTestingUtils = await readFile(
-    path.resolve(__dirname, `../../${localPath}`),
+    path.resolve(__dirname, `../${fileName}.ts`),
     'utf-8',
   );
 

--- a/packages/entity-testing-utils/tsconfig.build.json
+++ b/packages/entity-testing-utils/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity-testing-utils/tsconfig.json
+++ b/packages/entity-testing-utils/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -10,6 +10,7 @@
   "types": "build/index.d.ts",
   "scripts": {
     "tsc": "tsc",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "rm -rf build coverage coverage-integration",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -17,11 +17,11 @@ import {
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
 } from '../internal/SingleFieldHolder';
-import { deepEqualEntityAware } from '../internal/__tests__/TSMockitoExtensions';
 import IEntityMetricsAdapter from '../metrics/IEntityMetricsAdapter';
 import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter';
 import StubDatabaseAdapter from '../utils/__testfixtures__/StubDatabaseAdapter';
 import StubQueryContextProvider from '../utils/__testfixtures__/StubQueryContextProvider';
+import { deepEqualEntityAware } from '../utils/__testfixtures__/TSMockitoExtensions';
 import TestEntity, {
   TestFields,
   TestEntityPrivacyPolicy,

--- a/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
@@ -8,7 +8,7 @@ import {
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
 } from '../internal/SingleFieldHolder';
-import { deepEqualEntityAware } from '../internal/__tests__/TSMockitoExtensions';
+import { deepEqualEntityAware } from '../utils/__testfixtures__/TSMockitoExtensions';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -3,13 +3,16 @@ import { verify, mock, instance, when, anything } from 'ts-mockito';
 import EntityConfiguration from '../../EntityConfiguration';
 import { UUIDField } from '../../EntityFields';
 import IEntityCacheAdapter from '../../IEntityCacheAdapter';
+import {
+  deepEqualEntityAware,
+  isEqualWithEntityAware,
+} from '../../utils/__testfixtures__/TSMockitoExtensions';
 import ReadThroughEntityCache, { CacheStatus } from '../ReadThroughEntityCache';
 import {
   SingleFieldHolder,
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
 } from '../SingleFieldHolder';
-import { deepEqualEntityAware, isEqualWithEntityAware } from './TSMockitoExtensions';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
+++ b/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
@@ -1,9 +1,12 @@
 import isEqualWith from 'lodash/isEqualWith';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 
-import { SerializableKeyMap } from '../../utils/collections/SerializableKeyMap';
-import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../SingleFieldHolder';
+import {
+  CompositeFieldHolder,
+  CompositeFieldValueHolder,
+} from '../../internal/CompositeFieldHolder';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../../internal/SingleFieldHolder';
+import { SerializableKeyMap } from '../collections/SerializableKeyMap';
 
 export function isEqualWithEntityAware(expected: any, actual: any): boolean {
   return isEqualWith(expected, actual, (expected: any, actual: any): boolean | undefined => {

--- a/packages/entity/tsconfig.build.json
+++ b/packages/entity/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+}

--- a/packages/entity/tsconfig.json
+++ b/packages/entity/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "build",
-  },
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "**/__tests__/**",
+    "**/__integration-tests__/**",
+    "**/__mocks__/**",
+    "**/__testfixtures__/**"
+  ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "strict": true,
+    "outDir": "${configDir}/build",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitAny": true,
@@ -19,5 +20,5 @@
     "noImplicitOverride": true,
     "esModuleInterop": true,
     "types": ["jest", "node"]
-  }
+  },
 }


### PR DESCRIPTION
# Why

A follow-up to #280 to no longer include test files in built files. While this shouldn't matter too much (since they weren't in the barrel files) it is still better for sanity.

This allows us to consolidate testfixture pattern and clean up the sync test from #280.

# How

Add new tsconfigs, update scripts, update test.

# Test Plan

Run tests. Then try `yarn tsc` and `yarn build`, inspect the outputs.