### PR TITLE
feat: add transaction-scoped dataloaders

### DIFF
--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -47,7 +47,7 @@ describe(PostgresEntityQueryContextProvider, () => {
         .updateAsync();
 
       // ensure the outer transaction is not aborted due to postgres error in inner transaction,
-      // in this case the error triggered is a unique constraint violation
+      // in this case the error triggered is a unique constraint violation from a conflict with the first entity created above
       try {
         await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
           const entity = await PostgresUniqueTestEntity.loader(
@@ -68,6 +68,342 @@ describe(PostgresEntityQueryContextProvider, () => {
 
     const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(id);
     expect(entityLoaded.getField('name')).toEqual('wat3');
+  });
+
+  test('dataloader consistency with nested transactions', async () => {
+    const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+    // put it in local dataloader
+    const entity = await PostgresUniqueTestEntity.creator(vc1)
+      .setField('name', 'who')
+      .createAsync();
+    const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(entity.getID());
+    expect(entityLoaded.getField('name')).toEqual('who');
+
+    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+      const entityLoadedOuter = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
+        entity.getID(),
+      );
+      expect(entityLoadedOuter.getField('name')).toEqual('who');
+
+      await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+        const entityLoadedInner = await PostgresUniqueTestEntity.loader(
+          vc1,
+          innerQueryContext,
+        ).loadByIDAsync(entity.getID());
+        const updatedEntity = await PostgresUniqueTestEntity.updater(
+          entityLoadedInner,
+          innerQueryContext,
+        )
+          .setField('name', 'wat')
+          .updateAsync();
+        expect(updatedEntity.getField('name')).toEqual('wat');
+      });
+
+      const entityLoadedAfterNested = await PostgresUniqueTestEntity.loader(
+        vc1,
+        queryContext,
+      ).loadByIDAsync(entity.getID());
+      expect(entityLoadedAfterNested.getField('name')).toEqual('wat');
+    });
+
+    const entityLoadedAfterTransaction = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
+      entity.getID(),
+    );
+    expect(entityLoadedAfterTransaction.getField('name')).toEqual('wat');
+  });
+
+  test('dataloader consistency with nested transactions that throw', async () => {
+    const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+    // put it in local dataloader
+    const entity = await PostgresUniqueTestEntity.creator(vc1)
+      .setField('name', 'who')
+      .createAsync();
+    const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(entity.getID());
+    expect(entityLoaded.getField('name')).toEqual('who');
+
+    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+      const entityLoadedOuter = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
+        entity.getID(),
+      );
+      expect(entityLoadedOuter.getField('name')).toEqual('who');
+
+      try {
+        await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+          const entityLoadedInner = await PostgresUniqueTestEntity.loader(
+            vc1,
+            innerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          const updatedEntity = await PostgresUniqueTestEntity.updater(
+            entityLoadedInner,
+            innerQueryContext,
+          )
+            .setField('name', 'wat')
+            .updateAsync();
+          expect(updatedEntity.getField('name')).toEqual('wat');
+          throw new Error('wat');
+        });
+      } catch {}
+
+      const entityLoadedAfterNested = await PostgresUniqueTestEntity.loader(
+        vc1,
+        queryContext,
+      ).loadByIDAsync(entity.getID());
+      expect(entityLoadedAfterNested.getField('name')).toEqual('who');
+    });
+
+    const entityLoadedAfterTransaction = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
+      entity.getID(),
+    );
+    expect(entityLoadedAfterTransaction.getField('name')).toEqual('who');
+  });
+
+  test('dataloader consistency with concurrent loads outside of transaction', async () => {
+    const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+    // put it in local dataloader
+    const entity = await PostgresUniqueTestEntity.creator(vc1)
+      .setField('name', 'who')
+      .createAsync();
+    const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(entity.getID());
+    expect(entityLoaded.getField('name')).toEqual('who');
+
+    let openBarrier1: () => void;
+    const barrier1 = new Promise<void>((resolve) => {
+      openBarrier1 = resolve;
+    });
+
+    let openBarrier2: () => void;
+    const barrier2 = new Promise<void>((resolve) => {
+      openBarrier2 = resolve;
+    });
+
+    await Promise.all([
+      vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+        const entityLoadedOuter = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
+          entity.getID(),
+        );
+        expect(entityLoadedOuter.getField('name')).toEqual('who');
+
+        await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+          const entityLoadedInner = await PostgresUniqueTestEntity.loader(
+            vc1,
+            innerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          const updatedEntity = await PostgresUniqueTestEntity.updater(
+            entityLoadedInner,
+            innerQueryContext,
+          )
+            .setField('name', 'wat')
+            .updateAsync();
+          expect(updatedEntity.getField('name')).toEqual('wat');
+          const entityLoadedAfterUpdate = await PostgresUniqueTestEntity.loader(
+            vc1,
+            innerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          expect(entityLoadedAfterUpdate.getField('name')).toEqual('wat');
+        });
+        openBarrier1();
+        await barrier2;
+      }),
+      (async () => {
+        await barrier1;
+
+        const entityLoadedOutsideOfTransactionsBeforeNestedCommit =
+          await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(entity.getID());
+        expect(entityLoadedOutsideOfTransactionsBeforeNestedCommit.getField('name')).toEqual('who');
+        openBarrier2!();
+      })(),
+    ]);
+
+    const entityLoadedAfterTransaction = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
+      entity.getID(),
+    );
+    expect(entityLoadedAfterTransaction.getField('name')).toEqual('wat');
+  });
+
+  test('consistent behavior with and without transactional dataloader for concurrent loads outside of nested transaction', async () => {
+    // Subtransactions are not supported in postgres. See #194 for more info.
+    // Instead, savepoints and rollbacks are used to simulate subtransactions, which results in non-isolated read semantics.
+    //
+    // This test tests the same behavior exists whether there is a dataloader or not in transactions, thus indicating that
+    // the dataloader invalidation is not the issue.
+
+    const runTest = async (shouldDisableTransactionalDataloader: boolean): Promise<void> => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+      await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+        'postgres',
+        async (outerQueryContext) => {
+          // put it in local dataloader
+          const entity = await PostgresUniqueTestEntity.creator(vc1, outerQueryContext)
+            .setField('name', 'who')
+            .createAsync();
+          const entityLoaded = await PostgresUniqueTestEntity.loader(
+            vc1,
+            outerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          if (entityLoaded.getField('name') !== 'who') {
+            throw new Error('entity loaded wrong value');
+          }
+
+          let openBarrier1: () => void;
+          const barrier1 = new Promise<void>((resolve) => {
+            openBarrier1 = resolve;
+          });
+
+          let openBarrier2: () => void;
+          const barrier2 = new Promise<void>((resolve) => {
+            openBarrier2 = resolve;
+          });
+
+          await Promise.all([
+            outerQueryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+              const entityLoadedInner = await PostgresUniqueTestEntity.loader(
+                vc1,
+                innerQueryContext,
+              ).loadByIDAsync(entity.getID());
+              const updatedEntity = await PostgresUniqueTestEntity.updater(
+                entityLoadedInner,
+                innerQueryContext,
+              )
+                .setField('name', 'wat')
+                .updateAsync();
+              if (updatedEntity.getField('name') !== 'wat') {
+                throw new Error('entity updated wrong value');
+              }
+
+              const entityLoadedAfterUpdate = await PostgresUniqueTestEntity.loader(
+                vc1,
+                innerQueryContext,
+              ).loadByIDAsync(entity.getID());
+              if (entityLoadedAfterUpdate.getField('name') !== 'wat') {
+                throw new Error('entity loaded wrong value after update');
+              }
+              openBarrier1();
+              await barrier2;
+            }),
+            (async () => {
+              await barrier1;
+
+              // if postgres supported nested transactions, this would read isolated from the nested transaction above
+              // but since it doesn't, this will read the updated value.
+              const entityLoadedInOuterTransactionBeforeNestedCommit =
+                await PostgresUniqueTestEntity.loader(vc1, outerQueryContext).loadByIDAsync(
+                  entity.getID(),
+                );
+              if (entityLoadedInOuterTransactionBeforeNestedCommit.getField('name') !== 'who') {
+                throw new Error('outer transaction read wrong value');
+              }
+
+              openBarrier2!();
+            })(),
+          ]);
+
+          const entityLoadedAfterTransaction = await PostgresUniqueTestEntity.loader(
+            vc1,
+            outerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          if (entityLoadedAfterTransaction.getField('name') !== 'wat') {
+            throw new Error('entity loaded wrong value after transaction');
+          }
+        },
+        { disableTransactionalDataloader: shouldDisableTransactionalDataloader },
+      );
+    };
+
+    await expect(runTest(true)).rejects.toThrow('outer transaction read wrong value');
+    await expect(runTest(false)).rejects.toThrow('outer transaction read wrong value');
+  });
+
+  test('consistent behavior with and without transactional dataloader for concurrent mutations outside of nested transaction that reads', async () => {
+    // this test has a similar issue to the one above: absence of real nested transactions in postgres
+    // this should have the same behavior no matter if there is a dataloader or not in transactions
+
+    const runTest = async (shouldDisableTransactionalDataloader: boolean): Promise<void> => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+      await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+        'postgres',
+        async (outerQueryContext) => {
+          // put it in local dataloader
+          const entity = await PostgresUniqueTestEntity.creator(vc1, outerQueryContext)
+            .setField('name', 'who')
+            .createAsync();
+          const entityLoaded = await PostgresUniqueTestEntity.loader(
+            vc1,
+            outerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          if (entityLoaded.getField('name') !== 'who') {
+            throw new Error('entity loaded wrong value');
+          }
+
+          let openBarrier1: () => void;
+          const barrier1 = new Promise<void>((resolve) => {
+            openBarrier1 = resolve;
+          });
+
+          let openBarrier2: () => void;
+          const barrier2 = new Promise<void>((resolve) => {
+            openBarrier2 = resolve;
+          });
+
+          await Promise.all([
+            (async () => {
+              await barrier1;
+
+              const entityLoadedOuterAgain = await PostgresUniqueTestEntity.loader(
+                vc1,
+                outerQueryContext,
+              ).loadByIDAsync(entity.getID());
+              const updatedEntity = await PostgresUniqueTestEntity.updater(
+                entityLoadedOuterAgain,
+                outerQueryContext,
+              )
+                .setField('name', 'wat')
+                .updateAsync();
+              if (updatedEntity.getField('name') !== 'wat') {
+                throw new Error('entity updated wrong value');
+              }
+
+              openBarrier2!();
+            })(),
+
+            outerQueryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+              const entityLoadedInner = await PostgresUniqueTestEntity.loader(
+                vc1,
+                innerQueryContext,
+              ).loadByIDAsync(entity.getID());
+              if (entityLoadedInner.getField('name') !== 'who') {
+                throw new Error('entity loaded inner wrong value 1');
+              }
+
+              openBarrier1();
+              await barrier2;
+
+              const entityLoadedInnerAgain = await PostgresUniqueTestEntity.loader(
+                vc1,
+                innerQueryContext,
+              ).loadByIDAsync(entity.getID());
+              if (entityLoadedInnerAgain.getField('name') !== 'who') {
+                throw new Error('entity loaded inner wrong value 2');
+              }
+            }),
+          ]);
+
+          const entityLoadedAfterTransaction = await PostgresUniqueTestEntity.loader(
+            vc1,
+            outerQueryContext,
+          ).loadByIDAsync(entity.getID());
+          if (entityLoadedAfterTransaction.getField('name') !== 'wat') {
+            throw new Error('entity loaded wrong value after transaction');
+          }
+        },
+        { disableTransactionalDataloader: shouldDisableTransactionalDataloader },
+      );
+    };
+
+    await expect(runTest(true)).rejects.toThrow('entity loaded inner wrong value 2');
+    await expect(runTest(false)).rejects.toThrow('entity loaded inner wrong value 2');
   });
 
   it('supports multi-nested transactions', async () => {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -163,7 +163,7 @@ describe('Lack of entity cache push safety with RedisCacheInvalidationStrategy.C
       await TestEntityPreDeploy.loader(viewerContextRequest1).loadByIDAsync(entityId);
     expect(entityReq1Loaded).not.toBeNull();
 
-    // request 2 loads the entity in the new code version (caching it in cache key version 2), updates it (invalidating in both 1 and 2), and loads it again (caching it in cache key version 2)
+    // request 2 loads the entity in the new code version (caching it in cache key version 2), updates it (invalidating in 2), and loads it again (caching it in cache key version 2)
     const viewerContextRequest2 = new ViewerContext(
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );
@@ -174,7 +174,7 @@ describe('Lack of entity cache push safety with RedisCacheInvalidationStrategy.C
       await TestEntityNew.loader(viewerContextRequest2).loadByIDAsync(entityId);
     expect(entityReq2UpdatedLoaded).not.toBeNull();
 
-    // request 3 loads the entity in the old code version (caching it in cache key version 1), updates it (invalidating in both 1 and 2), and loads it again (caching it in cache key version 1)
+    // request 3 loads the entity in the old code version (loading it from cache key version 1)
     const viewerContextRequest3 = new ViewerContext(
       createFullIntegrationTestEntityCompanionProvider(knexInstance, genericRedisCacheContext),
     );

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -31,9 +31,7 @@
     "@expo/results": "^1.0.0",
     "dataloader": "^2.2.3",
     "es6-error": "^4.1.1",
-    "invariant": "^2.2.4",
-    "uuid": "^8.3.0",
-    "uuidv7": "^1.0.0"
+    "invariant": "^2.2.4"
   },
   "devDependencies": {
     "@types/invariant": "^2.2.37",
@@ -51,6 +49,8 @@
     "prettier-plugin-organize-imports": "^4.1.0",
     "ts-jest": "^29.3.2",
     "ts-mockito": "^2.6.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "uuid": "^8.3.0",
+    "uuidv7": "^1.0.0"
   }
 }

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -7,7 +7,7 @@ import EntityDatabaseAdapter, {
   QuerySelectionModifiers,
   QuerySelectionModifiersWithOrderByRaw,
 } from '../EntityDatabaseAdapter';
-import { EntityQueryContext } from '../EntityQueryContext';
+import { EntityQueryContext, EntityTransactionalQueryContext } from '../EntityQueryContext';
 import EntityQueryContextProvider from '../EntityQueryContextProvider';
 import { partitionErrors } from '../entityUtils';
 import { IEntityLoadKey, IEntityLoadValue, LoadPair } from './EntityLoadInterfaces';
@@ -21,6 +21,11 @@ import IEntityMetricsAdapter, {
 } from '../metrics/IEntityMetricsAdapter';
 import { computeIfAbsent } from '../utils/collections/maps';
 
+type DataLoaderMap<TFields extends Record<string, any>> = Map<
+  string,
+  DataLoader<unknown, readonly Readonly<TFields>[]>
+>;
+
 /**
  * A data manager is responsible for orchestrating multiple sources of entity
  * data including local caches, EntityCacheAdapter, and EntityDatabaseAdapter.
@@ -31,8 +36,11 @@ export default class EntityDataManager<
   TFields extends Record<string, any>,
   TIDField extends keyof TFields,
 > {
-  private readonly dataloaders: Map<string, DataLoader<unknown, readonly Readonly<TFields>[]>> =
-    new Map();
+  // map from (load method type + data manager data loader key) to dataloader
+  private readonly dataLoaders: DataLoaderMap<TFields> = new Map();
+
+  // map from transaction id to dataloader map
+  private readonly transactionalDataLoaders: Map<string, DataLoaderMap<TFields>> = new Map();
 
   constructor(
     private readonly databaseAdapter: EntityDatabaseAdapter<TFields, TIDField>,
@@ -48,7 +56,7 @@ export default class EntityDataManager<
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey): DataLoader<TSerializedLoadValue, readonly Readonly<TFields>[]> {
     return computeIfAbsent(
-      this.dataloaders,
+      this.dataLoaders,
       key.getLoadMethodType() + key.getDataManagerDataLoaderKey(),
       () => {
         return new DataLoader(
@@ -58,7 +66,7 @@ export default class EntityDataManager<
             const values = serializedLoadValues.map((serializedLoadValue) =>
               key.deserializeLoadValue(serializedLoadValue),
             );
-            const objectMap = await this.loadManyForDataLoaderAsync(key, values);
+            const objectMap = await this.loadManyForNonTransactionalDataLoaderAsync(key, values);
             return values.map((value) => objectMap.get(value) ?? []);
           },
         );
@@ -66,7 +74,7 @@ export default class EntityDataManager<
     );
   }
 
-  private async loadManyForDataLoaderAsync<
+  private async loadManyForNonTransactionalDataLoaderAsync<
     TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
     TSerializedLoadValue,
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
@@ -76,6 +84,7 @@ export default class EntityDataManager<
   ): Promise<ReadonlyMap<TLoadValue, readonly Readonly<TFields>[]>> {
     this.metricsAdapter.incrementDataManagerLoadCount({
       type: IncrementLoadCountEventType.CACHE,
+      isInTransaction: false,
       fieldValueCount: values.length,
       entityClassName: this.entityClassName,
       loadType: key.getLoadMethodType(),
@@ -84,6 +93,7 @@ export default class EntityDataManager<
     return await this.entityCache.readManyThroughAsync(key, values, async (fetcherValues) => {
       this.metricsAdapter.incrementDataManagerLoadCount({
         type: IncrementLoadCountEventType.DATABASE,
+        isInTransaction: false,
         fieldValueCount: fetcherValues.length,
         entityClassName: this.entityClassName,
         loadType: key.getLoadMethodType(),
@@ -94,6 +104,61 @@ export default class EntityDataManager<
         fetcherValues,
       );
     });
+  }
+
+  private getTransactionalDataLoaderForLoadKey<
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    queryContext: EntityTransactionalQueryContext,
+    key: TLoadKey,
+  ): DataLoader<TSerializedLoadValue, readonly Readonly<TFields>[]> {
+    const dataLoaderMapForTransaction = computeIfAbsent(
+      this.transactionalDataLoaders,
+      queryContext.transactionId,
+      () => new Map(),
+    );
+    return computeIfAbsent(
+      dataLoaderMapForTransaction,
+      key.getLoadMethodType() + key.getDataManagerDataLoaderKey(),
+      () => {
+        return new DataLoader(
+          async (
+            serializedLoadValues: readonly TSerializedLoadValue[],
+          ): Promise<readonly (readonly TFields[])[]> => {
+            const values = serializedLoadValues.map((serializedLoadValue) =>
+              key.deserializeLoadValue(serializedLoadValue),
+            );
+            const objectMap = await this.loadManyForTransactionalDataLoaderAsync(
+              queryContext,
+              key,
+              values,
+            );
+            return values.map((value) => objectMap.get(value) ?? []);
+          },
+        );
+      },
+    );
+  }
+
+  private async loadManyForTransactionalDataLoaderAsync<
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(
+    queryContext: EntityTransactionalQueryContext,
+    key: TLoadKey,
+    values: readonly TLoadValue[],
+  ): Promise<ReadonlyMap<TLoadValue, readonly Readonly<TFields>[]>> {
+    this.metricsAdapter.incrementDataManagerLoadCount({
+      type: IncrementLoadCountEventType.DATABASE,
+      isInTransaction: true,
+      fieldValueCount: values.length,
+      entityClassName: this.entityClassName,
+      loadType: key.getLoadMethodType(),
+    });
+    return await this.databaseAdapter.fetchManyWhereAsync(queryContext, key, values);
   }
 
   /**
@@ -117,6 +182,7 @@ export default class EntityDataManager<
       this.metricsAdapter,
       EntityMetricsLoadType.LOAD_MANY,
       this.entityClassName,
+      queryContext,
     )(this.loadManyEqualingInternalAsync(queryContext, key, values));
   }
 
@@ -132,17 +198,27 @@ export default class EntityDataManager<
     key.validateRuntimeLoadValuesForDataManagerDataLoader(values, this.entityClassName);
 
     // don't cache when in transaction, as rollbacks complicate things significantly
-    if (queryContext.isInTransaction()) {
+    if (queryContext.isInTransaction() && queryContext.shouldDisableTransactionalDataloader) {
+      this.metricsAdapter.incrementDataManagerLoadCount({
+        type: IncrementLoadCountEventType.DATABASE,
+        isInTransaction: true,
+        fieldValueCount: values.length,
+        entityClassName: this.entityClassName,
+        loadType: key.getLoadMethodType(),
+      });
       return await this.databaseAdapter.fetchManyWhereAsync(queryContext, key, values);
     }
 
     this.metricsAdapter.incrementDataManagerLoadCount({
       type: IncrementLoadCountEventType.DATALOADER,
+      isInTransaction: queryContext.isInTransaction(),
       fieldValueCount: values.length,
       entityClassName: this.entityClassName,
       loadType: key.getLoadMethodType(),
     });
-    const dataLoader = this.getDataLoaderForLoadKey(key);
+    const dataLoader = queryContext.isInTransaction()
+      ? this.getTransactionalDataLoaderForLoadKey(queryContext, key)
+      : this.getDataLoaderForLoadKey(key);
     const results = await dataLoader.loadMany(values.map((v) => key.serializeLoadValue(v)));
     const [successfulValues, errors] = partitionErrors(results);
     if (errors.length > 0) {
@@ -179,6 +255,7 @@ export default class EntityDataManager<
       this.metricsAdapter,
       EntityMetricsLoadType.LOAD_MANY_EQUALITY_CONJUNCTION,
       this.entityClassName,
+      queryContext,
     )(
       this.databaseAdapter.fetchManyByFieldEqualityConjunctionAsync(
         queryContext,
@@ -207,6 +284,7 @@ export default class EntityDataManager<
       this.metricsAdapter,
       EntityMetricsLoadType.LOAD_MANY_RAW,
       this.entityClassName,
+      queryContext,
     )(
       this.databaseAdapter.fetchManyByRawWhereClauseAsync(
         queryContext,
@@ -226,6 +304,16 @@ export default class EntityDataManager<
     this.getDataLoaderForLoadKey(key).clear(key.serializeLoadValue(value));
   }
 
+  private invalidateOneForTransaction<
+    TLoadKey extends IEntityLoadKey<TFields, TIDField, TSerializedLoadValue, TLoadValue>,
+    TSerializedLoadValue,
+    TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
+  >(queryContext: EntityTransactionalQueryContext, key: TLoadKey, value: TLoadValue): void {
+    this.getTransactionalDataLoaderForLoadKey(queryContext, key).clear(
+      key.serializeLoadValue(value),
+    );
+  }
+
   /**
    * Invalidate all caches, in-memory or otherwise, for sets of key-value pairs.
    * @param pairs - key-value pairs to invalidate
@@ -233,7 +321,67 @@ export default class EntityDataManager<
   public async invalidateKeyValuePairsAsync(
     pairs: readonly LoadPair<TFields, TIDField, any, any, any>[],
   ): Promise<void> {
-    // TODO(wschurman): check for races with load
     await Promise.all(pairs.map(([key, value]) => this.invalidateOneAsync(key, value)));
+  }
+
+  /**
+   * Invalidate all in-memory caches for sets of key-value pairs for all transactions and parent transactions.
+   * @param pairs - key-value pairs to invalidate
+   */
+  public invalidateKeyValuePairsForTransaction(
+    queryContext: EntityTransactionalQueryContext,
+    pairs: readonly LoadPair<TFields, TIDField, any, any, any>[],
+  ): void {
+    if (queryContext.shouldDisableTransactionalDataloader) {
+      return;
+    }
+
+    // invalidate all query contexts in transaction tree
+    const outermostTransactionalQueryContext =
+      EntityDataManager.getOutermostTransactionalQueryContextIfInNestedTransaction(queryContext);
+    const allQueryContextsToInvalidate = [
+      outermostTransactionalQueryContext,
+      ...EntityDataManager.getAllDescendantTransactionalQueryContexts(
+        outermostTransactionalQueryContext,
+      ),
+    ];
+    for (const currentQueryContext of allQueryContextsToInvalidate) {
+      for (const [key, value] of pairs) {
+        this.invalidateOneForTransaction(currentQueryContext, key, value);
+      }
+    }
+  }
+
+  /**
+   * Traverse to root of transactional query context tree.
+   */
+  private static getOutermostTransactionalQueryContextIfInNestedTransaction(
+    queryContext: EntityTransactionalQueryContext,
+  ): EntityTransactionalQueryContext {
+    if (queryContext.isInNestedTransaction()) {
+      return EntityDataManager.getOutermostTransactionalQueryContextIfInNestedTransaction(
+        queryContext.parentQueryContext,
+      );
+    } else {
+      return queryContext;
+    }
+  }
+
+  /**
+   * Get a list of all child query contexts recursively for a given query context.
+   */
+  private static getAllDescendantTransactionalQueryContexts(
+    queryContext: EntityTransactionalQueryContext,
+  ): readonly EntityTransactionalQueryContext[] {
+    if (queryContext.childQueryContexts.length === 0) {
+      return [];
+    }
+
+    return queryContext.childQueryContexts.flatMap((childQueryContext) => {
+      return [
+        childQueryContext,
+        ...EntityDataManager.getAllDescendantTransactionalQueryContexts(childQueryContext),
+      ];
+    });
   }
 }

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -4,11 +4,11 @@ import {
   when,
   anything,
   verify,
-  objectContaining,
   spy,
   anyString,
   resetCalls,
   deepEqual,
+  anyNumber,
 } from 'ts-mockito';
 
 import EntityDatabaseAdapter from '../../EntityDatabaseAdapter';
@@ -310,6 +310,159 @@ describe(EntityDataManager, () => {
     cacheSpy.mockReset();
   });
 
+  it('loads and in-memory caches (dataloader) loads in transaction when enabled and does not read from cache for transactions and nested transactions', async () => {
+    const objects = getObjects();
+    const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+      testEntityConfiguration,
+      objects,
+    );
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
+    const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+    const entityDataManager = new EntityDataManager(
+      databaseAdapter,
+      entityCache,
+      new StubQueryContextProvider(),
+      new NoOpEntityMetricsAdapter(),
+      TestEntity.name,
+    );
+
+    const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
+    const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
+
+    const [entityData, entityData2, entityData3, entityData4] =
+      await new StubQueryContextProvider().runInTransactionAsync(async (queryContext) => {
+        const entityData = await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('stringField'),
+          [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+        );
+        const entityData2 = await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('stringField'),
+          [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+        );
+        const [entityData3, entityData4] = await queryContext.runInNestedTransactionAsync(
+          async (innerQueryContext) => {
+            const entityData3 = await entityDataManager.loadManyEqualingAsync(
+              innerQueryContext,
+              new SingleFieldHolder('stringField'),
+              [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+            );
+
+            const entityData4 = await queryContext.runInNestedTransactionAsync(
+              async (innerInnerQueryContext) => {
+                return await entityDataManager.loadManyEqualingAsync(
+                  innerInnerQueryContext,
+                  new SingleFieldHolder('stringField'),
+                  [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+                );
+              },
+            );
+
+            return [entityData3, entityData4];
+          },
+        );
+        return [entityData, entityData2, entityData3, entityData4];
+      });
+
+    // entityData, entityData3 (new nested transaction), and entityData4 (new nested transaction) loads should all need to call the database
+    expect(dbSpy).toHaveBeenCalledTimes(3);
+    expect(cacheSpy).toHaveBeenCalledTimes(0);
+
+    expect(entityData).toMatchObject(entityData2);
+    expect(entityData2).toMatchObject(entityData3);
+    expect(entityData3).toMatchObject(entityData4);
+    expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
+    expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
+
+    dbSpy.mockReset();
+    cacheSpy.mockReset();
+  });
+
+  it('loads and does not in-memory cache (dataloader) loads in transaction when disabled', async () => {
+    const objects = getObjects();
+    const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+      testEntityConfiguration,
+      objects,
+    );
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
+    const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+    const entityDataManager = new EntityDataManager(
+      databaseAdapter,
+      entityCache,
+      new StubQueryContextProvider(),
+      new NoOpEntityMetricsAdapter(),
+      TestEntity.name,
+    );
+
+    const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
+    const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
+
+    const [entityData, entityData2, entityData3, entityData4] =
+      await new StubQueryContextProvider().runInTransactionAsync(
+        async (queryContext) => {
+          const entityData = await entityDataManager.loadManyEqualingAsync(
+            queryContext,
+            new SingleFieldHolder('stringField'),
+            [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+          );
+          const entityData2 = await entityDataManager.loadManyEqualingAsync(
+            queryContext,
+            new SingleFieldHolder('stringField'),
+            [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+          );
+          const [entityData3, entityData4] = await queryContext.runInNestedTransactionAsync(
+            async (innerQueryContext) => {
+              const entityData3 = await entityDataManager.loadManyEqualingAsync(
+                innerQueryContext,
+                new SingleFieldHolder('stringField'),
+                [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+              );
+
+              const entityData4 = await queryContext.runInNestedTransactionAsync(
+                async (innerInnerQueryContext) => {
+                  return await entityDataManager.loadManyEqualingAsync(
+                    innerInnerQueryContext,
+                    new SingleFieldHolder('stringField'),
+                    [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
+                  );
+                },
+              );
+
+              return [entityData3, entityData4];
+            },
+          );
+          return [entityData, entityData2, entityData3, entityData4];
+        },
+        {
+          disableTransactionalDataloader: true,
+        },
+      );
+
+    // entityData, entityData2, entityData3 (new nested transaction), and entityData4 (new nested transaction) loads should all need to call the database
+    expect(dbSpy).toHaveBeenCalledTimes(4);
+    expect(cacheSpy).toHaveBeenCalledTimes(0);
+
+    expect(entityData).toMatchObject(entityData2);
+    expect(entityData2).toMatchObject(entityData3);
+    expect(entityData3).toMatchObject(entityData4);
+    expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
+    expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
+
+    dbSpy.mockReset();
+    cacheSpy.mockReset();
+  });
+
   it('invalidates objects', async () => {
     const objects = getObjects();
     const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
@@ -412,7 +565,141 @@ describe(EntityDataManager, () => {
     cacheSpy.mockReset();
   });
 
-  it('loads only from DB when in transaction', async () => {
+  it('invalidates transactions and nested transactions correctly', async () => {
+    const objects = getObjects();
+    const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+      testEntityConfiguration,
+      objects,
+    );
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
+    const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+    const entityDataManager = new EntityDataManager(
+      databaseAdapter,
+      entityCache,
+      new StubQueryContextProvider(),
+      new NoOpEntityMetricsAdapter(),
+      TestEntity.name,
+    );
+
+    await new StubQueryContextProvider().runInTransactionAsync(async (queryContext) => {
+      const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1]!;
+
+      const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
+      const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
+
+      await entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('testIndexedField'),
+        [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+      );
+      entityDataManager.invalidateKeyValuePairsForTransaction(queryContext, [
+        [
+          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
+        ],
+      ]);
+      await entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('testIndexedField'),
+        [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+      );
+
+      expect(dbSpy).toHaveBeenCalledTimes(2);
+      expect(cacheSpy).toHaveBeenCalledTimes(0);
+
+      dbSpy.mockClear();
+      cacheSpy.mockClear();
+
+      await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+        await entityDataManager.loadManyEqualingAsync(
+          innerQueryContext,
+          new SingleFieldHolder('testIndexedField'),
+          [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+        );
+        entityDataManager.invalidateKeyValuePairsForTransaction(innerQueryContext, [
+          [
+            new SingleFieldHolder('testIndexedField'),
+            new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
+          ],
+        ]);
+        await entityDataManager.loadManyEqualingAsync(
+          innerQueryContext,
+          new SingleFieldHolder('testIndexedField'),
+          [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+        );
+
+        expect(dbSpy).toHaveBeenCalledTimes(2);
+        expect(cacheSpy).toHaveBeenCalledTimes(0);
+
+        dbSpy.mockClear();
+        cacheSpy.mockClear();
+      });
+    });
+  });
+
+  it('does not use transactional dataloader when disabled', async () => {
+    const objects = getObjects();
+    const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+      testEntityConfiguration,
+      objects,
+    );
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
+    const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+    const entityDataManager = new EntityDataManager(
+      databaseAdapter,
+      entityCache,
+      new StubQueryContextProvider(),
+      new NoOpEntityMetricsAdapter(),
+      TestEntity.name,
+    );
+
+    await new StubQueryContextProvider().runInTransactionAsync(
+      async (queryContext) => {
+        const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1]!;
+
+        const dbSpy = jest.spyOn(databaseAdapter, 'fetchManyWhereAsync');
+        const cacheSpy = jest.spyOn(entityCache, 'readManyThroughAsync');
+
+        await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('testIndexedField'),
+          [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+        );
+        entityDataManager.invalidateKeyValuePairsForTransaction(queryContext, [
+          [
+            new SingleFieldHolder('testIndexedField'),
+            new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
+          ],
+        ]);
+        await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('testIndexedField'),
+          [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
+        );
+
+        expect(dbSpy).toHaveBeenCalledTimes(2);
+        expect(cacheSpy).toHaveBeenCalledTimes(0);
+
+        dbSpy.mockClear();
+        cacheSpy.mockClear();
+      },
+      { disableTransactionalDataloader: true },
+    );
+
+    expect(entityDataManager['transactionalDataLoaders'].size).toBe(0);
+  });
+
+  it('does not load from cache when in transaction', async () => {
     const objects = getObjects();
     const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
       testEntityConfiguration,
@@ -533,194 +820,350 @@ describe(EntityDataManager, () => {
     ).rejects.toThrow();
   });
 
-  it('records metrics appropriately', async () => {
-    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
-    const metricsAdapter = instance(metricsAdapterMock);
+  describe('metrics', () => {
+    it('records metrics appropriately outside of transactions', async () => {
+      const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+      const metricsAdapter = instance(metricsAdapterMock);
 
-    const objects = getObjects();
-    const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
-      testEntityConfiguration,
-      objects,
-    );
-    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
-      testEntityConfiguration,
-      dataStore,
-    );
-    const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
-    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
-    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
-    const entityDataManager = new EntityDataManager(
-      databaseAdapter,
-      entityCache,
-      new StubQueryContextProvider(),
-      metricsAdapter,
-      TestEntity.name,
-    );
-    const queryContext = new StubQueryContextProvider().getQueryContext();
+      const objects = getObjects();
+      const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+        testEntityConfiguration,
+        objects,
+      );
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        dataStore,
+      );
+      const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+      const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+      const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+      const entityDataManager = new EntityDataManager(
+        databaseAdapter,
+        entityCache,
+        new StubQueryContextProvider(),
+        metricsAdapter,
+        TestEntity.name,
+      );
+      const queryContext = new StubQueryContextProvider().getQueryContext();
 
-    // make call to loadManyByFieldEqualingAsync to populate cache and dataloader, ensure metrics are recorded
-    // for dataloader, cache, and database
-    await entityDataManager.loadManyEqualingAsync(
-      queryContext,
-      new SingleFieldHolder('testIndexedField'),
-      [new SingleFieldValueHolder('unique1')],
-    );
-    verify(
-      metricsAdapterMock.logDataManagerLoadEvent(
-        objectContaining({
-          type: EntityMetricsLoadType.LOAD_MANY,
-          entityClassName: TestEntity.name,
-          count: 1,
-        }),
-      ),
-    ).once();
-    verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).thrice();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.DATALOADER,
-          fieldValueCount: 1,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.CACHE,
-          fieldValueCount: 1,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.DATABASE,
-          fieldValueCount: 1,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
+      // make call to loadManyByFieldEqualingAsync to populate cache and dataloader, ensure metrics are recorded
+      // for dataloader, cache, and database
+      await entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('testIndexedField'),
+        [new SingleFieldValueHolder('unique1')],
+      );
+      verify(
+        metricsAdapterMock.logDataManagerLoadEvent(
+          deepEqual({
+            type: EntityMetricsLoadType.LOAD_MANY,
+            isInTransaction: false,
+            entityClassName: TestEntity.name,
+            duration: anyNumber(),
+            count: 1,
+          }),
+        ),
+      ).once();
+      verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).thrice();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.DATALOADER,
+            isInTransaction: false,
+            fieldValueCount: 1,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.CACHE,
+            isInTransaction: false,
+            fieldValueCount: 1,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.DATABASE,
+            isInTransaction: false,
+            fieldValueCount: 1,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
 
-    resetCalls(metricsAdapterMock);
+      resetCalls(metricsAdapterMock);
 
-    // make second call to loadManyByFieldEqualingAsync, ensure metrics are only recorded for dataloader since
-    // entity is in local dataloader
-    await entityDataManager.loadManyEqualingAsync(
-      queryContext,
-      new SingleFieldHolder('testIndexedField'),
-      [new SingleFieldValueHolder('unique1')],
-    );
-    verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).once();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.DATALOADER,
-          fieldValueCount: 1,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
+      // make second call to loadManyByFieldEqualingAsync, ensure metrics are only recorded for dataloader since
+      // entity is in local dataloader
+      await entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('testIndexedField'),
+        [new SingleFieldValueHolder('unique1')],
+      );
+      verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).once();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.DATALOADER,
+            isInTransaction: false,
+            fieldValueCount: 1,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
 
-    resetCalls(metricsAdapterMock);
+      resetCalls(metricsAdapterMock);
 
-    // make third call in new data manager but query two keys, ensure only one of the keys is fetched
-    // from the database and the other is fetched from the cache
-    const entityCache2 = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
-    const entityDataManager2 = new EntityDataManager(
-      databaseAdapter,
-      entityCache2,
-      new StubQueryContextProvider(),
-      metricsAdapter,
-      TestEntity.name,
-    );
-    await entityDataManager2.loadManyEqualingAsync(
-      queryContext,
-      new SingleFieldHolder('testIndexedField'),
-      [new SingleFieldValueHolder('unique1'), new SingleFieldValueHolder('unique2')],
-    );
-    verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).thrice();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.DATALOADER,
-          fieldValueCount: 2,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.CACHE,
-          fieldValueCount: 2,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
-    verify(
-      metricsAdapterMock.incrementDataManagerLoadCount(
-        deepEqual({
-          type: IncrementLoadCountEventType.DATABASE,
-          fieldValueCount: 1,
-          entityClassName: TestEntity.name,
-          loadType: EntityLoadMethodType.SINGLE,
-        }),
-      ),
-    ).once();
+      // make third call in new data manager but query two keys, ensure only one of the keys is fetched
+      // from the database and the other is fetched from the cache
+      const entityCache2 = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+      const entityDataManager2 = new EntityDataManager(
+        databaseAdapter,
+        entityCache2,
+        new StubQueryContextProvider(),
+        metricsAdapter,
+        TestEntity.name,
+      );
+      await entityDataManager2.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder('testIndexedField'),
+        [new SingleFieldValueHolder('unique1'), new SingleFieldValueHolder('unique2')],
+      );
+      verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).thrice();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.DATALOADER,
+            isInTransaction: false,
+            fieldValueCount: 2,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.CACHE,
+            isInTransaction: false,
+            fieldValueCount: 2,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
+      verify(
+        metricsAdapterMock.incrementDataManagerLoadCount(
+          deepEqual({
+            type: IncrementLoadCountEventType.DATABASE,
+            isInTransaction: false,
+            fieldValueCount: 1,
+            entityClassName: TestEntity.name,
+            loadType: EntityLoadMethodType.SINGLE,
+          }),
+        ),
+      ).once();
 
-    resetCalls(metricsAdapterMock);
+      resetCalls(metricsAdapterMock);
 
-    await entityDataManager.loadManyByFieldEqualityConjunctionAsync(
-      queryContext,
-      [
-        {
-          fieldName: 'testIndexedField',
-          fieldValue: 'unique1',
-        },
-      ],
-      {},
-    );
-    verify(
-      metricsAdapterMock.logDataManagerLoadEvent(
-        objectContaining({
-          type: EntityMetricsLoadType.LOAD_MANY_EQUALITY_CONJUNCTION,
-          entityClassName: TestEntity.name,
-          count: 1,
-        }),
-      ),
-    ).once();
+      await entityDataManager.loadManyByFieldEqualityConjunctionAsync(
+        queryContext,
+        [
+          {
+            fieldName: 'testIndexedField',
+            fieldValue: 'unique1',
+          },
+        ],
+        {},
+      );
+      verify(
+        metricsAdapterMock.logDataManagerLoadEvent(
+          deepEqual({
+            type: EntityMetricsLoadType.LOAD_MANY_EQUALITY_CONJUNCTION,
+            isInTransaction: false,
+            entityClassName: TestEntity.name,
+            duration: anyNumber(),
+            count: 1,
+          }),
+        ),
+      ).once();
 
-    resetCalls(metricsAdapterMock);
+      resetCalls(metricsAdapterMock);
 
-    const databaseAdapterSpy = spy(databaseAdapter);
-    when(
-      databaseAdapterSpy.fetchManyByRawWhereClauseAsync(
-        anything(),
-        anyString(),
-        anything(),
-        anything(),
-      ),
-    ).thenResolve([]);
-    await entityDataManager.loadManyByRawWhereClauseAsync(queryContext, '', [], {});
-    verify(
-      metricsAdapterMock.logDataManagerLoadEvent(
-        objectContaining({
-          type: EntityMetricsLoadType.LOAD_MANY_RAW,
-          entityClassName: TestEntity.name,
-          count: 0,
-        }),
-      ),
-    ).once();
+      const databaseAdapterSpy = spy(databaseAdapter);
+      when(
+        databaseAdapterSpy.fetchManyByRawWhereClauseAsync(
+          anything(),
+          anyString(),
+          anything(),
+          anything(),
+        ),
+      ).thenResolve([]);
+      await entityDataManager.loadManyByRawWhereClauseAsync(queryContext, '', [], {});
+      verify(
+        metricsAdapterMock.logDataManagerLoadEvent(
+          deepEqual({
+            type: EntityMetricsLoadType.LOAD_MANY_RAW,
+            isInTransaction: false,
+            entityClassName: TestEntity.name,
+            duration: anyNumber(),
+            count: 0,
+          }),
+        ),
+      ).once();
 
-    verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).never();
+      verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).never();
+    });
+
+    it('records metrics appropriately inside of transactions', async () => {
+      const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+      const metricsAdapter = instance(metricsAdapterMock);
+
+      const objects = getObjects();
+      const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+        testEntityConfiguration,
+        objects,
+      );
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        dataStore,
+      );
+      const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+      const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+      const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+      const entityDataManager = new EntityDataManager(
+        databaseAdapter,
+        entityCache,
+        new StubQueryContextProvider(),
+        metricsAdapter,
+        TestEntity.name,
+      );
+
+      await new StubQueryContextProvider().runInTransactionAsync(async (queryContext) => {
+        // make call to loadManyByFieldEqualingAsync to populate cache and dataloader, ensure metrics are recorded
+        // for dataloader, cache, and database
+        await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('testIndexedField'),
+          [new SingleFieldValueHolder('unique1')],
+        );
+        verify(
+          metricsAdapterMock.logDataManagerLoadEvent(
+            deepEqual({
+              type: EntityMetricsLoadType.LOAD_MANY,
+              isInTransaction: true,
+              entityClassName: TestEntity.name,
+              duration: anyNumber(),
+              count: 1,
+            }),
+          ),
+        ).once();
+        verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).twice();
+        verify(
+          metricsAdapterMock.incrementDataManagerLoadCount(
+            deepEqual({
+              type: IncrementLoadCountEventType.DATALOADER,
+              isInTransaction: true,
+              fieldValueCount: 1,
+              entityClassName: TestEntity.name,
+              loadType: EntityLoadMethodType.SINGLE,
+            }),
+          ),
+        ).once();
+        verify(
+          metricsAdapterMock.incrementDataManagerLoadCount(
+            deepEqual({
+              type: IncrementLoadCountEventType.DATABASE,
+              isInTransaction: true,
+              fieldValueCount: 1,
+              entityClassName: TestEntity.name,
+              loadType: EntityLoadMethodType.SINGLE,
+            }),
+          ),
+        ).once();
+
+        resetCalls(metricsAdapterMock);
+
+        // make second call to loadManyByFieldEqualingAsync, ensure metrics are only recorded for dataloader since
+        // entity is in local dataloader
+        await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder('testIndexedField'),
+          [new SingleFieldValueHolder('unique1')],
+        );
+        verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).once();
+        verify(
+          metricsAdapterMock.incrementDataManagerLoadCount(
+            deepEqual({
+              type: IncrementLoadCountEventType.DATALOADER,
+              isInTransaction: true,
+              fieldValueCount: 1,
+              entityClassName: TestEntity.name,
+              loadType: EntityLoadMethodType.SINGLE,
+            }),
+          ),
+        ).once();
+
+        resetCalls(metricsAdapterMock);
+
+        await entityDataManager.loadManyByFieldEqualityConjunctionAsync(
+          queryContext,
+          [
+            {
+              fieldName: 'testIndexedField',
+              fieldValue: 'unique1',
+            },
+          ],
+          {},
+        );
+        verify(
+          metricsAdapterMock.logDataManagerLoadEvent(
+            deepEqual({
+              type: EntityMetricsLoadType.LOAD_MANY_EQUALITY_CONJUNCTION,
+              isInTransaction: true,
+              entityClassName: TestEntity.name,
+              duration: anyNumber(),
+              count: 1,
+            }),
+          ),
+        ).once();
+
+        resetCalls(metricsAdapterMock);
+
+        const databaseAdapterSpy = spy(databaseAdapter);
+        when(
+          databaseAdapterSpy.fetchManyByRawWhereClauseAsync(
+            anything(),
+            anyString(),
+            anything(),
+            anything(),
+          ),
+        ).thenResolve([]);
+        await entityDataManager.loadManyByRawWhereClauseAsync(queryContext, '', [], {});
+        verify(
+          metricsAdapterMock.logDataManagerLoadEvent(
+            deepEqual({
+              type: EntityMetricsLoadType.LOAD_MANY_RAW,
+              isInTransaction: true,
+              entityClassName: TestEntity.name,
+              duration: anyNumber(),
+              count: 0,
+            }),
+          ),
+        ).once();
+
+        verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).never();
+      });
+    });
   });
 
   it('throws when a single value load-by value is null or undefined', async () => {

--- a/packages/entity/src/metrics/EntityMetricsUtils.ts
+++ b/packages/entity/src/metrics/EntityMetricsUtils.ts
@@ -2,6 +2,7 @@ import IEntityMetricsAdapter, {
   EntityMetricsLoadType,
   EntityMetricsMutationType,
 } from './IEntityMetricsAdapter';
+import { EntityQueryContext } from '../EntityQueryContext';
 import { IEntityLoadValue } from '../internal/EntityLoadInterfaces';
 import { reduceMap } from '../utils/collections/maps';
 
@@ -10,6 +11,7 @@ export const timeAndLogLoadEventAsync =
     metricsAdapter: IEntityMetricsAdapter,
     loadType: EntityMetricsLoadType,
     entityClassName: string,
+    queryContext: EntityQueryContext,
   ) =>
   async <TFields>(promise: Promise<readonly Readonly<TFields>[]>) => {
     const startTime = Date.now();
@@ -18,6 +20,7 @@ export const timeAndLogLoadEventAsync =
 
     metricsAdapter.logDataManagerLoadEvent({
       type: loadType,
+      isInTransaction: queryContext.isInTransaction(),
       entityClassName,
       duration: endTime - startTime,
       count: result.length,
@@ -31,6 +34,7 @@ export const timeAndLogLoadMapEventAsync =
     metricsAdapter: IEntityMetricsAdapter,
     loadType: EntityMetricsLoadType,
     entityClassName: string,
+    queryContext: EntityQueryContext,
   ) =>
   async <
     TFields extends Record<string, any>,
@@ -47,6 +51,7 @@ export const timeAndLogLoadMapEventAsync =
 
     metricsAdapter.logDataManagerLoadEvent({
       type: loadType,
+      isInTransaction: queryContext.isInTransaction(),
       entityClassName,
       duration: endTime - startTime,
       count,
@@ -60,6 +65,7 @@ export const timeAndLogMutationEventAsync =
     metricsAdapter: IEntityMetricsAdapter,
     mutationType: EntityMetricsMutationType,
     entityClassName: string,
+    queryContext: EntityQueryContext,
   ) =>
   async <T>(promise: Promise<T>) => {
     const startTime = Date.now();
@@ -68,6 +74,7 @@ export const timeAndLogMutationEventAsync =
 
     metricsAdapter.logMutatorMutationEvent({
       type: mutationType,
+      isInTransaction: queryContext.isInTransaction(),
       entityClassName,
       duration: endTime - startTime,
     });

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -20,6 +20,11 @@ export interface EntityMetricsLoadEvent {
   type: EntityMetricsLoadType;
 
   /**
+   * Whether this load is within a transaction.
+   */
+  isInTransaction: boolean;
+
+  /**
    * Class name of the Entity being loaded.
    */
   entityClassName: string;
@@ -46,6 +51,11 @@ export interface EntityMetricsMutationEvent {
    * EntityMetricsMutationType for this mutation.
    */
   type: EntityMetricsMutationType;
+
+  /**
+   * Whether this mutation is within a transaction.
+   */
+  isInTransaction: boolean;
 
   /**
    * Class name of the Entity being mutated.
@@ -86,6 +96,11 @@ export interface IncrementLoadCountEvent {
   type: IncrementLoadCountEventType;
 
   /**
+   * Whether this load is within a transaction.
+   */
+  isInTransaction: boolean;
+
+  /**
    * Load method type for this event.
    */
   loadType: EntityLoadMethodType;
@@ -114,8 +129,20 @@ export interface EntityMetricsAuthorizationEvent {
    * Class name of the Entity being authorized.
    */
   entityClassName: string;
+
+  /**
+   * The action being authorized.
+   */
   action: EntityAuthorizationAction;
+
+  /**
+   * The result of the authorization.
+   */
   evaluationResult: EntityMetricsAuthorizationResult;
+
+  /**
+   * The evaluation mode of the privacy policy.
+   */
   privacyPolicyEvaluationMode: EntityPrivacyPolicyEvaluationMode;
 }
 


### PR DESCRIPTION
# Why

This is a retry of #98. It has become more important in Expo's server application due to more things running within transactions. When it was written previously, relatively few things were transactional.

The idea is that within a transaction, subsequent reads should be able to be cached locally (dataloader) as long as the local cache is kept consistent (not in the cache adapter though).

# How

The way this is done is to keep a dataloader map (dataloader per-entity like we do for the top-level loads) per-transaction as well. Then, when in a transaction, instead of going directly to the database, go through the transaction's dataloader before hitting the database. This way loads within the transaction are coalesced and cached locally.

Invalidation becomes more complex though. 
- We still only want to invalidate the non-transactional dataloader/cache at the end of the transaction (as late as possible for least chance of race condition) for all changed entities. This didn't change.
- As for when to invalidate the transactional dataloaders, we need to think about this like database sub-transaction visibility, but only in the sense that we don't want inconsistent reads. Put another way, any load in or out of any transaction or nested transaction needs to be consistent with what is in the database, so any time the loaded value would change if it went directly do the database we must also invalidate the cache.
   - This is further complicated by the fact that postgres doesn't have real subtransactions (see #194 for more discussion) and subtransactions weren't an entity feature for the first attempt at this. This means that it's hard to test the case where a nested transaction is isolated from the parent transaction for uncommitted reads or the inverse.
   - The way I came up with achieving this is to just to over-invalidate: clear all the dataloaders in the transaction recursively starting from the outermost transaction. And do this clearing right after the mutation and at the end of the sub-transaction and at the end of the transaction (recursively).

# Test Plan

Run new tests.
