### PR TITLE
feat: add createOrGetExistingAsync and createWithUniqueConstraintRecoveryAsync utility methods

### DIFF
--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
@@ -1,0 +1,223 @@
+import { createWithUniqueConstraintRecoveryAsync, ViewerContext } from '@expo/entity';
+import knex, { Knex } from 'knex';
+import nullthrows from 'nullthrows';
+
+import PostgresUniqueTestEntity from '../__testfixtures__/PostgresUniqueTestEntity';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';
+
+describe(createWithUniqueConstraintRecoveryAsync, () => {
+  let knexInstance: Knex;
+
+  beforeAll(() => {
+    knexInstance = knex({
+      client: 'pg',
+      connection: {
+        user: nullthrows(process.env['PGUSER']),
+        password: nullthrows(process.env['PGPASSWORD']),
+        host: 'localhost',
+        port: parseInt(nullthrows(process.env['PGPORT']), 10),
+        database: nullthrows(process.env['PGDATABASE']),
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    await PostgresUniqueTestEntity.createOrTruncatePostgresTableAsync(knexInstance);
+  });
+
+  afterAll(async () => {
+    await PostgresUniqueTestEntity.dropPostgresTableAsync(knexInstance);
+    await knexInstance.destroy();
+  });
+
+  describe.each([true, false])('is parallel creations %p', (parallel) => {
+    it('recovers when the same entity is created twice outside of transaction', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      const args = {
+        name: 'unique',
+      };
+
+      let createdEntities: [PostgresUniqueTestEntity, PostgresUniqueTestEntity];
+      if (parallel) {
+        createdEntities = await Promise.all([
+          createWithUniqueConstraintRecoveryAsync(
+            vc1,
+            PostgresUniqueTestEntity,
+            PostgresUniqueTestEntity.getByNameAsync,
+            args,
+            PostgresUniqueTestEntity.createWithNameAsync,
+            args,
+          ),
+          createWithUniqueConstraintRecoveryAsync(
+            vc1,
+            PostgresUniqueTestEntity,
+            PostgresUniqueTestEntity.getByNameAsync,
+            args,
+            PostgresUniqueTestEntity.createWithNameAsync,
+            args,
+          ),
+        ]);
+      } else {
+        createdEntities = [
+          await createWithUniqueConstraintRecoveryAsync(
+            vc1,
+            PostgresUniqueTestEntity,
+            PostgresUniqueTestEntity.getByNameAsync,
+            args,
+            PostgresUniqueTestEntity.createWithNameAsync,
+            args,
+          ),
+          await createWithUniqueConstraintRecoveryAsync(
+            vc1,
+            PostgresUniqueTestEntity,
+            PostgresUniqueTestEntity.getByNameAsync,
+            args,
+            PostgresUniqueTestEntity.createWithNameAsync,
+            args,
+          ),
+        ];
+      }
+
+      expect(createdEntities[0].getID()).toEqual(createdEntities[1].getID());
+    });
+
+    it('recovers when the same entity is created twice within same transaction', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      const args = {
+        name: 'unique',
+      };
+
+      const createdEntities = await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          if (parallel) {
+            return await Promise.all([
+              createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              ),
+              createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              ),
+            ]);
+          } else {
+            return [
+              await createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              ),
+              await createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              ),
+            ];
+          }
+        },
+      );
+
+      expect(nullthrows(createdEntities[0]).getID()).toEqual(
+        nullthrows(createdEntities[1]).getID(),
+      );
+    });
+
+    it('recovers when the same entity is created twice within two transactions', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      const args = {
+        name: 'unique',
+      };
+
+      let createdEntities: [PostgresUniqueTestEntity, PostgresUniqueTestEntity];
+      if (parallel) {
+        createdEntities = await Promise.all([
+          await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+            'postgres',
+            async (queryContext) => {
+              return await createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              );
+            },
+          ),
+          await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+            'postgres',
+            async (queryContext) => {
+              return await createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              );
+            },
+          ),
+        ]);
+      } else {
+        createdEntities = [
+          await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+            'postgres',
+            async (queryContext) => {
+              return await createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              );
+            },
+          ),
+          await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+            'postgres',
+            async (queryContext) => {
+              return await createWithUniqueConstraintRecoveryAsync(
+                vc1,
+                PostgresUniqueTestEntity,
+                PostgresUniqueTestEntity.getByNameAsync,
+                args,
+                PostgresUniqueTestEntity.createWithNameAsync,
+                args,
+                queryContext,
+              );
+            },
+          ),
+        ];
+      }
+
+      expect(nullthrows(createdEntities[0]).getID()).toEqual(
+        nullthrows(createdEntities[1]).getID(),
+      );
+    });
+  });
+});

--- a/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresUniqueTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresUniqueTestEntity.ts
@@ -7,6 +7,7 @@ import {
   EntityCompanionDefinition,
   Entity,
   UUIDField,
+  EntityTransactionalQueryContext,
 } from '@expo/entity';
 import { Knex } from 'knex';
 
@@ -52,6 +53,27 @@ export default class PostgresUniqueTestEntity extends Entity<
     if (hasTable) {
       await knex.schema.dropTable(tableName);
     }
+  }
+
+  public static async getByNameAsync(
+    viewerContext: ViewerContext,
+    args: { name: string },
+    queryContext?: EntityTransactionalQueryContext,
+  ): Promise<PostgresUniqueTestEntity | null> {
+    return await PostgresUniqueTestEntity.loader(
+      viewerContext,
+      queryContext,
+    ).loadByFieldEqualingAsync('name', args.name);
+  }
+
+  public static async createWithNameAsync(
+    viewerContext: ViewerContext,
+    args: { name: string },
+    queryContext?: EntityTransactionalQueryContext,
+  ): Promise<PostgresUniqueTestEntity> {
+    return await PostgresUniqueTestEntity.creator(viewerContext, queryContext)
+      .setField('name', args.name)
+      .createAsync();
   }
 }
 
@@ -108,6 +130,7 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<
     }),
     name: new StringField({
       columnName: 'name',
+      cache: true,
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -237,7 +237,13 @@ export default class AuthorizationResultBasedEntityLoader<
       const entityResult = entityResultsForId[0];
       return (
         entityResult ??
-        result(new EntityNotFoundError(this.entityClass, this.entityConfiguration.idField, id))
+        result(
+          new EntityNotFoundError({
+            entityClass: this.entityClass,
+            fieldName: this.entityConfiguration.idField,
+            fieldValue: id,
+          }),
+        )
       );
     });
   }

--- a/packages/entity/src/errors/EntityNotFoundError.ts
+++ b/packages/entity/src/errors/EntityNotFoundError.ts
@@ -4,6 +4,33 @@ import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
 import ReadonlyEntity from '../ReadonlyEntity';
 import ViewerContext from '../ViewerContext';
 
+type EntityNotFoundOptions<
+  TFields extends Record<string, any>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  N extends keyof TFields,
+  TSelectedFields extends keyof TFields = keyof TFields,
+> = {
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >;
+  fieldName: N;
+  fieldValue: TFields[N];
+};
+
 export default class EntityNotFoundError<
   TFields extends Record<string, any>,
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
@@ -22,18 +49,38 @@ export default class EntityNotFoundError<
   public readonly state = EntityErrorState.PERMANENT;
   public readonly code = EntityErrorCode.ERR_ENTITY_NOT_FOUND;
 
+  constructor(message: string);
   constructor(
-    entityClass: IEntityClass<
+    options: EntityNotFoundOptions<
       TFields,
       TIDField,
       TViewerContext,
       TEntity,
       TPrivacyPolicy,
+      N,
       TSelectedFields
     >,
-    fieldName: N,
-    fieldValue: TFields[N],
+  );
+
+  constructor(
+    messageOrOptions:
+      | string
+      | EntityNotFoundOptions<
+          TFields,
+          TIDField,
+          TViewerContext,
+          TEntity,
+          TPrivacyPolicy,
+          N,
+          TSelectedFields
+        >,
   ) {
-    super(`Entity not found: ${entityClass.name} (${String(fieldName)} = ${fieldValue})`);
+    if (typeof messageOrOptions === 'string') {
+      super(messageOrOptions);
+    } else {
+      super(
+        `Entity not found: ${messageOrOptions.entityClass.name} (${String(messageOrOptions.fieldName)} = ${messageOrOptions.fieldValue})`,
+      );
+    }
   }
 }

--- a/packages/entity/src/errors/__tests__/EntityDatabaseAdapterError-test.ts
+++ b/packages/entity/src/errors/__tests__/EntityDatabaseAdapterError-test.ts
@@ -1,0 +1,26 @@
+import EntityDatabaseAdapterError, {
+  EntityDatabaseAdapterTransientError,
+  EntityDatabaseAdapterUnknownError,
+  EntityDatabaseAdapterCheckConstraintError,
+  EntityDatabaseAdapterExclusionConstraintError,
+  EntityDatabaseAdapterForeignKeyConstraintError,
+  EntityDatabaseAdapterNotNullConstraintError,
+  EntityDatabaseAdapterUniqueConstraintError,
+} from '../EntityDatabaseAdapterError';
+
+describe(EntityDatabaseAdapterError, () => {
+  // necessary for coverage within the entity package since these errors are
+  // currently only ever instantiated by database adapter implementations
+  it('instantiates all errors successfully', () => {
+    const errors = [
+      new EntityDatabaseAdapterTransientError('test'),
+      new EntityDatabaseAdapterUnknownError('test'),
+      new EntityDatabaseAdapterCheckConstraintError('test'),
+      new EntityDatabaseAdapterExclusionConstraintError('test'),
+      new EntityDatabaseAdapterForeignKeyConstraintError('test'),
+      new EntityDatabaseAdapterNotNullConstraintError('test'),
+      new EntityDatabaseAdapterUniqueConstraintError('test'),
+    ];
+    expect(errors).not.toBeFalsy();
+  });
+});

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -85,6 +85,7 @@ export { default as AlwaysDenyPrivacyPolicyRule } from './rules/AlwaysDenyPrivac
 export { default as AlwaysSkipPrivacyPolicyRule } from './rules/AlwaysSkipPrivacyPolicyRule';
 export { default as PrivacyPolicyRule } from './rules/PrivacyPolicyRule';
 export * from './rules/PrivacyPolicyRule';
+export * from './utils/EntityCreationUtils';
 export * from './utils/EntityPrivacyUtils';
 export * from './utils/mergeEntityMutationTriggerConfigurations';
 export * from './utils/collections/maps';

--- a/packages/entity/src/utils/EntityCreationUtils.ts
+++ b/packages/entity/src/utils/EntityCreationUtils.ts
@@ -1,0 +1,143 @@
+import { IEntityClass } from '../Entity';
+import EntityPrivacyPolicy from '../EntityPrivacyPolicy';
+import { EntityTransactionalQueryContext } from '../EntityQueryContext';
+import ReadonlyEntity from '../ReadonlyEntity';
+import ViewerContext from '../ViewerContext';
+import { EntityDatabaseAdapterUniqueConstraintError } from '../errors/EntityDatabaseAdapterError';
+import EntityNotFoundError from '../errors/EntityNotFoundError';
+
+/**
+ * Create an entity if it doesn't exist, or get the existing entity if it does.
+ */
+export async function createOrGetExistingAsync<
+  TFields extends object,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TGetArgs,
+  TCreateArgs,
+  TSelectedFields extends keyof TFields = keyof TFields,
+>(
+  viewerContext: TViewerContext,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
+  getAsync: (
+    viewerContext: TViewerContext,
+    getArgs: TGetArgs,
+    queryContext?: EntityTransactionalQueryContext,
+  ) => Promise<TEntity | null>,
+  getArgs: TGetArgs,
+  createAsync: (
+    viewerContext: TViewerContext,
+    createArgs: TCreateArgs,
+    queryContext?: EntityTransactionalQueryContext,
+  ) => Promise<TEntity>,
+  createArgs: TCreateArgs,
+  queryContext?: EntityTransactionalQueryContext,
+): Promise<TEntity> {
+  if (!queryContext) {
+    const maybeEntity = await getAsync(viewerContext, getArgs);
+    if (maybeEntity) {
+      return maybeEntity;
+    }
+  } else {
+    // This is done in a nested transaction since entity may negatively cache load results per-transaction (when configured).
+    // Without it, it would
+    // 1. load the entity in the current query context, negatively cache it
+    // 2. then try to create it in the nested transaction, which may fail due to a unique constraint error
+    // 3. then try to load the entity again in the current query context, which would return null due to negative cache
+    const maybeEntity = await queryContext.runInNestedTransactionAsync((nestedQueryContext) =>
+      getAsync(viewerContext, getArgs, nestedQueryContext),
+    );
+    if (maybeEntity) {
+      return maybeEntity;
+    }
+  }
+  return await createWithUniqueConstraintRecoveryAsync(
+    viewerContext,
+    entityClass,
+    getAsync,
+    getArgs,
+    createAsync,
+    createArgs,
+    queryContext,
+  );
+}
+
+/**
+ * Account for concurrent requests that may try to create the same entity.
+ * Return the existing entity if we get a Unique Constraint error.
+ */
+export async function createWithUniqueConstraintRecoveryAsync<
+  TFields extends object,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TPrivacyPolicy extends EntityPrivacyPolicy<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TSelectedFields
+  >,
+  TGetArgs,
+  TCreateArgs,
+  TSelectedFields extends keyof TFields = keyof TFields,
+>(
+  viewerContext: TViewerContext,
+  entityClass: IEntityClass<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  >,
+  getAsync: (
+    viewerContext: TViewerContext,
+    getArgs: TGetArgs,
+    queryContext?: EntityTransactionalQueryContext,
+  ) => Promise<TEntity | null>,
+  getArgs: TGetArgs,
+  createAsync: (
+    viewerContext: TViewerContext,
+    createArgs: TCreateArgs,
+    queryContext?: EntityTransactionalQueryContext,
+  ) => Promise<TEntity>,
+  createArgs: TCreateArgs,
+  queryContext?: EntityTransactionalQueryContext,
+): Promise<TEntity> {
+  try {
+    if (!queryContext) {
+      return await createAsync(viewerContext, createArgs);
+    }
+    return await queryContext.runInNestedTransactionAsync((nestedQueryContext) =>
+      createAsync(viewerContext, createArgs, nestedQueryContext),
+    );
+  } catch (e) {
+    if (e instanceof EntityDatabaseAdapterUniqueConstraintError) {
+      const entity = await getAsync(viewerContext, getArgs, queryContext);
+      if (!entity) {
+        throw new EntityNotFoundError(
+          `Expected entity to exist after unique constraint error: ${entityClass.name}`,
+        );
+      }
+      return entity;
+    } else {
+      throw e;
+    }
+  }
+}

--- a/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
@@ -1,0 +1,354 @@
+import { EntityTransactionalQueryContext } from '../../EntityQueryContext';
+import ViewerContext from '../../ViewerContext';
+import { EntityDatabaseAdapterUniqueConstraintError } from '../../errors/EntityDatabaseAdapterError';
+import EntityNotFoundError from '../../errors/EntityNotFoundError';
+import {
+  createOrGetExistingAsync,
+  createWithUniqueConstraintRecoveryAsync,
+} from '../EntityCreationUtils';
+import SimpleTestEntity from '../__testfixtures__/SimpleTestEntity';
+import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider';
+
+type TArgs = object;
+
+describe.each([true, false])('in transaction %p', (inTransaction) => {
+  describe(createOrGetExistingAsync, () => {
+    it('does not create when already exists', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      const entity = await SimpleTestEntity.creator(viewerContext).createAsync();
+
+      const args: TArgs = {};
+
+      const getFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          return entity;
+        },
+      );
+
+      const createFn = jest.fn(
+        async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
+          return await SimpleTestEntity.creator(vc, queryContext).createAsync();
+        },
+      );
+
+      if (inTransaction) {
+        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          'postgres',
+          async (queryContext) => {
+            await createOrGetExistingAsync(
+              viewerContext,
+              SimpleTestEntity,
+              getFn,
+              args,
+              createFn,
+              args,
+              queryContext,
+            );
+          },
+        );
+      } else {
+        await createOrGetExistingAsync(
+          viewerContext,
+          SimpleTestEntity,
+          getFn,
+          args,
+          createFn,
+          args,
+        );
+      }
+
+      expect(getFn).toHaveBeenCalledTimes(1);
+      expect(createFn).toHaveBeenCalledTimes(0);
+    });
+
+    it('creates when not found', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      const args: TArgs = {};
+
+      const getFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          return null;
+        },
+      );
+
+      const createFn = jest.fn(
+        async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
+          return await SimpleTestEntity.creator(vc, queryContext).createAsync();
+        },
+      );
+
+      if (inTransaction) {
+        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          'postgres',
+          async (queryContext) => {
+            await createOrGetExistingAsync(
+              viewerContext,
+              SimpleTestEntity,
+              getFn,
+              args,
+              createFn,
+              args,
+              queryContext,
+            );
+          },
+        );
+      } else {
+        await createOrGetExistingAsync(
+          viewerContext,
+          SimpleTestEntity,
+          getFn,
+          args,
+          createFn,
+          args,
+        );
+      }
+
+      expect(getFn).toHaveBeenCalledTimes(1);
+      expect(createFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe(createWithUniqueConstraintRecoveryAsync, () => {
+    it('does not call get when creation succeeds', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      const args: TArgs = {};
+
+      const getFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          return null;
+        },
+      );
+
+      const createFn = jest.fn(
+        async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
+          return await SimpleTestEntity.creator(vc, queryContext).createAsync();
+        },
+      );
+
+      if (inTransaction) {
+        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          'postgres',
+          async (queryContext) => {
+            await createWithUniqueConstraintRecoveryAsync(
+              viewerContext,
+              SimpleTestEntity,
+              getFn,
+              args,
+              createFn,
+              args,
+              queryContext,
+            );
+          },
+        );
+      } else {
+        await createWithUniqueConstraintRecoveryAsync(
+          viewerContext,
+          SimpleTestEntity,
+          getFn,
+          args,
+          createFn,
+          args,
+        );
+      }
+
+      expect(getFn).toHaveBeenCalledTimes(0);
+      expect(createFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls get when database adapter throws EntityDatabaseAdapterUniqueConstraintError', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      const entity = await SimpleTestEntity.creator(viewerContext).createAsync();
+
+      const args: TArgs = {};
+
+      const getFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          return entity;
+        },
+      );
+
+      const createFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          throw new EntityDatabaseAdapterUniqueConstraintError('wat');
+        },
+      );
+
+      if (inTransaction) {
+        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          'postgres',
+          async (queryContext) => {
+            await createWithUniqueConstraintRecoveryAsync(
+              viewerContext,
+              SimpleTestEntity,
+              getFn,
+              args,
+              createFn,
+              args,
+              queryContext,
+            );
+          },
+        );
+      } else {
+        await createWithUniqueConstraintRecoveryAsync(
+          viewerContext,
+          SimpleTestEntity,
+          getFn,
+          args,
+          createFn,
+          args,
+        );
+      }
+
+      expect(getFn).toHaveBeenCalledTimes(1);
+      expect(createFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws an EntityNotFoundError when database adapter throws EntityDatabaseAdapterUniqueConstraintError and getFn returns null', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      const args: TArgs = {};
+
+      const getFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          return null;
+        },
+      );
+
+      const createFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          throw new EntityDatabaseAdapterUniqueConstraintError('wat');
+        },
+      );
+
+      if (inTransaction) {
+        await expect(
+          viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+            'postgres',
+            async (queryContext) => {
+              return await createWithUniqueConstraintRecoveryAsync(
+                viewerContext,
+                SimpleTestEntity,
+                getFn,
+                args,
+                createFn,
+                args,
+                queryContext,
+              );
+            },
+          ),
+        ).rejects.toThrow(EntityNotFoundError);
+      } else {
+        await expect(
+          createWithUniqueConstraintRecoveryAsync(
+            viewerContext,
+            SimpleTestEntity,
+            getFn,
+            args,
+            createFn,
+            args,
+          ),
+        ).rejects.toThrow(EntityNotFoundError);
+      }
+
+      expect(getFn).toHaveBeenCalledTimes(1);
+      expect(createFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows whatever error is thrown from database adapter  if not EntityDatabaseAdapterUniqueConstraintError', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      const args: TArgs = {};
+
+      const getFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          return null;
+        },
+      );
+
+      const createFn = jest.fn(
+        async (
+          _vc: ViewerContext,
+          _args: TArgs,
+          _queryContext?: EntityTransactionalQueryContext,
+        ) => {
+          throw new Error('wat');
+        },
+      );
+
+      if (inTransaction) {
+        await expect(
+          viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+            'postgres',
+            async (queryContext) => {
+              return await createWithUniqueConstraintRecoveryAsync(
+                viewerContext,
+                SimpleTestEntity,
+                getFn,
+                args,
+                createFn,
+                args,
+                queryContext,
+              );
+            },
+          ),
+        ).rejects.toThrow('wat');
+      } else {
+        await expect(
+          createWithUniqueConstraintRecoveryAsync(
+            viewerContext,
+            SimpleTestEntity,
+            getFn,
+            args,
+            createFn,
+            args,
+          ),
+        ).rejects.toThrow('wat');
+      }
+
+      expect(getFn).toHaveBeenCalledTimes(0);
+      expect(createFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
# Why

This brings some utility methods from Expo's server implementation into the entity package itself and adds more tests for them within different transaction scenarios.

Closes #202.

# How

Copy code, make more generic, add tests.

# Test Plan

Run tests.
