### PR TITLE
feat: switch local cache to an interface

### DIFF
--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -28,13 +28,12 @@
   "author": "Expo",
   "license": "MIT",
   "dependencies": {
-    "@expo/entity": "workspace:^",
-    "lru-cache": "^6.0.0"
+    "@expo/entity": "workspace:^"
   },
   "devDependencies": {
     "@expo/entity-testing-utils": "workspace:^",
+    "@isaacs/ttlcache": "^2.1.3",
     "@jest/globals": "^30.2.0",
-    "@types/lru-cache": "^5.1.1",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -6,15 +6,18 @@ import {
   IEntityCacheAdapterProvider,
 } from '@expo/entity';
 
-import { GenericLocalMemoryCacher, LocalMemoryCache } from './GenericLocalMemoryCacher';
+import { GenericLocalMemoryCacher, ILocalMemoryCache } from './GenericLocalMemoryCacher';
 
+export type LocalMemoryCacheCreator = <
+  TFields extends Record<string, any>,
+>() => ILocalMemoryCache<TFields>;
 /**
  * Vends local memory cache adapters. An instance of this class may be shared across requests to
  * share the local memory cache.
  */
 export class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvider {
   /**
-   * @returns a no-op local memory cache adapter provider, or one that doesn't cache locally.
+   * @returns a no-op local memory cache adapter provider, or one that doesn't cache at all.
    */
   static createNoOpProvider(): IEntityCacheAdapterProvider {
     return new LocalMemoryCacheAdapterProvider(<TFields extends Record<string, any>>() =>
@@ -23,14 +26,12 @@ export class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvi
   }
 
   /**
-   * @returns a local memory cache adapter provider configured with the supplied options.
+   * @returns a local memory cache adapter provider configured with the supplied local memory cache creator function.
    */
-  static createProviderWithOptions(
-    options: { maxSize?: number; ttlSeconds?: number } = {},
+  static createProviderWithCacheCreator(
+    cacheCreator: LocalMemoryCacheCreator,
   ): IEntityCacheAdapterProvider {
-    return new LocalMemoryCacheAdapterProvider(<TFields extends Record<string, any>>() =>
-      GenericLocalMemoryCacher.createLRUCache<TFields>(options),
-    );
+    return new LocalMemoryCacheAdapterProvider(cacheCreator);
   }
 
   private readonly localMemoryCacheAdapterMap = new Map<
@@ -38,11 +39,7 @@ export class LocalMemoryCacheAdapterProvider implements IEntityCacheAdapterProvi
     GenericEntityCacheAdapter<any, any>
   >();
 
-  private constructor(
-    private readonly localMemoryCacheCreator: <
-      TFields extends Record<string, any>,
-    >() => LocalMemoryCache<TFields>,
-  ) {}
+  private constructor(private readonly localMemoryCacheCreator: LocalMemoryCacheCreator) {}
 
   public getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
     entityConfiguration: EntityConfiguration<TFields, TIDField>,

--- a/packages/entity-cache-adapter-local-memory/src/__testfixtures__/createLocalMemoryTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__testfixtures__/createLocalMemoryTestEntityCompanionProvider.ts
@@ -4,10 +4,25 @@ import {
   NoOpEntityMetricsAdapter,
 } from '@expo/entity';
 import { StubDatabaseAdapterProvider, StubQueryContextProvider } from '@expo/entity-testing-utils';
+import { TTLCache } from '@isaacs/ttlcache';
 
+import { ILocalMemoryCache, LocalMemoryCacheValue } from '../GenericLocalMemoryCacher';
 import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
 
 const queryContextProvider = new StubQueryContextProvider();
+
+function createTTLCache<TFields extends Record<string, any>>(
+  options: { maxSize?: number; ttlSeconds?: number } = {},
+): ILocalMemoryCache<TFields> {
+  const DEFAULT_LRU_CACHE_MAX_AGE_SECONDS = 10;
+  const DEFAULT_LRU_CACHE_SIZE = 10000;
+  const maxAgeSeconds = options.ttlSeconds ?? DEFAULT_LRU_CACHE_MAX_AGE_SECONDS;
+  return new TTLCache<string, LocalMemoryCacheValue<TFields>>({
+    max: options.maxSize ?? DEFAULT_LRU_CACHE_SIZE,
+    ttl: maxAgeSeconds * 1000, // convert to ms
+    updateAgeOnGet: true,
+  });
+}
 
 export const createLocalMemoryTestEntityCompanionProvider = (
   localMemoryOptions: { maxSize?: number; ttlSeconds?: number } = {},
@@ -16,7 +31,9 @@ export const createLocalMemoryTestEntityCompanionProvider = (
   const localMemoryCacheAdapterProvider =
     localMemoryOptions.maxSize === 0 && localMemoryOptions.ttlSeconds === 0
       ? LocalMemoryCacheAdapterProvider.createNoOpProvider()
-      : LocalMemoryCacheAdapterProvider.createProviderWithOptions(localMemoryOptions);
+      : LocalMemoryCacheAdapterProvider.createProviderWithCacheCreator(() =>
+          createTTLCache(localMemoryOptions),
+        );
   return new EntityCompanionProvider(
     metricsAdapter,
     new Map([

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -32,6 +32,7 @@
     "@expo/entity-cache-adapter-local-memory": "workspace:^"
   },
   "devDependencies": {
+    "@isaacs/ttlcache": "^2.1.3",
     "@jest/globals": "^30.0.1",
     "nullthrows": "^1.1.1",
     "typescript": "^5.9.3"

--- a/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-local-memory/src/LocalMemorySecondaryEntityCache.ts
@@ -1,7 +1,7 @@
 import { EntityConfiguration, GenericSecondaryEntityCache } from '@expo/entity';
 import {
   GenericLocalMemoryCacher,
-  LocalMemoryCache,
+  ILocalMemoryCache,
 } from '@expo/entity-cache-adapter-local-memory';
 
 /**
@@ -18,7 +18,7 @@ export class LocalMemorySecondaryEntityCache<
 > extends GenericSecondaryEntityCache<TFields, TIDField, TLoadParams> {
   constructor(
     entityConfiguration: EntityConfiguration<TFields, TIDField>,
-    localMemoryCache: LocalMemoryCache<TFields>,
+    localMemoryCache: ILocalMemoryCache<TFields>,
   ) {
     super(new GenericLocalMemoryCacher(entityConfiguration, localMemoryCache), (params) =>
       JSON.stringify(params),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2581,9 +2581,8 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-testing-utils": "workspace:^"
+    "@isaacs/ttlcache": "npm:^2.1.3"
     "@jest/globals": "npm:^30.2.0"
-    "@types/lru-cache": "npm:^5.1.1"
-    lru-cache: "npm:^6.0.0"
     typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
@@ -2683,6 +2682,7 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-cache-adapter-local-memory": "workspace:^"
+    "@isaacs/ttlcache": "npm:^2.1.3"
     "@jest/globals": "npm:^30.0.1"
     nullthrows: "npm:^1.1.1"
     typescript: "npm:^5.9.3"
@@ -2885,6 +2885,13 @@ __metadata:
   version: 1.1.0
   resolution: "@isaacs/string-locale-compare@npm:1.1.0"
   checksum: 10c0/d67226ff7ac544a495c77df38187e69e0e3a0783724777f86caadafb306e2155dc3b5787d5927916ddd7fb4a53561ac8f705448ac3235d18ea60da5854829fdf
+  languageName: node
+  linkType: hard
+
+"@isaacs/ttlcache@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@isaacs/ttlcache@npm:2.1.3"
+  checksum: 10c0/3a8210d37a23e1a671297c2cd0f703303a39a1822e471a484fde5874828c57ce2cd730435ba12579f21e5b295ebaf66a72312d07511cacb8554006fab5e75b81
   languageName: node
   linkType: hard
 
@@ -4634,13 +4641,6 @@ __metadata:
   version: 4.0.2
   resolution: "@types/long@npm:4.0.2"
   checksum: 10c0/42ec66ade1f72ff9d143c5a519a65efc7c1c77be7b1ac5455c530ae9acd87baba065542f8847522af2e3ace2cc999f3ad464ef86e6b7352eece34daf88f8c924
-  languageName: node
-  linkType: hard
-
-"@types/lru-cache@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@types/lru-cache@npm:5.1.1"
-  checksum: 10c0/1f17ec9b202c01a89337cc5528198a690be6b61a6688242125fbfb7fa17770e453e00e4685021abf5ae605860ca0722209faac5c254b780d0104730bb0b9e354
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

We've fallen too far behind on lru-cache. We previously decided to lock it @ 6.x in https://github.com/expo/entity/pull/170 because our use case couldn't pre-allocate all the data structures ahead of time efficiently.

But while reading the thread for that, I noticed the author has a ttl-cache: https://github.com/isaacs/node-lru-cache/issues/208#issuecomment-1092140956. This is much closer to our needs. 

We essentially simulate a LRU cache by updating the TTL on each get: https://github.com/isaacs/ttlcache?tab=readme-ov-file#cachegetkey-updateageonget-checkageonget-ttl--

Because our TTL is short yet we require storing N caches this use case is more optimal.

Ref: ENG-18193

# How

Switch to ttl-cache but only as a dev dependency, make exported API an interface so that consumers can choose between old lru-cache and ttl-cache.

# Test Plan

Run all tests.
