### PR TITLE
feat: add EvaluateIfEntityFieldPredicatePrivacyPolicyRule

### DIFF
--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -70,6 +70,7 @@ export * from './rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule';
 export * from './rules/AlwaysAllowPrivacyPolicyRule';
 export * from './rules/AlwaysDenyPrivacyPolicyRule';
 export * from './rules/AlwaysSkipPrivacyPolicyRule';
+export * from './rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule';
 export * from './rules/PrivacyPolicyRule';
 export * from './utils/EntityCreationUtils';
 export * from './utils/EntityPrivacyUtils';

--- a/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
@@ -1,0 +1,46 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../EntityQueryContext';
+import { ReadonlyEntity } from '../ReadonlyEntity';
+import { ViewerContext } from '../ViewerContext';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+
+export class EvaluateIfEntityFieldPredicatePrivacyPolicyRule<
+  TFields extends object,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  N extends TSelectedFields,
+  TSelectedFields extends keyof TFields = keyof TFields,
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
+  constructor(
+    private readonly fieldName: N,
+    private readonly shouldEvaluatePredicate: (fieldValue: TFields[N]) => boolean,
+    private readonly rule: PrivacyPolicyRule<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+  ) {
+    super();
+  }
+
+  async evaluateAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    entity: TEntity,
+  ): Promise<RuleEvaluationResult> {
+    const fieldValue = entity.getField(this.fieldName);
+    return this.shouldEvaluatePredicate(fieldValue)
+      ? await this.rule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity)
+      : RuleEvaluationResult.SKIP;
+  }
+}

--- a/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
@@ -1,0 +1,47 @@
+import { mock, instance, when } from 'ts-mockito';
+
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../EntityQueryContext';
+import { ViewerContext } from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
+import { TestEntity, TestFields } from '../../utils/__testfixtures__/TestEntity';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
+import { EvaluateIfEntityFieldPredicatePrivacyPolicyRule } from '../EvaluateIfEntityFieldPredicatePrivacyPolicyRule';
+
+const entityBlahMock = mock(TestEntity);
+when(entityBlahMock.getField('testIndexedField')).thenReturn('1');
+const entityBlah = instance(entityBlahMock);
+
+const entityFooMock = mock(TestEntity);
+when(entityFooMock.getField('testIndexedField')).thenReturn('2');
+const entityFoo = instance(entityFooMock);
+
+describePrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity>(
+  new EvaluateIfEntityFieldPredicatePrivacyPolicyRule<
+    TestFields,
+    'customIdField',
+    ViewerContext,
+    TestEntity,
+    'testIndexedField'
+  >('testIndexedField', (val) => val === '1', new AlwaysAllowPrivacyPolicyRule()),
+  {
+    allowCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: entityBlah,
+      },
+    ],
+    skipCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: entityFoo,
+      },
+    ],
+  },
+);


### PR DESCRIPTION
# Why

One other rule we've found useful in the Expo application is a simple predicate rule based on an entity field.

This PR upstreams this rule.

# How

Add rule and test.

# Test Plan

Run test.