### PR TITLE
chore: upgrade docker compose for tests to postgres 18

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -7,11 +7,11 @@ services:
     volumes:
       - redis_data:/data
   postgres:
-    image: postgres:14@sha256:5fd97d3efae5e17da18b5884532f07c411330253e0a864d8895f176ab4ab0f90
+    image: postgres:18@sha256:bfe50b2b0ddd9b55eadedd066fe24c7c6fe06626185b73358c480ea37868024d
     ports:
       - "${PGPORT}:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     environment:
       POSTGRES_USER: "${PGUSER}"
       POSTGRES_PASSWORD: "${PGPASSWORD}"


### PR DESCRIPTION
# Why

Supersedes #363 (renovate) to change where data is stored as well.

# How

This is a good test to ensure entity supports many postgres versions. Theoretically we should run a matrix of versions, but I think this is fine too (just testing the latest version).

# Test Plan

CI (integration tests)