### PR TITLE
chore: Remove unneeded files from packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-**/__tests__/**
-**/__integration-tests__/**
-**/__mocks__/**
-**/__testfixtures__/**

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "test:all": "yarn test",
     "integration": "./resources/run-with-docker yarn test --config jest-integration.config.js --runInBand",
     "integration:all": "yarn integration",
-    "prepack": "yarn build",
     "ctix": "ctix build && resources/prepend-barrels.sh",
+    "package-files": "yarn workspaces foreach --all --no-private --parallel --topological pack --dry-run",
     "typedoc": "yarn build && typedoc"
   },
   "devDependencies": {

--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -4,12 +4,15 @@
   "description": "Cross-request local memory cache adapter for @expo/entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn lint --fix",

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -4,12 +4,15 @@
   "description": "Redis cache adapter for @expo/entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn lint --fix",

--- a/packages/entity-codemod/package.json
+++ b/packages/entity-codemod/package.json
@@ -4,12 +4,15 @@
   "description": "jscodeshift codemods for @expo/entity upgrades",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn lint --fix",

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -4,12 +4,15 @@
   "description": "Knex database adapter for @expo/entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn lint --fix",

--- a/packages/entity-ip-address-field/package.json
+++ b/packages/entity-ip-address-field/package.json
@@ -4,12 +4,15 @@
   "description": "IP address EntityField definitions for @expo/entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn lint --fix",

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -4,12 +4,15 @@
   "description": "Local memory secondary cache for @expo/entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn run lint --fix",

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -4,12 +4,15 @@
   "description": "Redis secondary cache for @expo/entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn run lint --fix",

--- a/packages/entity-testing-utils/package.json
+++ b/packages/entity-testing-utils/package.json
@@ -4,12 +4,15 @@
   "description": "A package containing utilities for testing applications that use Entity",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn run lint --fix",

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -4,12 +4,15 @@
   "description": "A privacy-first data model",
   "files": [
     "build",
+    "!*.tsbuildinfo",
+    "!__*",
     "src"
   ],
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "prepack": "rm -rf build && yarn build",
     "clean": "yarn build --clean",
     "lint": "yarn run --top-level eslint src",
     "lint-fix": "yarn run lint --fix",


### PR DESCRIPTION
# Why

The most recent release included test files.

# How

The `.npmignore` did not work!  Instead I changed each  package.json to filter the files which shouldn't be published.

- `**/__*`: we use this pattern to indicate test-only files of some kind
- `*.tsbuildinfo`: typescript uses these to track build caching 

# Test Plan

Run `yarn package-files` from root and you'll see exactly what files will be included in each package.