### PR TITLE
chore: Update release instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Note: The entity framework instance should not be shared across multiple request
 
 To release a new version:
 1. `git checkout main`
+1. `npm login` (to refresh token)
 1. `yarn lerna publish [patch|minor|major] -- --conventional-commits  --force-publish`
 1. In GitHub release interface, create a new release from the tag, copy changelog changes to release description.
 


### PR DESCRIPTION
# Why

Added npm login step to the release process to ensure token is fresh before running the process.

# Test Plan

Just ran the process smoothly.
