### PR TITLE
feat: add more documentation to entity errors

### DIFF
--- a/packages/entity/src/errors/EntityCacheAdapterError.ts
+++ b/packages/entity/src/errors/EntityCacheAdapterError.ts
@@ -1,7 +1,14 @@
 import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
 
+/**
+ * Base class for errors thrown by the entity cache adapter.
+ */
 export abstract class EntityCacheAdapterError extends EntityError {}
 
+/**
+ * Error thrown when a transient error occurs in the entity cache adapter.
+ * Transient errors may succeed if retried.
+ */
 export class EntityCacheAdapterTransientError extends EntityCacheAdapterError {
   public readonly state = EntityErrorState.TRANSIENT;
   public readonly code = EntityErrorCode.ERR_ENTITY_CACHE_ADAPTER_TRANSIENT;

--- a/packages/entity/src/errors/EntityError.ts
+++ b/packages/entity/src/errors/EntityError.ts
@@ -1,11 +1,17 @@
 import ES6Error from 'es6-error';
 
+/**
+ * The state of an entity error, indicating whether it may be transient/retryable.
+ */
 export enum EntityErrorState {
   UNKNOWN,
   TRANSIENT,
   PERMANENT,
 }
 
+/**
+ * Error code for an entity error. Each error code should map to a specific class of Entity error.
+ */
 export enum EntityErrorCode {
   ERR_ENTITY_NOT_AUTHORIZED = 'ERR_ENTITY_NOT_AUTHORIZED',
   ERR_ENTITY_NOT_FOUND = 'ERR_ENTITY_NOT_FOUND',
@@ -25,6 +31,9 @@ export enum EntityErrorCode {
   ERR_ENTITY_CACHE_ADAPTER_TRANSIENT = 'ERR_ENTITY_CACHE_ADAPTER_TRANSIENT',
 }
 
+/**
+ * Base class for all known errors thrown by the entity system.
+ */
 export abstract class EntityError extends ES6Error {
   public abstract readonly state: EntityErrorState;
   public abstract readonly code: EntityErrorCode;

--- a/packages/entity/src/errors/EntityInvalidFieldValueError.ts
+++ b/packages/entity/src/errors/EntityInvalidFieldValueError.ts
@@ -4,6 +4,9 @@ import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
 import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
 
+/**
+ * Error thrown when an entity field has an invalid value, either during load or mutation.
+ */
 export class EntityInvalidFieldValueError<
   TFields extends Record<string, any>,
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,

--- a/packages/entity/src/errors/EntityNotAuthorizedError.ts
+++ b/packages/entity/src/errors/EntityNotAuthorizedError.ts
@@ -3,6 +3,9 @@ import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
 import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
 
+/**
+ * Error thrown when viewer context is not authorized to perform an action on an entity.
+ */
 export class EntityNotAuthorizedError<
   TFields extends Record<string, any>,
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,

--- a/packages/entity/src/errors/EntityNotFoundError.ts
+++ b/packages/entity/src/errors/EntityNotFoundError.ts
@@ -31,6 +31,9 @@ type EntityNotFoundOptions<
   fieldValue: TFields[N];
 };
 
+/**
+ * Error thrown when an entity is not found during certain load methods.
+ */
 export class EntityNotFoundError<
   TFields extends Record<string, any>,
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,


### PR DESCRIPTION
# Why

#311 added more documentation to database adapter errors. This PR adds it for the rest of entity errors.

# How

Add more documentation.

# Test Plan

Proofread.