### PR TITLE
chore: require eqeqeq lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ module.exports = defineConfig([
       'tsdoc/syntax': 'warn',
       'no-console': 'warn',
       'handle-callback-err': 'off',
+      eqeqeq: ['warn', 'always'],
       'no-restricted-properties': [
         'warn',
         {


### PR DESCRIPTION
# Why

This matches the current style and pattern within this library.

https://eslint.org/docs/latest/rules/eqeqeq

This algorithm is hard to remember, prefer being explicit in this library. https://262.ecma-international.org/5.1/#sec-11.9.3

# How

Enable rule more strictly. It is already a part of eslint-config-universe but is configured to `eqeqeq: ['warn', 'smart'],` which is less strict and doesn't match the explicitness of this library.

# Test Plan

`yarn lint`