### PR TITLE
chore: Use 'v8' coverage provider

### DIFF
--- a/resources/jest.config.js
+++ b/resources/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  collectCoverageFrom: ['src/**/*', 'src/*', '!src/**/__*test*__/**'],
+  collectCoverageFrom: ['src/**/*', '!src/index.ts', '!src/**/__*test*__/**'],
+  coverageProvider: 'v8',
   testMatch: ['**/__tests__/**/*-test.ts'],
   transform: {
     '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }],


### PR DESCRIPTION
# Why

I was hoping this would be more accurate and consistent.

# Test Plan

Codecov report from CI.

It looks like there are a few small changes here and there, and then the `src/index.ts` files were all added to coverage and marked as uncovered. 