### PR TITLE
fix: fix generated tsc definition sentinel type visibility

### DIFF
--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -177,7 +177,7 @@ export abstract class EntityFieldDefinition<T, TRequireExplicitCache extends boo
 
   // @ts-expect-error this is to ensure that different constructor requirements produce incompatible
   // objects in the eyes of the type system
-  private readonly cacheRawSentinel: TRequireExplicitCache;
+  protected readonly _cacheRawSentinel: TRequireExplicitCache;
 
   /**
    * @param options - options for this field definition


### PR DESCRIPTION
# Why

This sentinel makes the inferred type compatibility between instances of a class with `EntityFieldDefinitionOptionsExplicitCache` incompatible with `EntityFieldDefinitionOptions`. The problem is that tsc removes types from private fields, so the generate .d.ts file didn't have an appropriate sentinel in the resulting library typedefs.

# How

This PR fixes it by making the field protected, which seems to be the only option.

# Test Plan

The way to test this is by trying it in a library that consumes `@expo/entity`, notably `@expo/entity-example` on the `NoteEntity` with the built .d.ts file.
