### PR TITLE
fix: prevent dataloader from issuing queries to a completed transaction later in run loop

### DIFF
--- a/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
+++ b/packages/entity-example/src/adapters/InMemoryQueryContextProvider.ts
@@ -5,6 +5,10 @@ export default class InMemoryQueryContextProvider extends EntityQueryContextProv
     return {};
   }
 
+  public isQueryInterfaceTransactionAndCompleted(_queryInterface: any): boolean {
+    return false;
+  }
+
   protected createTransactionRunner<T>(
     _transactionConfig?: TransactionConfig,
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {

--- a/packages/entity-testing-utils/src/StubQueryContextProvider.ts
+++ b/packages/entity-testing-utils/src/StubQueryContextProvider.ts
@@ -5,6 +5,10 @@ export default class StubQueryContextProvider extends EntityQueryContextProvider
     return {};
   }
 
+  public isQueryInterfaceTransactionAndCompleted(_queryInterface: any): boolean {
+    return false;
+  }
+
   protected createTransactionRunner<T>(
     _transactionConfig?: TransactionConfig,
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -8,20 +8,31 @@ import {
 /**
  * A query context provider vends transactional and non-transactional query contexts.
  */
-export default abstract class EntityQueryContextProvider {
+export default abstract class EntityQueryContextProvider<
+  TQueryInterface = any,
+  TTransactionalQueryInterface extends TQueryInterface = any,
+> {
   private queryContextCounter: number = 1;
 
   /**
    * Vend a regular (non-transactional) entity query context.
    */
-  public getQueryContext(): EntityNonTransactionalQueryContext {
+  public getQueryContext(): EntityNonTransactionalQueryContext<
+    TQueryInterface,
+    TTransactionalQueryInterface
+  > {
     return new EntityNonTransactionalQueryContext(this.getQueryInterface(), this);
   }
 
   /**
    * Get the query interface for constructing a query context.
    */
-  protected abstract getQueryInterface(): any;
+  protected abstract getQueryInterface(): TQueryInterface;
+
+  /**
+   * @returns true if the query interface is a transaction that is already completed.
+   */
+  public abstract isQueryInterfaceTransactionAndCompleted(queryInterface: TQueryInterface): boolean;
 
   /**
    * @returns true if the transactional dataloader should be disabled for all transactions.
@@ -35,24 +46,29 @@ export default abstract class EntityQueryContextProvider {
    */
   protected abstract createTransactionRunner<T>(
     transactionConfig?: TransactionConfig,
-  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T>;
+  ): (transactionScope: (queryInterface: TTransactionalQueryInterface) => Promise<T>) => Promise<T>;
 
   protected abstract createNestedTransactionRunner<T>(
-    outerQueryInterface: any,
-  ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T>;
+    outerQueryInterface: TTransactionalQueryInterface,
+  ): (transactionScope: (queryInterface: TTransactionalQueryInterface) => Promise<T>) => Promise<T>;
 
   /**
    * Start a transaction and execute the provided transaction-scoped closure within the transaction.
    * @param transactionScope - async callback to execute within the transaction
    */
   async runInTransactionAsync<T>(
-    transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<T>,
+    transactionScope: (
+      queryContext: EntityTransactionalQueryContext<TQueryInterface, TTransactionalQueryInterface>,
+    ) => Promise<T>,
     transactionConfig?: TransactionConfig,
   ): Promise<T> {
     const [returnedValue, queryContext] = await this.createTransactionRunner<
-      [T, EntityTransactionalQueryContext]
+      [T, EntityTransactionalQueryContext<TQueryInterface, TTransactionalQueryInterface>]
     >(transactionConfig)(async (queryInterface) => {
-      const queryContext = new EntityTransactionalQueryContext(
+      const queryContext = new EntityTransactionalQueryContext<
+        TQueryInterface,
+        TTransactionalQueryInterface
+      >(
         queryInterface,
         this,
         String(this.queryContextCounter++),
@@ -74,11 +90,19 @@ export default abstract class EntityQueryContextProvider {
    * @param transactionScope - async callback to execute within the nested transaction
    */
   async runInNestedTransactionAsync<T>(
-    outerQueryContext: EntityTransactionalQueryContext,
-    transactionScope: (innerQueryContext: EntityNestedTransactionalQueryContext) => Promise<T>,
+    outerQueryContext: EntityTransactionalQueryContext<
+      TQueryInterface,
+      TTransactionalQueryInterface
+    >,
+    transactionScope: (
+      innerQueryContext: EntityNestedTransactionalQueryContext<
+        TQueryInterface,
+        TTransactionalQueryInterface
+      >,
+    ) => Promise<T>,
   ): Promise<T> {
     const [returnedValue, innerQueryContext] = await this.createNestedTransactionRunner<
-      [T, EntityNestedTransactionalQueryContext]
+      [T, EntityNestedTransactionalQueryContext<TQueryInterface, TTransactionalQueryInterface>]
     >(outerQueryContext.getQueryInterface())(async (innerQueryInterface) => {
       const innerQueryContext = new EntityNestedTransactionalQueryContext(
         innerQueryInterface,

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -203,6 +203,10 @@ describe(EntityQueryContext, () => {
         return {};
       }
 
+      public isQueryInterfaceTransactionAndCompleted(_queryInterface: any): boolean {
+        return false;
+      }
+
       protected override shouldDisableTransactionalDataloaderForAllTransactions(): boolean {
         return true;
       }

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -132,6 +132,11 @@ export default class EntityDataManager<
             const values = serializedLoadValues.map((serializedLoadValue) =>
               key.deserializeLoadValue(serializedLoadValue),
             );
+            if (queryContext.isCompleted()) {
+              // return empty array if the transaction is completed
+              return values.map(() => []);
+            }
+
             const objectMap = await this.loadManyForTransactionalDataLoaderAsync(
               queryContext,
               key,

--- a/packages/entity/src/utils/__testfixtures__/StubQueryContextProvider.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubQueryContextProvider.ts
@@ -6,6 +6,10 @@ export default class StubQueryContextProvider extends EntityQueryContextProvider
     return {};
   }
 
+  public isQueryInterfaceTransactionAndCompleted(_queryInterface: any): boolean {
+    return false;
+  }
+
   protected createTransactionRunner<T>(
     _transactionConfig?: TransactionConfig,
   ): (transactionScope: (queryInterface: any) => Promise<T>) => Promise<T> {


### PR DESCRIPTION
# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests!
