### PR TITLE
chore: fix erroneous describe.only and add lint rule to prevent it

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,24 @@ module.exports = defineConfig([
       'tsdoc/syntax': 'warn',
       'no-console': 'warn',
       'handle-callback-err': 'off',
+      'no-restricted-properties': [
+        'warn',
+        {
+          object: 'it',
+          property: 'only',
+          message: 'it.only should not be committed to main.',
+        },
+        {
+          object: 'test',
+          property: 'only',
+          message: 'test.only should not be committed to main.',
+        },
+        {
+          object: 'describe',
+          property: 'only',
+          message: 'describe.only should not be committed to main.',
+        },
+      ],
     },
   },
   {

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -256,7 +256,7 @@ describe('postgres entity integration', () => {
     });
   });
 
-  describe.only('BYTEA fields', () => {
+  describe('BYTEA fields', () => {
     it('supports BYTEA fields', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 


### PR DESCRIPTION
# Why

In other repositories at Expo we have this lint disallow rule to avoid accidental skips like this. This PR adds the same rule.

# How

1. Add rule.
2. Fix violation.

# Test Plan

`yarn lint`