### PR TITLE
fix: validate that UUID field is lower-case

### DIFF
--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -6,7 +6,7 @@ import {
 
 // Use our own regex since the `uuid` package doesn't support validating UUIDv6/7/8 yet
 const UUID_REGEX =
-  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/;
 
 /**
  * EntityFieldDefinition for a column with a JS string type.
@@ -22,7 +22,9 @@ export class StringField<TRequireExplicitCache extends boolean> extends EntityFi
 
 /**
  * EntityFieldDefinition for a column with a JS string type.
- * Enforces that the string is a valid UUID.
+ * Enforces that the string is a valid UUID and that it is lowercase. Entity requires UUIDs to be lowercase since most
+ * databases (e.g. Postgres) treat UUIDs as case-insensitive, which can lead to unexpected entity load results if mixed-case
+ * UUIDs are used.
  */
 export class UUIDField<
   TRequireExplicitCache extends boolean,

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -65,7 +65,7 @@ describeFieldTestCase(
     uuidv5('wat', uuidv5.DNS),
     /* UUIDv7 */ '018ebfda-dc80-782d-a891-22a0aa057d52',
   ],
-  [uuidv4().replace('-', ''), '', 'hello'],
+  [uuidv4().replace('-', ''), '', 'hello', uuidv4().toUpperCase()],
 );
 describeFieldTestCase(new DateField({ columnName: 'wat' }), [new Date()], [Date.now()]);
 describeFieldTestCase(new BooleanField({ columnName: 'wat' }), [true, false], [0, 1, '']);


### PR DESCRIPTION
# Why

Technically upper-case UUIDs are valid according to https://datatracker.ietf.org/doc/html/rfc4122.

But the way entity is written expects case sensitivity due to them being treated as simple strings. For example, this would be the expected behavior:
```
const entities = await TestEntity.loader(vc).loadManyByFieldEqualingAsync('id', ['018EBFDA-DC80-782D-A891-22A0AA057D52']);
=> Map(['018EBFDA-DC80-782D-A891-22A0AA057D52', TestEntity[...]])
```

The issue is that Postgres stores them in a case-insensitive manner (which is correct according to the UUID spec). So in actuality, the above code would theoretically do something like:
```
const entities = await TestEntity.loader(vc).loadManyByFieldEqualingAsync('id', ['018EBFDA-DC80-782D-A891-22A0AA057D52']);
=> Map(['018ebfda-dc80-782d-a891-22a0aa057d52', TestEntity[...]])
```
(it actually fails due to this change of case further up in the stack at https://github.com/expo/entity/blob/077d53cd86d4c54132ea2ebcc59d1d75e2b507d0/packages/entity/src/EntityDatabaseAdapter.ts#L182, but the reason is the same: postgres transforms to lower case under-the-hood)

This results in breaking invariants the framework provides (all keys in === all keys out).

This PR solves this problem by just enforcing UUID casing in fields to match what Postgres already does to avoid this issue.

Ref: WWW-37

# How

I first tried a field normalization approach in #309, but this also had the same problem: the fields in !== fields out. Unless we were to invert the normalization on the way out, but that comes with a lot of added complexity.

So this is the solution I propose: just don't allow any upper-case characters in the UUIDs. This is technically not UUID spec compliant since we no longer accept all technically valid UUIDs.

# Test Plan

Run the test.