### PR TITLE
chore: validate conventional commit PR title in GHA

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,4 +1,4 @@
-name: 'Lint PR'
+name: Lint PR
 
 on:
   pull_request_target:


### PR DESCRIPTION
# Why

Since this library uses conventional commits to generate changelogs, we want to validate that the PR title is in a valid conventional commit format.

Closes ENG-15958.

# How

Add lint action.

# Test Plan

This only runs once committed to main so we'll need to commit this and then try it out.

I audited the action code at a glance.