### PR TITLE
fix: make in memory and stub database adapters behave more similarly to sql

### DIFF
--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -9,7 +9,6 @@ import {
   type TableQuerySelectionModifiers,
   getDatabaseFieldForEntityField,
 } from '@expo/entity';
-import invariant from 'invariant';
 import { v4 as uuidv4 } from 'uuid';
 
 const dbObjects: Readonly<{ [key: string]: any }>[] = [];
@@ -162,7 +161,13 @@ class InMemoryDatabaseAdapter<
     const objectIndex = dbObjects.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
-    invariant(objectIndex >= 0, 'should exist');
+
+    // SQL updates to a nonexistent row succeed but affect 0 rows,
+    // mirror that behavior here for better test simulation
+    if (objectIndex < 0) {
+      return [];
+    }
+
     dbObjects[objectIndex] = {
       ...dbObjects[objectIndex],
       ...object,
@@ -179,7 +184,13 @@ class InMemoryDatabaseAdapter<
     const objectIndex = dbObjects.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
-    invariant(objectIndex >= 0, 'should exist');
+
+    // SQL deletes to a nonexistent row succeed and affect 0 rows,
+    // mirror that behavior here for better test simulation
+    if (objectIndex < 0) {
+      return 0;
+    }
+
     dbObjects.splice(objectIndex, 1);
     return 1;
   }

--- a/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
@@ -233,7 +233,13 @@ export class StubDatabaseAdapter<
     const objectIndex = objectCollection.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
-    invariant(objectIndex >= 0, 'should exist');
+
+    // SQL updates to a nonexistent row succeed but affect 0 rows,
+    // mirror that behavior here for better test simulation
+    if (objectIndex < 0) {
+      return [];
+    }
+
     objectCollection[objectIndex] = {
       ...objectCollection[objectIndex],
       ...object,
@@ -252,9 +258,13 @@ export class StubDatabaseAdapter<
     const objectIndex = objectCollection.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
+
+    // SQL deletes to a nonexistent row succeed and affect 0 rows,
+    // mirror that behavior here for better test simulation
     if (objectIndex < 0) {
       return 0;
     }
+
     objectCollection.splice(objectIndex, 1);
     return 1;
   }

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -234,7 +234,13 @@ export class StubDatabaseAdapter<
     const objectIndex = objectCollection.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
-    invariant(objectIndex >= 0, 'should exist');
+
+    // SQL updates to a nonexistent row succeed but affect 0 rows,
+    // mirror that behavior here for better test simulation
+    if (objectIndex < 0) {
+      return [];
+    }
+
     objectCollection[objectIndex] = {
       ...objectCollection[objectIndex],
       ...object,
@@ -253,9 +259,13 @@ export class StubDatabaseAdapter<
     const objectIndex = objectCollection.findIndex((obj) => {
       return obj[tableIdField] === id;
     });
+
+    // SQL deletes to a nonexistent row succeed and affect 0 rows,
+    // mirror that behavior here for better test simulation
     if (objectIndex < 0) {
       return 0;
     }
+
     objectCollection.splice(objectIndex, 1);
     return 1;
   }


### PR DESCRIPTION
# Why

#311 updated the errors for postgres, but the conditions in the stub adapters preempted those errors in test code, so their behavior diverged. This PR makes the stub adapters behave more similarly to Postgres adapter.

# How

Return more similar results in not-found cases. See inline comments.

# Test Plan

`yarn tsc`. Also the tests in entity-example test this.