### PR TITLE
feat: allow manual specification of cascadingDeleteCause in delete mutator factory method

### DIFF
--- a/packages/entity/src/EntityDeleter.ts
+++ b/packages/entity/src/EntityDeleter.ts
@@ -68,6 +68,6 @@ export class EntityDeleter<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this.entityClass)
       .getMutatorFactory()
-      .forDelete(this.existingEntity, this.queryContext);
+      .forDelete(this.existingEntity, this.queryContext, /* cascadingDeleteCause */ null);
   }
 }

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -8,6 +8,7 @@ import { EntityCompanionProvider } from './EntityCompanionProvider';
 import { EntityConfiguration } from './EntityConfiguration';
 import { EntityDatabaseAdapter } from './EntityDatabaseAdapter';
 import { EntityLoaderFactory } from './EntityLoaderFactory';
+import { EntityCascadingDeletionInfo } from './EntityMutationInfo';
 import { EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration';
 import { EntityMutationValidator } from './EntityMutationValidator';
 import { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
@@ -111,6 +112,7 @@ export class EntityMutatorFactory<
   forUpdate(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null,
   ): AuthorizationResultBasedUpdateMutator<
     TFields,
     TIDField,
@@ -132,6 +134,7 @@ export class EntityMutatorFactory<
       this.databaseAdapter,
       this.metricsAdapter,
       existingEntity,
+      cascadingDeleteCause,
     );
   }
 
@@ -143,6 +146,7 @@ export class EntityMutatorFactory<
   forDelete(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null,
   ): AuthorizationResultBasedDeleteMutator<
     TFields,
     TIDField,
@@ -164,6 +168,7 @@ export class EntityMutatorFactory<
       this.databaseAdapter,
       this.metricsAdapter,
       existingEntity,
+      cascadingDeleteCause,
     );
   }
 }

--- a/packages/entity/src/EntityUpdater.ts
+++ b/packages/entity/src/EntityUpdater.ts
@@ -68,6 +68,6 @@ export class EntityUpdater<
       .getViewerContext()
       .getViewerScopedEntityCompanionForClass(this.entityClass)
       .getMutatorFactory()
-      .forUpdate(this.existingEntity, this.queryContext);
+      .forUpdate(this.existingEntity, this.queryContext, /* cascadingDeleteCause */ null);
   }
 }

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -3,6 +3,7 @@ import {
   AuthorizationResultBasedDeleteMutator,
   AuthorizationResultBasedUpdateMutator,
 } from './AuthorizationResultBasedEntityMutator';
+import { EntityCascadingDeletionInfo } from './EntityMutationInfo';
 import { EntityMutatorFactory } from './EntityMutatorFactory';
 import { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -54,6 +55,7 @@ export class ViewerScopedEntityMutatorFactory<
   forUpdate(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null,
   ): AuthorizationResultBasedUpdateMutator<
     TFields,
     TIDField,
@@ -62,12 +64,13 @@ export class ViewerScopedEntityMutatorFactory<
     TPrivacyPolicy,
     TSelectedFields
   > {
-    return this.entityMutatorFactory.forUpdate(existingEntity, queryContext);
+    return this.entityMutatorFactory.forUpdate(existingEntity, queryContext, cascadingDeleteCause);
   }
 
   forDelete(
     existingEntity: TEntity,
     queryContext: EntityQueryContext,
+    cascadingDeleteCause: EntityCascadingDeletionInfo | null,
   ): AuthorizationResultBasedDeleteMutator<
     TFields,
     TIDField,
@@ -76,6 +79,6 @@ export class ViewerScopedEntityMutatorFactory<
     TPrivacyPolicy,
     TSelectedFields
   > {
-    return this.entityMutatorFactory.forDelete(existingEntity, queryContext);
+    return this.entityMutatorFactory.forDelete(existingEntity, queryContext, cascadingDeleteCause);
   }
 }


### PR DESCRIPTION
# Why

In the same way that the cascadingDeleteCause can be specified in application code during a call to the load factory method (which is the advanced way of creating a loader), it should be possible to specify for the updater and deleter when constructed via their factory methods.

Note that this doesn't affect the normal `Entity.deleter(entity).deleteAsync()` method of calling. Only when called in the following form is it specifiable from application code:
```typescript
this.existingEntity
      .getViewerContext()
      .getViewerScopedEntityCompanionForClass(this.entityClass)
      .getMutatorFactory()
      .forUpdate(this.existingEntity, this.queryContext, cascadingDeleteCause);
```

Concretely, this is useful in application code for bulk/batch deletions ahead of calling the parent entity's delete. Once #220 is implemented, this theoretically wouldn't be necessary, but as it currently stands, bulk/batch deletion is implemented in application code and therefore needs access to slightly lower-level entity constructs.

# How

Change arg, propagate to mutator classes, see that it's better represented as a constructor arg now.

Add tests.

# Test Plan

Run test.