### PR TITLE
chore: Explicitly list files to collect coverage from

### DIFF
--- a/resources/jest.config.js
+++ b/resources/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  coveragePathIgnorePatterns: ['__testfixtures__'],
+  collectCoverageFrom: ['src/**/*', 'src/*', '!src/**/__*test*__/**'],
   testMatch: ['**/__tests__/**/*-test.ts'],
   transform: {
     '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }],


### PR DESCRIPTION
# Why

By default jest will only track coverage stats for files imported by a test.  What about files that are never imported by any test?  They aren't included in the report.  But it would be better to include them and mark them as having 0% coverage.

# Test Plan

Codecov in CI will show a difference in the results.

e: It looks like it adds two untested source files to coverage, and removes two test files from it. 