### PR TITLE
fix: introduce transactional dataloader mode and fix global transaction ID generation

### DIFF
--- a/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
@@ -49,6 +49,18 @@ export default class StubDatabaseAdapter<
     return new Map();
   }
 
+  private static uniqBy<T>(a: T[], keyExtractor: (k: T) => string): T[] {
+    const seen = new Set();
+    return a.filter((item) => {
+      const k = keyExtractor(item);
+      if (seen.has(k)) {
+        return false;
+      }
+      seen.add(k);
+      return true;
+    });
+  }
+
   protected async fetchManyWhereInternalAsync(
     _queryInterface: any,
     tableName: string,
@@ -56,7 +68,7 @@ export default class StubDatabaseAdapter<
     tableTuples: (readonly any[])[],
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
-    const results = tableTuples.reduce(
+    const results = StubDatabaseAdapter.uniqBy(tableTuples, (tuple) => tuple.join(':')).reduce(
       (acc, tableTuple) => {
         return acc.concat(
           objectCollection.filter((obj) => {

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -14,9 +14,15 @@ export enum TransactionIsolationLevel {
   SERIALIZABLE = 'SERIALIZABLE',
 }
 
+export enum TransactionalDataLoaderMode {
+  ENABLED = 'ENABLED',
+  ENABLED_BATCH_ONLY = 'ENABLED_BATCH_ONLY',
+  DISABLED = 'DISABLED',
+}
+
 export type TransactionConfig = {
   isolationLevel?: TransactionIsolationLevel;
-  disableTransactionalDataloader?: boolean;
+  transactionalDataLoaderMode?: TransactionalDataLoaderMode;
 };
 
 /**
@@ -93,7 +99,7 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
      * @internal
      */
     readonly transactionId: string,
-    public readonly shouldDisableTransactionalDataloader: boolean,
+    public readonly transactionalDataLoaderMode: TransactionalDataLoaderMode,
   ) {
     super(queryInterface);
   }
@@ -208,14 +214,9 @@ export class EntityNestedTransactionalQueryContext extends EntityTransactionalQu
     readonly parentQueryContext: EntityTransactionalQueryContext,
     entityQueryContextProvider: EntityQueryContextProvider,
     transactionId: string,
-    shouldDisableTransactionalDataloader: boolean,
+    transactionalDataLoaderMode: TransactionalDataLoaderMode,
   ) {
-    super(
-      queryInterface,
-      entityQueryContextProvider,
-      transactionId,
-      shouldDisableTransactionalDataloader,
-    );
+    super(queryInterface, entityQueryContextProvider, transactionId, transactionalDataLoaderMode);
     parentQueryContext.childQueryContexts.push(this);
   }
 

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -4,6 +4,7 @@ import invariant from 'invariant';
 import EntityCompanionProvider from '../EntityCompanionProvider';
 import {
   EntityQueryContext,
+  TransactionalDataLoaderMode,
   TransactionConfig,
   TransactionIsolationLevel,
 } from '../EntityQueryContext';
@@ -173,38 +174,44 @@ describe(EntityQueryContext, () => {
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
-          expect(queryContext.shouldDisableTransactionalDataloader).toBe(true);
+          expect(queryContext.transactionalDataLoaderMode).toBe(
+            TransactionalDataLoaderMode.DISABLED,
+          );
         },
-        { disableTransactionalDataloader: true },
+        { transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED },
       );
 
       await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
-          expect(queryContext.shouldDisableTransactionalDataloader).toBe(false);
+          expect(queryContext.transactionalDataLoaderMode).toBe(
+            TransactionalDataLoaderMode.ENABLED_BATCH_ONLY,
+          );
         },
-        { disableTransactionalDataloader: false },
+        { transactionalDataLoaderMode: TransactionalDataLoaderMode.ENABLED_BATCH_ONLY },
       );
 
       await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
-          expect(queryContext.shouldDisableTransactionalDataloader).toBe(false);
+          expect(queryContext.transactionalDataLoaderMode).toBe(
+            TransactionalDataLoaderMode.ENABLED,
+          );
         },
       );
     });
   });
 
-  describe('global shouldDisableTransactionalDataloaderForAllTransactions', () => {
+  describe('global defaultTransactionalDataLoaderMode', () => {
     class StubQueryContextProviderWithDisabledTransactionalDataLoaders extends EntityQueryContextProvider {
       protected getQueryInterface(): any {
         return {};
       }
 
-      protected override shouldDisableTransactionalDataloaderForAllTransactions(): boolean {
-        return true;
+      protected override defaultTransactionalDataLoaderMode(): TransactionalDataLoaderMode {
+        return TransactionalDataLoaderMode.DISABLED;
       }
 
       protected createTransactionRunner<T>(
@@ -248,25 +255,31 @@ describe(EntityQueryContext, () => {
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
-          expect(queryContext.shouldDisableTransactionalDataloader).toBe(true);
+          expect(queryContext.transactionalDataLoaderMode).toBe(
+            TransactionalDataLoaderMode.DISABLED,
+          );
         },
-        { disableTransactionalDataloader: true },
+        { transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED },
       );
 
       await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
-          expect(queryContext.shouldDisableTransactionalDataloader).toBe(false);
+          expect(queryContext.transactionalDataLoaderMode).toBe(
+            TransactionalDataLoaderMode.ENABLED_BATCH_ONLY,
+          );
         },
-        { disableTransactionalDataloader: false },
+        { transactionalDataLoaderMode: TransactionalDataLoaderMode.ENABLED_BATCH_ONLY },
       );
 
       await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
-          expect(queryContext.shouldDisableTransactionalDataloader).toBe(true);
+          expect(queryContext.transactionalDataLoaderMode).toBe(
+            TransactionalDataLoaderMode.DISABLED,
+          );
         },
       );
     });

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -49,6 +49,18 @@ export default class StubDatabaseAdapter<
     return new Map();
   }
 
+  private static uniqBy<T>(a: T[], keyExtractor: (k: T) => string): T[] {
+    const seen = new Set();
+    return a.filter((item) => {
+      const k = keyExtractor(item);
+      if (seen.has(k)) {
+        return false;
+      }
+      seen.add(k);
+      return true;
+    });
+  }
+
   protected async fetchManyWhereInternalAsync(
     _queryInterface: any,
     tableName: string,
@@ -56,7 +68,7 @@ export default class StubDatabaseAdapter<
     tableTuples: (readonly any[])[],
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
-    const results = tableTuples.reduce(
+    const results = StubDatabaseAdapter.uniqBy(tableTuples, (tuple) => tuple.join(':')).reduce(
       (acc, tableTuple) => {
         return acc.concat(
           objectCollection.filter((obj) => {


### PR DESCRIPTION
# Why

Tested #284 in Expo's server. It turns out that there are definitely some instances where a transactional dataloader produces unexpected results. Namely of the forms:

### Purposefully trying loading the same entity repeatedly in the same transaction until it exists

The solution here is to use the new `TransactionalDataLoaderMode.DISABLED` for this transaction, or `TransactionalDataLoaderMode.ENABLED_BATCH_ONLY` works as well.

```typescript
async function waitUntilEntityWithIdExistsAsync(
  viewerContext: ViewerContext,
  queryContext: EntityTransactionalQueryContext,
  id: string
): Promise<TestEntity> {
  return await promiseRetry(
    async (retry) => {
      const retryAfterTimeoutAsync = async (error: any): Promise<never> => {
        await setTimeout(1000); // 1 second between attemps
        return retry(error);
      };

      try {
        return await TestEntity.loader(viewerContext, queryContext).loadByIDAsync(id);
      } catch (e) {
        // it's fine to retry all errors since we're only retrying for a very short period of time
        return await retryAfterTimeoutAsync(e);
      }
    },
    {
      factor: 1,
      retries: 3,
    }
  );
}
```

### Get and create if not exists and handle unique constraint error race condition

The solution here could be to require all callers to use `TransactionalDataLoaderMode.DISABLED`/`TransactionalDataLoaderMode.ENABLED_BATCH_ONLY`, or to just put the first call to `getAsync` in a nested transaction (so that it gets its own dataloader).

```typescript
export default async function createOrGetExistingAsync(
  viewerContext: ViewerContext,
  entityClass: IEntityClass,
  getAsync: (
    viewerContext: TViewerContext,
    getArgs: TGetArgs,
    queryContext?: EntityTransactionalQueryContext
  ) => Promise<TEntity | null>,
  getArgs: TGetArgs,
  createAsync: (
    viewerContext: TViewerContext,
    createArgs: TCreateArgs,
    queryContext?: EntityTransactionalQueryContext
  ) => Promise<TEntity>,
  createArgs: TCreateArgs,
  queryContext?: EntityTransactionalQueryContext
): Promise<TEntity> {
  const maybeEntity = await getAsync(viewerContext, getArgs, queryContext);
  if (maybeEntity) {
    return maybeEntity;
  }
  
  try {
    if (!queryContext) {
      return await createAsync(viewerContext, createArgs);
    }
    return await queryContext.runInNestedTransactionAsync((nestedQueryContext) =>
      createAsync(viewerContext, createArgs, nestedQueryContext)
    );
  } catch (e) {
    if (e instanceof EntityDatabaseAdapterUniqueConstraintError) {
      const entity = await getAsync(viewerContext, getArgs, queryContext);
      if (!entity) {
        throw new EntityNotFound400Error(
          `Expected entity to exist after unique constraint error: ${entityClass.name}`
        );
      }
      return entity;
    } else {
      throw e;
    }
  }
}
```

# How

The takeaway from the two cases above is that a) we need to be able to specify whether batching and caching features of dataloader are enabled on a per-transaction basis.

This also fixes a bug where more than one query context provider is created for an application (multiple database flavors, for example) and thus the query context IDs generated wouldn't be globally-unique (or even unique to the companion provider). The fix is to simply use UUID.

# Test Plan

Run all tests.
