### PR TITLE
chore: Remove @jest/types

### DIFF
--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@expo/entity-testing-utils": "workspace:^",
-    "@types/jest": "^29.5.14",
     "@types/lru-cache": "^5.1.1",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -7,6 +7,7 @@ import {
   SingleFieldValueHolder,
   ViewerContext,
 } from '@expo/entity';
+import { describe, expect, it } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
 import GenericLocalMemoryCacher from '../GenericLocalMemoryCacher';

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
@@ -7,6 +7,7 @@ import {
   SingleFieldValueHolderMap,
   UUIDField,
 } from '@expo/entity';
+import { describe, expect, it } from '@jest/globals';
 
 import GenericLocalMemoryCacher, {
   DOES_NOT_EXIST_LOCAL_MEMORY_CACHE,

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@expo/batcher": "^1.0.0",
     "@expo/entity-testing-utils": "workspace:^",
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",
     "eslint": "^9.26.0",

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -6,6 +6,7 @@ import {
   ViewerContext,
   zipToMap,
 } from '@expo/entity';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import invariant from 'invariant';
 import Redis from 'ioredis';
 import nullthrows from 'nullthrows';

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -7,6 +7,7 @@ import {
   ViewerContext,
 } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -1,4 +1,5 @@
 import { CacheStatus, ViewerContext } from '@expo/entity';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { URL } from 'url';
 

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -1,4 +1,5 @@
 import { EntityCacheAdapterTransientError, ViewerContext } from '@expo/entity';
+import { beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { URL } from 'url';
 

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -5,6 +5,7 @@ import {
   SingleFieldValueHolder,
   UUIDField,
 } from '@expo/entity';
+import { describe, expect, it } from '@jest/globals';
 import { Redis, Pipeline } from 'ioredis';
 import { mock, when, instance, anything, verify } from 'ts-mockito';
 

--- a/packages/entity-cache-adapter-redis/src/errors/__tests__/wrapNativeRedisCallAsync-test.ts
+++ b/packages/entity-cache-adapter-redis/src/errors/__tests__/wrapNativeRedisCallAsync-test.ts
@@ -1,4 +1,5 @@
 import { EntityCacheAdapterTransientError } from '@expo/entity';
+import { describe, expect, it } from '@jest/globals';
 
 import wrapNativeRedisCallAsync from '../wrapNativeRedisCallAsync';
 

--- a/packages/entity-cache-adapter-redis/src/utils/__tests__/getSurroundingCacheKeyVersionsForInvalidation-test.ts
+++ b/packages/entity-cache-adapter-redis/src/utils/__tests__/getSurroundingCacheKeyVersionsForInvalidation-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { getSurroundingCacheKeyVersionsForInvalidation } from '../getSurroundingCacheKeyVersionsForInvalidation';
 
 describe(getSurroundingCacheKeyVersionsForInvalidation, () => {

--- a/packages/entity-codemod/package.json
+++ b/packages/entity-codemod/package.json
@@ -25,7 +25,6 @@
   "author": "Expo",
   "license": "MIT",
   "devDependencies": {
-    "@types/jest": "^29.5.14",
     "@types/jscodeshift": "^0.12.0",
     "@types/node": "^20.14.1",
     "eslint": "^9.26.0",

--- a/packages/entity-codemod/src/transforms/__tests__/v0.39.0-v0.40.0-test.ts
+++ b/packages/entity-codemod/src/transforms/__tests__/v0.39.0-v0.40.0-test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { readdirSync } from 'fs';
 import { join } from 'path';
 

--- a/packages/entity-codemod/src/transforms/__tests__/v0.40.0-v0.41.0-test.ts
+++ b/packages/entity-codemod/src/transforms/__tests__/v0.40.0-v0.41.0-test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { readdirSync } from 'fs';
 import { join } from 'path';
 

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@expo/entity-testing-utils": "workspace:^",
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",
     "eslint": "^9.26.0",

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
@@ -1,4 +1,5 @@
 import { createWithUniqueConstraintRecoveryAsync, ViewerContext } from '@expo/entity';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import knex, { Knex } from 'knex';
 import nullthrows from 'nullthrows';
 

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -1,6 +1,7 @@
 import { OrderByOrdering, ViewerContext, TransactionIsolationLevel } from '@expo/entity';
 import { createUnitTestEntityCompanionProvider } from '@expo/entity-testing-utils';
 import { enforceAsyncResult } from '@expo/results';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, test } from '@jest/globals';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';
 import { setTimeout } from 'timers/promises';

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -1,4 +1,5 @@
 import { TransactionalDataLoaderMode, ViewerContext } from '@expo/entity';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, test } from '@jest/globals';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';
 

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -1,5 +1,6 @@
 import { ViewerContext } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';
 

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -8,6 +8,7 @@ import {
   EntityDatabaseAdapterUniqueConstraintError,
   EntityDatabaseAdapterUnknownError,
 } from '@expo/entity';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';
 

--- a/packages/entity-database-adapter-knex/src/errors/__tests__/wrapNativePostgresCallAsync-test.ts
+++ b/packages/entity-database-adapter-knex/src/errors/__tests__/wrapNativePostgresCallAsync-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import wrapNativePostgresCallAsync from '../wrapNativePostgresCallAsync';
 
 describe(wrapNativePostgresCallAsync, () => {

--- a/packages/entity-example/package.json
+++ b/packages/entity-example/package.json
@@ -34,7 +34,6 @@
     "koa-bodyparser": "^4.4.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
     "@types/koa": "^2.13.6",
     "@types/koa-bodyparser": "^4.3.10",
     "@types/koa__cors": "^4.0.0",

--- a/packages/entity-example/src/__tests__/NoteEntity-test.ts
+++ b/packages/entity-example/src/__tests__/NoteEntity-test.ts
@@ -1,4 +1,5 @@
 import { createUnitTestEntityCompanionProvider } from '@expo/entity-testing-utils';
+import { describe, expect, test } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
 import NoteEntity from '../entities/NoteEntity';

--- a/packages/entity-example/src/__tests__/graphql-integration-test.ts
+++ b/packages/entity-example/src/__tests__/graphql-integration-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import http from 'http';
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/entity-example/src/__tests__/notesRouter-integration-test.ts
+++ b/packages/entity-example/src/__tests__/notesRouter-integration-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import http from 'http';
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/entity-full-integration-tests/package.json
+++ b/packages/entity-full-integration-tests/package.json
@@ -27,7 +27,6 @@
     "@expo/entity-database-adapter-knex": "workspace:^"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.14.1",
     "eslint": "^9.26.0",
     "eslint-config-universe": "^15.0.3",

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -12,6 +12,7 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -12,6 +12,7 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -3,6 +3,7 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -11,6 +11,7 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -12,6 +12,7 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
 import nullthrows from 'nullthrows';

--- a/packages/entity-ip-address-field/package.json
+++ b/packages/entity-ip-address-field/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@expo/entity-testing-utils": "workspace:^",
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",
     "eslint": "^9.26.0",

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -32,7 +32,6 @@
     "@expo/entity-cache-adapter-local-memory": "workspace:^"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",
     "eslint": "^9.26.0",

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -18,6 +18,7 @@ import {
   LocalMemoryCacheAdapterProvider,
 } from '@expo/entity-cache-adapter-local-memory';
 import { StubQueryContextProvider, StubDatabaseAdapterProvider } from '@expo/entity-testing-utils';
+import { describe, expect, it } from '@jest/globals';
 import nullthrows from 'nullthrows';
 
 import LocalMemorySecondaryEntityCache from '../LocalMemorySecondaryEntityCache';

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -32,7 +32,6 @@
     "@expo/entity-cache-adapter-redis": "workspace:^"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",
     "eslint": "^9.26.0",

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -3,6 +3,7 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import nullthrows from 'nullthrows';
 import { URL } from 'url';

--- a/packages/entity-testing-utils/package.json
+++ b/packages/entity-testing-utils/package.json
@@ -30,8 +30,10 @@
     "lodash": "^4.17.21",
     "ts-mockito": "^2.6.1"
   },
+  "peerDependencies": {
+    "jest": "*"
+  },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.16",
     "@types/node": "^20.14.1",
     "ctix": "^2.7.0",

--- a/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
@@ -6,6 +6,7 @@ import {
   PrivacyPolicyRule,
   RuleEvaluationResult,
 } from '@expo/entity';
+import { describe, expect, test } from '@jest/globals';
 
 export interface Case<
   TFields extends Record<string, any>,

--- a/packages/entity-testing-utils/src/__tests__/FileConsistentcyWithEntity-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/FileConsistentcyWithEntity-test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from '@jest/globals';
 import { readFile } from 'fs/promises';
 import path from 'path';
 

--- a/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
@@ -5,6 +5,7 @@ import {
   AlwaysAllowPrivacyPolicyRule,
   AlwaysDenyPrivacyPolicyRule,
 } from '@expo/entity';
+import { describe } from '@jest/globals';
 import { anything, instance, mock } from 'ts-mockito';
 
 import { describePrivacyPolicyRuleWithAsyncTestCase } from '../PrivacyPolicyRuleTestUtils';

--- a/packages/entity-testing-utils/src/__tests__/StubCacheAdapter-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/StubCacheAdapter-test.ts
@@ -7,6 +7,7 @@ import {
   SingleFieldValueHolderMap,
   CacheStatus,
 } from '@expo/entity';
+import { describe, expect, it } from '@jest/globals';
 
 import {
   InMemoryFullCacheStubCacheAdapterProvider,

--- a/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
@@ -6,6 +6,7 @@ import {
   SingleFieldHolder,
   SingleFieldValueHolder,
 } from '@expo/entity';
+import { describe, expect, it, jest } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
 import StubDatabaseAdapter from '../StubDatabaseAdapter';

--- a/packages/entity-testing-utils/src/__tests__/TSMockitoExtensions-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/TSMockitoExtensions-test.ts
@@ -1,4 +1,5 @@
 import { SingleFieldHolder, SingleFieldValueHolder, SingleFieldValueHolderMap } from '@expo/entity';
+import { describe, expect, it } from '@jest/globals';
 
 import {
   deepEqualEntityAware,

--- a/packages/entity-testing-utils/src/describeFieldTestCase.ts
+++ b/packages/entity-testing-utils/src/describeFieldTestCase.ts
@@ -1,4 +1,5 @@
 import { EntityFieldDefinition } from '@expo/entity';
+import { describe, expect, test } from '@jest/globals';
 
 export default function describeFieldTestCase<T>(
   fieldDefinition: EntityFieldDefinition<T, any>,

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@types/invariant": "^2.2.37",
-    "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.16",
     "@types/node": "^20.14.1",
     "@types/uuid": "^8.3.0",

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
@@ -1,4 +1,5 @@
 import { enforceAsyncResult } from '@expo/results';
+import { describe, expect, it } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
 import AuthorizationResultBasedEntityAssociationLoader from '../AuthorizationResultBasedEntityAssociationLoader';

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
 import AuthorizationResultBasedEntityLoader from '../AuthorizationResultBasedEntityLoader';

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -1,4 +1,5 @@
 import { enforceAsyncResult } from '@expo/results';
+import { describe, expect, it } from '@jest/globals';
 import { mock, instance, verify, spy, anyOfClass, anything, when } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import ComposedEntityCacheAdapter from '../ComposedEntityCacheAdapter';
 import EntityConfiguration from '../EntityConfiguration';
 import { UUIDField } from '../EntityFields';

--- a/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import invariant from 'invariant';
 import nullthrows from 'nullthrows';
 

--- a/packages/entity/src/__tests__/EnforcingEntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityAssociationLoader-test.ts
@@ -1,4 +1,5 @@
 import { result } from '@expo/results';
+import { describe, expect, it } from '@jest/globals';
 import { mock, instance, when, anything } from 'ts-mockito';
 
 import AuthorizationResultBasedEntityAssociationLoader from '../AuthorizationResultBasedEntityAssociationLoader';

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -1,4 +1,5 @@
 import { result } from '@expo/results';
+import { describe, expect, it } from '@jest/globals';
 import { mock, instance, when, anything } from 'ts-mockito';
 
 import AuthorizationResultBasedEntityLoader from '../AuthorizationResultBasedEntityLoader';

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import {
   AuthorizationResultBasedCreateMutator,
   AuthorizationResultBasedDeleteMutator,

--- a/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import AuthorizationResultBasedEntityAssociationLoader from '../AuthorizationResultBasedEntityAssociationLoader';
 import EnforcingEntityAssociationLoader from '../EnforcingEntityAssociationLoader';
 import EntityAssociationLoader from '../EntityAssociationLoader';

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -1,4 +1,5 @@
 import { enforceAsyncResult } from '@expo/results';
+import { expect, it } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
 import Entity from '../Entity';

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { instance, mock, when } from 'ts-mockito';
 
 import EntityCompanion from '../EntityCompanion';

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import Entity from '../Entity';
 import EntityCompanionProvider, { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, test } from '@jest/globals';
+
 import EntityConfiguration from '../EntityConfiguration';
 import { StringField, UUIDField } from '../EntityFields';
 import { CompositeFieldHolder } from '../internal/CompositeFieldHolder';

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
 import EntityDatabaseAdapter, {

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import invariant from 'invariant';
 
 import Entity from '../Entity';

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from '@jest/globals';
 import { v1 as uuidv1, v3 as uuidv3, v4 as uuidv4, v5 as uuidv5 } from 'uuid';
 
 import { EntityFieldDefinition } from '../EntityFieldDefinition';

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import AuthorizationResultBasedEntityLoader from '../AuthorizationResultBasedEntityLoader';
 import EnforcingEntityLoader from '../EnforcingEntityLoader';
 import EntityLoader from '../EntityLoader';

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -1,3 +1,5 @@
+import { describe, test } from '@jest/globals';
+
 import Entity from '../Entity';
 import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';

--- a/packages/entity/src/__tests__/EntityMutator-SingleCompositeFieldCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-SingleCompositeFieldCacheConsistency-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals';
+
 import EntityMutatorFactory from '../EntityMutatorFactory';
 import ViewerContext from '../ViewerContext';
 import TestEntity from '../utils/__testfixtures__/TestEntity';

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -1,4 +1,5 @@
 import { enforceAsyncResult } from '@expo/results';
+import { describe, expect, it } from '@jest/globals';
 import {
   mock,
   spy,

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { mock, instance, spy, verify, anyOfClass, anything, objectContaining } from 'ts-mockito';
 
 import Entity from '../Entity';

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import assert from 'assert';
 import invariant from 'invariant';
 

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { anyOfClass, anything, deepEqual, instance, mock, spy, verify, when } from 'ts-mockito';
 
 import { EntityNonTransactionalQueryContext } from '../EntityQueryContext';

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import Entity from '../Entity';
 import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import EntityConfiguration from '../EntityConfiguration';

--- a/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { mock, when, instance, anything, verify, deepEqual } from 'ts-mockito';
 
 import GenericEntityCacheAdapter from '../GenericEntityCacheAdapter';

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
 import AuthorizationResultBasedEntityAssociationLoader from '../AuthorizationResultBasedEntityAssociationLoader';

--- a/packages/entity/src/__tests__/ViewerContext-test.ts
+++ b/packages/entity/src/__tests__/ViewerContext-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { EntityQueryContext } from '../EntityQueryContext';
 import ViewerContext from '../ViewerContext';
 import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { mock, instance } from 'ts-mockito';
 
 import EntityCompanion from '../EntityCompanion';

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanionProvider-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { mock, instance } from 'ts-mockito';
 
 import EntityCompanionProvider from '../EntityCompanionProvider';

--- a/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { mock, verify, instance } from 'ts-mockito';
 
 import EntityLoaderFactory from '../EntityLoaderFactory';

--- a/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { mock, instance, verify } from 'ts-mockito';
 
 import EntityMutatorFactory from '../EntityMutatorFactory';

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals';
+
 import Entity from '../../Entity';
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals';
+
 import Entity from '../../Entity';
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';

--- a/packages/entity/src/__tests__/entityUtils-test.ts
+++ b/packages/entity/src/__tests__/entityUtils-test.ts
@@ -1,4 +1,5 @@
 import { result } from '@expo/results';
+import { describe, expect, it } from '@jest/globals';
 
 import {
   enforceResultsAsync,
@@ -105,7 +106,7 @@ describe(partitionArray, () => {
     type B = false;
     const arr: (A | B)[] = [true, false, true, true, false];
     const [as, bs] = partitionArray<A, B>(arr, (val: A | B): val is A => val === true);
-    expect(as).toMatchObject([true, true, true]);
-    expect(bs).toMatchObject([false, false]);
+    expect(as).toStrictEqual([true, true, true]);
+    expect(bs).toStrictEqual([false, false]);
   });
 });

--- a/packages/entity/src/errors/__tests__/EntityDatabaseAdapterError-test.ts
+++ b/packages/entity/src/errors/__tests__/EntityDatabaseAdapterError-test.ts
@@ -1,11 +1,13 @@
+import { describe, expect, it } from '@jest/globals';
+
 import EntityDatabaseAdapterError, {
-  EntityDatabaseAdapterTransientError,
-  EntityDatabaseAdapterUnknownError,
   EntityDatabaseAdapterCheckConstraintError,
   EntityDatabaseAdapterExclusionConstraintError,
   EntityDatabaseAdapterForeignKeyConstraintError,
   EntityDatabaseAdapterNotNullConstraintError,
+  EntityDatabaseAdapterTransientError,
   EntityDatabaseAdapterUniqueConstraintError,
+  EntityDatabaseAdapterUnknownError,
 } from '../EntityDatabaseAdapterError';
 
 describe(EntityDatabaseAdapterError, () => {

--- a/packages/entity/src/internal/__tests__/CompositeFieldHolder-test.ts
+++ b/packages/entity/src/internal/__tests__/CompositeFieldHolder-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder';
 
 describe(CompositeFieldHolder, () => {

--- a/packages/entity/src/internal/__tests__/CompositeFieldValueMap-test.ts
+++ b/packages/entity/src/internal/__tests__/CompositeFieldValueMap-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { EntityCompositeFieldValue } from '../../EntityConfiguration';
 import { CompositeFieldValueHolder } from '../CompositeFieldHolder';
 import { CompositeFieldValueMap } from '../CompositeFieldValueMap';

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -1,14 +1,15 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import {
-  mock,
-  instance,
-  when,
-  anything,
-  verify,
-  spy,
-  anyString,
-  resetCalls,
-  deepEqual,
   anyNumber,
+  anyString,
+  anything,
+  deepEqual,
+  instance,
+  mock,
+  resetCalls,
+  spy,
+  verify,
+  when,
 } from 'ts-mockito';
 
 import EntityDatabaseAdapter from '../../EntityDatabaseAdapter';
@@ -19,8 +20,8 @@ import IEntityMetricsAdapter, {
 } from '../../metrics/IEntityMetricsAdapter';
 import NoOpEntityMetricsAdapter from '../../metrics/NoOpEntityMetricsAdapter';
 import {
-  NoCacheStubCacheAdapterProvider,
   InMemoryFullCacheStubCacheAdapterProvider,
+  NoCacheStubCacheAdapterProvider,
 } from '../../utils/__testfixtures__/StubCacheAdapter';
 import StubDatabaseAdapter from '../../utils/__testfixtures__/StubDatabaseAdapter';
 import StubQueryContextProvider from '../../utils/__testfixtures__/StubQueryContextProvider';
@@ -303,7 +304,7 @@ describe(EntityDataManager, () => {
     expect(dbSpy).toHaveBeenCalledTimes(1);
     expect(cacheSpy).toHaveBeenCalledTimes(1);
 
-    expect(entityData).toMatchObject(entityData2);
+    expect(entityData).toEqual(entityData2);
     expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
     expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
 
@@ -378,9 +379,9 @@ describe(EntityDataManager, () => {
     expect(dbSpy).toHaveBeenCalledTimes(3);
     expect(cacheSpy).toHaveBeenCalledTimes(0);
 
-    expect(entityData).toMatchObject(entityData2);
-    expect(entityData2).toMatchObject(entityData3);
-    expect(entityData3).toMatchObject(entityData4);
+    expect(entityData).toEqual(entityData2);
+    expect(entityData2).toEqual(entityData3);
+    expect(entityData3).toEqual(entityData4);
     expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
     expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
 
@@ -453,9 +454,9 @@ describe(EntityDataManager, () => {
     expect(dbSpy).toHaveBeenCalledTimes(3);
     expect(cacheSpy).toHaveBeenCalledTimes(0);
 
-    expect(entityData).toMatchObject(entityData2);
-    expect(entityData2).toMatchObject(entityData3);
-    expect(entityData3).toMatchObject(entityData4);
+    expect(entityData).toEqual(entityData2);
+    expect(entityData2).toEqual(entityData3);
+    expect(entityData3).toEqual(entityData4);
     expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
     expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
 
@@ -532,9 +533,9 @@ describe(EntityDataManager, () => {
     expect(dbSpy).toHaveBeenCalledTimes(4);
     expect(cacheSpy).toHaveBeenCalledTimes(0);
 
-    expect(entityData).toMatchObject(entityData2);
-    expect(entityData2).toMatchObject(entityData3);
-    expect(entityData3).toMatchObject(entityData4);
+    expect(entityData).toEqual(entityData2);
+    expect(entityData2).toEqual(entityData3);
+    expect(entityData3).toEqual(entityData4);
     expect(entityData.get(new SingleFieldValueHolder('hello'))).toHaveLength(2);
     expect(entityData.get(new SingleFieldValueHolder('world'))).toHaveLength(1);
 

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import EntityConfiguration from '../../EntityConfiguration';
 import { StringField, UUIDField } from '../../EntityFields';
 import {

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { verify, mock, instance, when, anything } from 'ts-mockito';
 
 import EntityConfiguration from '../../EntityConfiguration';

--- a/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals';
+
 import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import ReadonlyEntity from '../../ReadonlyEntity';

--- a/packages/entity/src/utils/__testfixtures__/describeFieldTestCase.ts
+++ b/packages/entity/src/utils/__testfixtures__/describeFieldTestCase.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals';
+
 import { EntityFieldDefinition } from '../../EntityFieldDefinition';
 
 export default function describeFieldTestCase<T>(

--- a/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { EntityTransactionalQueryContext } from '../../EntityQueryContext';
 import ViewerContext from '../../ViewerContext';
 import { EntityDatabaseAdapterUniqueConstraintError } from '../../errors/EntityDatabaseAdapterError';

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import nullthrows from 'nullthrows';
 
 import Entity from '../../Entity';

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import Entity from '../../Entity';
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import EntityConfiguration from '../../EntityConfiguration';

--- a/packages/entity/src/utils/__tests__/mergeEntityMutationTriggerConfigurations-test.ts
+++ b/packages/entity/src/utils/__tests__/mergeEntityMutationTriggerConfigurations-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { TestMutationTrigger } from '../__testfixtures__/TestEntityWithMutationTriggers';
 import { mergeEntityMutationTriggerConfigurations } from '../mergeEntityMutationTriggerConfigurations';
 

--- a/packages/entity/src/utils/collections/__tests__/SerializableKeyMap-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/SerializableKeyMap-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { ISerializable, SerializableKeyMap } from '../SerializableKeyMap';
 
 describe(SerializableKeyMap, () => {

--- a/packages/entity/src/utils/collections/__tests__/maps-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/maps-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import {
   computeIfAbsent,
   mapMap,

--- a/packages/entity/src/utils/collections/__tests__/sets-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/sets-test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { areSetsEqual } from '../sets';
 
 describe(areSetsEqual, () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "noPropertyAccessFromIndexSignature": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
-    "esModuleInterop": true,
-    "types": ["jest", "node"]
-  },
+    "esModuleInterop": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,7 +1640,6 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-testing-utils": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/lru-cache": "npm:^5.1.1"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
@@ -1664,7 +1663,6 @@ __metadata:
     "@expo/batcher": "npm:^1.0.0"
     "@expo/entity": "workspace:^"
     "@expo/entity-testing-utils": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
     eslint: "npm:^9.26.0"
@@ -1686,7 +1684,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@expo/entity-codemod@workspace:packages/entity-codemod"
   dependencies:
-    "@types/jest": "npm:^29.5.14"
     "@types/jscodeshift": "npm:^0.12.0"
     "@types/node": "npm:^20.14.1"
     eslint: "npm:^9.26.0"
@@ -1707,7 +1704,6 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-testing-utils": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
     eslint: "npm:^9.26.0"
@@ -1734,7 +1730,6 @@ __metadata:
     "@expo/entity-testing-utils": "workspace:^"
     "@koa/cors": "npm:^4.0.0"
     "@koa/router": "npm:^12.0.0"
-    "@types/jest": "npm:^29.5.14"
     "@types/koa": "npm:^2.13.6"
     "@types/koa-bodyparser": "npm:^4.3.10"
     "@types/koa__cors": "npm:^4.0.0"
@@ -1764,7 +1759,6 @@ __metadata:
     "@expo/entity": "workspace:^"
     "@expo/entity-cache-adapter-redis": "workspace:^"
     "@expo/entity-database-adapter-knex": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20.14.1"
     eslint: "npm:^9.26.0"
     eslint-config-universe: "npm:^15.0.3"
@@ -1783,7 +1777,6 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-testing-utils": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
     eslint: "npm:^9.26.0"
@@ -1805,7 +1798,6 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-cache-adapter-local-memory": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
     eslint: "npm:^9.26.0"
@@ -1827,7 +1819,6 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-cache-adapter-redis": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
     eslint: "npm:^9.26.0"
@@ -1849,7 +1840,6 @@ __metadata:
   resolution: "@expo/entity-testing-utils@workspace:packages/entity-testing-utils"
   dependencies:
     "@expo/entity": "workspace:^"
-    "@types/jest": "npm:^29.5.14"
     "@types/lodash": "npm:^4.17.16"
     "@types/node": "npm:^20.14.1"
     ctix: "npm:^2.7.0"
@@ -1863,6 +1853,8 @@ __metadata:
     ts-jest: "npm:^29.3.2"
     ts-mockito: "npm:^2.6.1"
     typescript: "npm:^5.8.3"
+  peerDependencies:
+    jest: "*"
   languageName: unknown
   linkType: soft
 
@@ -1872,7 +1864,6 @@ __metadata:
   dependencies:
     "@expo/results": "npm:^1.0.0"
     "@types/invariant": "npm:^2.2.37"
-    "@types/jest": "npm:^29.5.14"
     "@types/lodash": "npm:^4.17.16"
     "@types/node": "npm:^20.14.1"
     "@types/uuid": "npm:^8.3.0"
@@ -2128,15 +2119,6 @@ __metadata:
     "@types/node": "npm:*"
     jest-mock: "npm:^29.7.0"
   checksum: 10c0/c7b1b40c618f8baf4d00609022d2afa086d9c6acc706f303a70bb4b67275868f620ad2e1a9efc5edd418906157337cce50589a627a6400bbdf117d351b91ef86
-  languageName: node
-  linkType: hard
-
-"@jest/expect-utils@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/expect-utils@npm:29.5.0"
-  dependencies:
-    jest-get-type: "npm:^29.4.3"
-  checksum: 10c0/e7f44de651b5ef71c6e1b7a0350a704258167c20b6e8165b3100346d5c7f8eb4cd2c229ea2c048e9161666d1c086fbbc422f111f3b77da3fb89a99d52d4b3690
   languageName: node
   linkType: hard
 
@@ -3553,16 +3535,6 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "npm:*"
   checksum: 10c0/e147f0db9346a0cae9a359220bc76f7c78509fb6979a2597feb24d64b6e8328d2d26f9d152abbd59c6bca721e4ea2530af20116d01df50815efafd1e151fd777
-  languageName: node
-  linkType: hard
-
-"@types/jest@npm:^29.5.14":
-  version: 29.5.14
-  resolution: "@types/jest@npm:29.5.14"
-  dependencies:
-    expect: "npm:^29.0.0"
-    pretty-format: "npm:^29.0.0"
-  checksum: 10c0/18e0712d818890db8a8dab3d91e9ea9f7f19e3f83c2e50b312f557017dc81466207a71f3ed79cf4428e813ba939954fa26ffa0a9a7f153181ba174581b1c2aed
   languageName: node
   linkType: hard
 
@@ -6069,13 +6041,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff-sequences@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "diff-sequences@npm:29.4.3"
-  checksum: 10c0/183800b9fd8523a05a3a50ade0fafe81d4b8a8ac113b077d2bc298052ccdc081e3b896f19bf65768b536daebd8169a493c4764cb70a2195e14c442c12538d121
-  languageName: node
-  linkType: hard
-
 "diff-sequences@npm:^29.6.3":
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
@@ -7181,19 +7146,6 @@ __metadata:
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
   checksum: 10c0/71d2ad9b36bc25bb8b104b17e830b40a08989be7f7d100b13269aaae7c3784c3e6e1e88a797e9e87523993a25ba27c8958959a554535370672cfb4d824af8989
-  languageName: node
-  linkType: hard
-
-"expect@npm:^29.0.0":
-  version: 29.5.0
-  resolution: "expect@npm:29.5.0"
-  dependencies:
-    "@jest/expect-utils": "npm:^29.5.0"
-    jest-get-type: "npm:^29.4.3"
-    jest-matcher-utils: "npm:^29.5.0"
-    jest-message-util: "npm:^29.5.0"
-    jest-util: "npm:^29.5.0"
-  checksum: 10c0/3c9382967217ad1453e9271e0da3f83c4aeb12272968007b90fc5873340e7fb64bf4852e1522bdf27556623d031ce62f82aaac09e485a15c6d0589d50999422d
   languageName: node
   linkType: hard
 
@@ -9568,18 +9520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-diff@npm:29.5.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    diff-sequences: "npm:^29.4.3"
-    jest-get-type: "npm:^29.4.3"
-    pretty-format: "npm:^29.5.0"
-  checksum: 10c0/00fda597fa6ee22774453c3cd35c2210bd7f749cf48ad7a41c13b898b2943c9c047842720eb928cdb949b9de87204d8d8987bf12aefdb2f0504f5f4112cab5b0
-  languageName: node
-  linkType: hard
-
 "jest-docblock@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-docblock@npm:29.7.0"
@@ -9613,13 +9553,6 @@ __metadata:
     jest-mock: "npm:^29.7.0"
     jest-util: "npm:^29.7.0"
   checksum: 10c0/61f04fec077f8b1b5c1a633e3612fc0c9aa79a0ab7b05600683428f1e01a4d35346c474bde6f439f9fcc1a4aa9a2861ff852d079a43ab64b02105d1004b2592b
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "jest-get-type@npm:29.4.3"
-  checksum: 10c0/874b0ced6b1cc677ff7fcf0dc86d02674617a7d0b73d47097604fb3ca460178d16104efdd3837e8b8bf0520ad5d210838c07483b058802b457b8413e60628fd0
   languageName: node
   linkType: hard
 
@@ -9663,18 +9596,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-matcher-utils@npm:29.5.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    jest-diff: "npm:^29.5.0"
-    jest-get-type: "npm:^29.4.3"
-    pretty-format: "npm:^29.5.0"
-  checksum: 10c0/0a3ae95ef5c5c4ac2b2c503c2f57e173fa82725722e1fadcd902fd801afe17d9d36e9366820959465f553627bf1e481a0e4a540125f3b4371eec674b3557f7f3
-  languageName: node
-  linkType: hard
-
 "jest-matcher-utils@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-matcher-utils@npm:29.7.0"
@@ -9684,23 +9605,6 @@ __metadata:
     jest-get-type: "npm:^29.6.3"
     pretty-format: "npm:^29.7.0"
   checksum: 10c0/0d0e70b28fa5c7d4dce701dc1f46ae0922102aadc24ed45d594dd9b7ae0a8a6ef8b216718d1ab79e451291217e05d4d49a82666e1a3cc2b428b75cd9c933244e
-  languageName: node
-  linkType: hard
-
-"jest-message-util@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-message-util@npm:29.5.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.12.13"
-    "@jest/types": "npm:^29.5.0"
-    "@types/stack-utils": "npm:^2.0.0"
-    chalk: "npm:^4.0.0"
-    graceful-fs: "npm:^4.2.9"
-    micromatch: "npm:^4.0.4"
-    pretty-format: "npm:^29.5.0"
-    slash: "npm:^3.0.0"
-    stack-utils: "npm:^2.0.3"
-  checksum: 10c0/706e89cacc89c090af584f4687c4e7f0616706481e468ec7c88270e07ae7458a829e477b7b3dff56b75d801f799d65eb2c28d6453c25dd02bea0fd98f0809dbb
   languageName: node
   linkType: hard
 
@@ -9865,7 +9769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.0.0, jest-util@npm:^29.5.0":
+"jest-util@npm:^29.0.0":
   version: 29.5.0
   resolution: "jest-util@npm:29.5.0"
   dependencies:
@@ -12541,17 +12445,6 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
-  languageName: node
-  linkType: hard
-
-"pretty-format@npm:^29.0.0, pretty-format@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "pretty-format@npm:29.5.0"
-  dependencies:
-    "@jest/schemas": "npm:^29.4.3"
-    ansi-styles: "npm:^5.0.0"
-    react-is: "npm:^18.0.0"
-  checksum: 10c0/bcc0190d050196b64e501e5c2b44beb802d79a2b70b6fe6b24ae2d5e0f31237dfcb1f0ab2ada4678829b6ee38507ba292396301aff0a8122e575ffd45d5d037c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Jest is written in typescript and ships with its own types.

# Test Plan

Typecheck and tests running in CI.