### PR TITLE
feat: Add AllowIfInParentCascadeDeletionPrivacyPolicyRule

### DIFF
--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -66,6 +66,7 @@ export * from './internal/SingleFieldHolder';
 export * from './metrics/EntityMetricsUtils';
 export * from './metrics/IEntityMetricsAdapter';
 export * from './metrics/NoOpEntityMetricsAdapter';
+export * from './rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule';
 export * from './rules/AlwaysAllowPrivacyPolicyRule';
 export * from './rules/AlwaysDenyPrivacyPolicyRule';
 export * from './rules/AlwaysSkipPrivacyPolicyRule';

--- a/packages/entity/src/rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule.ts
@@ -1,0 +1,177 @@
+import { IEntityClass } from '../Entity';
+import { EntityPrivacyPolicy, EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../EntityQueryContext';
+import { ReadonlyEntity } from '../ReadonlyEntity';
+import { ViewerContext } from '../ViewerContext';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+
+/**
+ * Directive for specifying the parent relationship in AllowIfInParentCascadeDeletionPrivacyPolicyRule.
+ */
+export interface AllowIfInParentCascadeDeletionDirective<
+  TViewerContext extends ViewerContext,
+  TFields,
+  TParentFields extends object,
+  TParentIDField extends keyof NonNullable<Pick<TParentFields, TParentSelectedFields>>,
+  TParentEntity extends ReadonlyEntity<
+    TParentFields,
+    TParentIDField,
+    TViewerContext,
+    TParentSelectedFields
+  >,
+  TParentPrivacyPolicy extends EntityPrivacyPolicy<
+    TParentFields,
+    TParentIDField,
+    TViewerContext,
+    TParentEntity,
+    TParentSelectedFields
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields,
+  TParentSelectedFields extends keyof TParentFields = keyof TParentFields,
+> {
+  /**
+   * Class of parent entity that should trigger a cascade set null update to a field within
+   * the entity being authorized.
+   */
+  parentEntityClass: IEntityClass<
+    TParentFields,
+    TParentIDField,
+    TViewerContext,
+    TParentEntity,
+    TParentPrivacyPolicy,
+    TParentSelectedFields
+  >;
+
+  /**
+   * Field of the current entity with references the deleting instace of parentEntityClass.
+   */
+  fieldIdentifyingParentEntity: keyof Pick<TFields, TSelectedFields>;
+
+  /**
+   * Field in parentEntityClass referenced by the value of fieldIdentifyingParentEntity.
+   * If not provided, ID is assumed.
+   */
+  parentEntityLookupByField?: keyof Pick<TParentFields, TParentSelectedFields>;
+}
+
+/**
+ * A generic privacy policy rule that allows when an entity is being authorized
+ * as part of a cascading delete from a parent entity. Handles two cases:
+ * - When the field has not yet been null'ed out due to a cascading set null. This is often
+ *   required for read rules to authorize the initial re-read of the entity being update set null'ed.
+ * - When the field has been null'ed out due to a cascading set null. This is often required
+ *   the update rules for the field nullification.
+ *
+ * These two cases could theoretically be handled by two separate (stricter) rules, but are combined
+ * to simplify configuration since practically there are few cases where having them be combined would
+ * preset an issue.
+ *
+ * @example
+ * Billing info owned by an account, but records who created the billing info in creating_user_id. User is a member of that account.
+ * User can delete themselves, and the billing info's creating_user_id field is cascade set null'ed when the user is deleted.
+ *
+ * ```ts
+ *  class BillingInfoEntityPrivacyPolicy extends EntityPrivacyPolicy<...> {
+ *    protected override readonly readRules = [
+ *      ...,
+ *      new AllowIfInParentCascadeDeletionPrivacyPolicyRule<...>({
+ *        fieldIdentifyingParentEntity: 'creating_user_id',
+ *        parentEntityClass: UserEntity,
+ *      }),
+ *    ];
+ *
+ *    protected override readonly updateRules = [
+ *      ...,
+ *      new AllowIfInParentCascadeDeletionPrivacyPolicyRule<...>({
+ *        fieldIdentifyingParentEntity: 'creating_user_id',
+ *        parentEntityClass: UserEntity,
+ *      }),
+ *    ];
+ *  }
+ * ```
+ */
+export class AllowIfInParentCascadeDeletionPrivacyPolicyRule<
+  TFields extends object,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TFields2 extends object,
+  TIDField2 extends keyof NonNullable<Pick<TFields2, TSelectedFields2>>,
+  TEntity2 extends ReadonlyEntity<TFields2, TIDField2, TViewerContext, TSelectedFields2>,
+  TPrivacyPolicy2 extends EntityPrivacyPolicy<
+    TFields2,
+    TIDField2,
+    TViewerContext,
+    TEntity2,
+    TSelectedFields2
+  >,
+  TSelectedFields extends keyof TFields = keyof TFields,
+  TSelectedFields2 extends keyof TFields2 = keyof TFields2,
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
+  constructor(
+    private readonly directive: AllowIfInParentCascadeDeletionDirective<
+      TViewerContext,
+      TFields,
+      TFields2,
+      TIDField2,
+      TEntity2,
+      TPrivacyPolicy2,
+      TSelectedFields,
+      TSelectedFields2
+    >,
+  ) {
+    super();
+  }
+
+  async evaluateAsync(
+    _viewerContext: TViewerContext,
+    _queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    entity: TEntity,
+  ): Promise<RuleEvaluationResult> {
+    const parentEntityClass = this.directive.parentEntityClass;
+
+    const deleteCause = evaluationContext.cascadingDeleteCause;
+    if (!deleteCause || !(deleteCause.entity instanceof parentEntityClass)) {
+      return RuleEvaluationResult.SKIP;
+    }
+
+    const entityBeingDeleted = deleteCause.entity;
+
+    // allow if parent foreign key field matches specified field in the entity being authorized
+    const valueInThisEntityReferencingParent = entity.getField(
+      this.directive.fieldIdentifyingParentEntity,
+    );
+    const valueInParent = this.directive.parentEntityLookupByField
+      ? entityBeingDeleted.getField(this.directive.parentEntityLookupByField)
+      : entityBeingDeleted.getID();
+
+    if (
+      valueInThisEntityReferencingParent &&
+      valueInThisEntityReferencingParent === valueInParent
+    ) {
+      return RuleEvaluationResult.ALLOW;
+    }
+
+    // allow if parent foreign key field matches specified field in the entity being authorized, and the
+    // field in the entity being authorized has been null'ed out  due to cascading set null
+    const valueInPreviousValueOfThisEntityReferencingParent =
+      evaluationContext.previousValue?.getField(this.directive.fieldIdentifyingParentEntity);
+
+    if (
+      valueInPreviousValueOfThisEntityReferencingParent &&
+      valueInPreviousValueOfThisEntityReferencingParent === valueInParent &&
+      valueInThisEntityReferencingParent === null
+    ) {
+      return RuleEvaluationResult.ALLOW;
+    }
+
+    return RuleEvaluationResult.SKIP;
+  }
+}

--- a/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
@@ -1,0 +1,258 @@
+import { instance, mock, when } from 'ts-mockito';
+
+import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../EntityQueryContext';
+import { ReadonlyEntity } from '../../ReadonlyEntity';
+import { ViewerContext } from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
+import { AllowIfInParentCascadeDeletionPrivacyPolicyRule } from '../AllowIfInParentCascadeDeletionPrivacyPolicyRule';
+
+// Define test field types
+type ParentFields = {
+  id: string;
+  name: string;
+};
+
+type ChildFields = {
+  id: string;
+  parent_id: string | null;
+  parent_name: string | null;
+};
+
+// Create a mock privacy policy for the parent entity
+class TestParentPrivacyPolicy extends EntityPrivacyPolicy<
+  ParentFields,
+  'id',
+  ViewerContext,
+  TestParentEntity
+> {
+  protected override readonly readRules = [];
+  protected override readonly createRules = [];
+  protected override readonly updateRules = [];
+  protected override readonly deleteRules = [];
+}
+
+// Create a mock parent entity class with required static method
+class TestParentEntity extends ReadonlyEntity<ParentFields, 'id', ViewerContext> {
+  static defineCompanionDefinition(): EntityCompanionDefinition<
+    ParentFields,
+    'id',
+    ViewerContext,
+    TestParentEntity,
+    TestParentPrivacyPolicy
+  > {
+    throw new Error('Not implemented for test');
+  }
+}
+
+// Create a mock child entity class
+class TestChildEntity extends ReadonlyEntity<ChildFields, 'id', ViewerContext> {}
+
+// Mock parent entities
+const parentEntityMock = mock(TestParentEntity);
+when(parentEntityMock.getID()).thenReturn('5');
+const parentEntity = instance(parentEntityMock);
+Object.setPrototypeOf(parentEntity, TestParentEntity.prototype);
+
+const otherParentEntityMock = mock(TestParentEntity);
+when(otherParentEntityMock.getID()).thenReturn('6');
+const otherParentEntity = instance(otherParentEntityMock);
+Object.setPrototypeOf(otherParentEntity, TestParentEntity.prototype);
+
+// Mock a non-parent entity (different class)
+class UnrelatedOtherEntity extends ReadonlyEntity<{ id: string }, 'id', ViewerContext> {}
+const unrelatedOtherEntityMock = mock(UnrelatedOtherEntity);
+Object.setPrototypeOf(unrelatedOtherEntityMock, UnrelatedOtherEntity.prototype);
+
+// Mock child entities
+const childEntityMock = mock(TestChildEntity);
+when(childEntityMock.getField('parent_id')).thenReturn('5');
+
+const childEntityMockWithNullifiedField = mock(TestChildEntity);
+when(childEntityMockWithNullifiedField.getField('parent_id')).thenReturn(null);
+
+const childEntityDifferentParentMock = mock(TestChildEntity);
+when(childEntityDifferentParentMock.getField('parent_id')).thenReturn('6');
+
+describePrivacyPolicyRule(
+  new AllowIfInParentCascadeDeletionPrivacyPolicyRule<
+    ChildFields,
+    'id',
+    ViewerContext,
+    TestChildEntity,
+    ParentFields,
+    'id',
+    TestParentEntity,
+    TestParentPrivacyPolicy
+  >({
+    fieldIdentifyingParentEntity: 'parent_id',
+    parentEntityClass: TestParentEntity,
+  }),
+  {
+    allowCases: [
+      // parent id matches parent being deleted, field not yet nullified
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: instance(childEntityMock),
+          cascadingDeleteCause: {
+            entity: parentEntity,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityMock),
+      },
+      // parent id matches parent being deleted, field null in current version but filled in previous version
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: instance(childEntityMock),
+          cascadingDeleteCause: {
+            entity: parentEntity,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityMockWithNullifiedField),
+      },
+    ],
+    skipCases: [
+      // no cascading delete
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: null,
+          cascadingDeleteCause: null,
+        },
+        entity: instance(childEntityMock),
+      },
+      // cascading delete not from parent entity class
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: null,
+          cascadingDeleteCause: {
+            entity: instance(unrelatedOtherEntityMock),
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityMock),
+      },
+      // cascading delete from different parent, field not nullified
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: null,
+          cascadingDeleteCause: {
+            entity: otherParentEntity,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityMock),
+      },
+      // entity belongs to different parent
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: null,
+          cascadingDeleteCause: {
+            entity: parentEntity,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityDifferentParentMock),
+      },
+      // parent id field undefined (null) and no previous value
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: null,
+          cascadingDeleteCause: {
+            entity: parentEntity,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityMockWithNullifiedField),
+      },
+      // parent id now null but previous value different parent
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: instance(childEntityDifferentParentMock),
+          cascadingDeleteCause: {
+            entity: parentEntity,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityMockWithNullifiedField),
+      },
+    ],
+  },
+);
+
+// Test with custom lookup field (parentEntityLookupByField)
+const parentEntityWithNameMock = mock(TestParentEntity);
+when(parentEntityWithNameMock.getField('name')).thenReturn('test-name');
+const parentEntityWithName = instance(parentEntityWithNameMock);
+Object.setPrototypeOf(parentEntityWithName, TestParentEntity.prototype);
+
+const childEntityWithNameRefMock = mock(TestChildEntity);
+when(childEntityWithNameRefMock.getField('parent_name')).thenReturn('test-name');
+
+const childEntityWithNameRefMockWithNullifiedField = mock(TestChildEntity);
+when(childEntityWithNameRefMockWithNullifiedField.getField('parent_name')).thenReturn(null);
+
+describePrivacyPolicyRule(
+  new AllowIfInParentCascadeDeletionPrivacyPolicyRule<
+    ChildFields,
+    'id',
+    ViewerContext,
+    TestChildEntity,
+    ParentFields,
+    'id',
+    TestParentEntity,
+    TestParentPrivacyPolicy
+  >({
+    fieldIdentifyingParentEntity: 'parent_name',
+    parentEntityClass: TestParentEntity,
+    parentEntityLookupByField: 'name',
+  }),
+  {
+    allowCases: [
+      // parent name matches parent being deleted, field not yet nullified
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: instance(childEntityWithNameRefMock),
+          cascadingDeleteCause: {
+            entity: parentEntityWithName,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityWithNameRefMock),
+      },
+      // parent name matches parent being deleted, field null in current version but filled in previous version
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext: {
+          previousValue: instance(childEntityWithNameRefMock),
+          cascadingDeleteCause: {
+            entity: parentEntityWithName,
+            cascadingDeleteCause: null,
+          },
+        },
+        entity: instance(childEntityWithNameRefMockWithNullifiedField),
+      },
+    ],
+  },
+);


### PR DESCRIPTION
# Why

Found this to be useful in the Expo backend application. The use case is that one may wish to permit access for the mostly-programmatic step of nullification of a field in an entity, whether or not any of the other privacy policy rules in the policy allow.

For example, let's say a user creates a build on organization X. Their user ID may be recorded in a foreign key field on the build so that the application can query all builds for that user. But then the user loses access to organization X. Then, they want to delete their user. This will do a cascade set null on the builds initiated by the user, but the user no longer has permission to update those builds via the normal organization membership permission rules, so this explicit allow-if-cascade-rule is used.

# How

Add a generic rule for use in applications.

# Test Plan

Add test.
