### PR TITLE
fix: add default for TSelectedFields in PrivacyPolicyTestUtils Case

### DIFF
--- a/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
@@ -13,7 +13,7 @@ export interface Case<
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields,
+  TSelectedFields extends keyof TFields = keyof TFields,
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
@@ -32,7 +32,7 @@ export type CaseMap<
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields,
+  TSelectedFields extends keyof TFields = keyof TFields,
 > = Map<string, () => Promise<Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>>>;
 
 /**

--- a/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
@@ -11,7 +11,7 @@ export interface Case<
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields,
+  TSelectedFields extends keyof TFields = keyof TFields,
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
@@ -30,7 +30,7 @@ export type CaseMap<
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
-  TSelectedFields extends keyof TFields,
+  TSelectedFields extends keyof TFields = keyof TFields,
 > = Map<string, () => Promise<Case<TFields, TIDField, TViewerContext, TEntity, TSelectedFields>>>;
 
 /**


### PR DESCRIPTION
# Why

Noticed this while working in the Expo server. Since this is an external interface created in application code, we want this generic to have a default (like other external interfaces).

Closes ENG-17962.

# How

Add default.

# Test Plan

`yarn tsc`