### PR TITLE
chore: upgrade to uuid 13

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   transform: { '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }] },
+  // ESM modules that need to be transformed
+  transformIgnorePatterns: ['node_modules/(?!(uuid)/)'],
   collectCoverageFrom: [
     'packages/*/src/**',
     '!packages/*/src/index.ts',

--- a/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
@@ -14,7 +14,7 @@ import {
   transformFieldsToDatabaseObject,
 } from '@expo/entity';
 import invariant from 'invariant';
-import { uuidv7 } from 'uuidv7';
+import { v7 as uuidv7 } from 'uuid';
 
 export class StubDatabaseAdapter<
   TFields extends Record<string, any>,

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -37,11 +37,9 @@
     "@types/invariant": "2.2.37",
     "@types/lodash": "4.17.21",
     "@types/node": "24.10.4",
-    "@types/uuid": "8.3.4",
     "lodash": "4.17.21",
     "ts-mockito": "2.6.1",
     "typescript": "5.9.3",
-    "uuid": "8.3.2",
-    "uuidv7": "1.1.0"
+    "uuid": "13.0.0"
   }
 }

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from '@jest/globals';
-import { v1 as uuidv1, v3 as uuidv3, v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+import { v1 as uuidv1, v3 as uuidv3, v4 as uuidv4, v5 as uuidv5, v7 as uuidv7 } from 'uuid';
 
 import { EntityFieldDefinition } from '../EntityFieldDefinition';
 import {
@@ -58,13 +58,7 @@ describe(EntityFieldDefinition, () => {
 describeFieldTestCase(new StringField({ columnName: 'wat' }), ['hello', ''], [1, true, {}, [[]]]);
 describeFieldTestCase(
   new UUIDField({ columnName: 'wat' }),
-  [
-    uuidv1(),
-    uuidv3('wat', uuidv3.DNS),
-    uuidv4(),
-    uuidv5('wat', uuidv5.DNS),
-    /* UUIDv7 */ '018ebfda-dc80-782d-a891-22a0aa057d52',
-  ],
+  [uuidv1(), uuidv3('wat', uuidv3.DNS), uuidv4(), uuidv5('wat', uuidv5.DNS), uuidv7()],
   [uuidv4().replace('-', ''), '', 'hello', uuidv4().toUpperCase()],
 );
 describeFieldTestCase(new DateField({ columnName: 'wat' }), [new Date()], [Date.now()]);

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -1,5 +1,5 @@
 import invariant from 'invariant';
-import { uuidv7 } from 'uuidv7';
+import { v7 as uuidv7 } from 'uuid';
 
 import { EntityConfiguration } from '../../EntityConfiguration';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,15 +2726,13 @@ __metadata:
     "@types/invariant": "npm:2.2.37"
     "@types/lodash": "npm:4.17.21"
     "@types/node": "npm:24.10.4"
-    "@types/uuid": "npm:8.3.4"
     dataloader: "npm:^2.2.3"
     es6-error: "npm:^4.1.1"
     invariant: "npm:^2.2.4"
     lodash: "npm:4.17.21"
     ts-mockito: "npm:2.6.1"
     typescript: "npm:5.9.3"
-    uuid: "npm:8.3.2"
-    uuidv7: "npm:1.1.0"
+    uuid: "npm:13.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4695,13 +4693,6 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:8.3.4":
-  version: 8.3.4
-  resolution: "@types/uuid@npm:8.3.4"
-  checksum: 10c0/b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
   languageName: node
   linkType: hard
 
@@ -14895,12 +14886,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:13.0.0":
+  version: 13.0.0
+  resolution: "uuid@npm:13.0.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/950e4c18d57fef6c69675344f5700a08af21e26b9eff2bf2180427564297368c538ea11ac9fb2e6528b17fc3966a9fd2c5049361b0b63c7d654f3c550c9b3d67
   languageName: node
   linkType: hard
 
@@ -14919,15 +14910,6 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
-  languageName: node
-  linkType: hard
-
-"uuidv7@npm:1.1.0":
-  version: 1.1.0
-  resolution: "uuidv7@npm:1.1.0"
-  bin:
-    uuidv7: cli.js
-  checksum: 10c0/eceeb6cd682e323f14778cda6f221ebfafc339cd8bf8032a905b367cec547bffd5c717a60e956891525066c9a45f44fbe7688c269d1f95773ab940a212f1319c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Instead of renovate's uuid upgrades, upgrade manually and remove types package. Also remove uuidv7 now that v7 is supported in uuid.

# Test Plan

CI