### PR TITLE
feat: add AllowIf[Any|All]SubRulesAllowPrivacyPolicyRule rules

### DIFF
--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -66,6 +66,8 @@ export * from './internal/SingleFieldHolder';
 export * from './metrics/EntityMetricsUtils';
 export * from './metrics/IEntityMetricsAdapter';
 export * from './metrics/NoOpEntityMetricsAdapter';
+export * from './rules/AllowIfAllSubRulesAllowPrivacyPolicyRule';
+export * from './rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule';
 export * from './rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule';
 export * from './rules/AlwaysAllowPrivacyPolicyRule';
 export * from './rules/AlwaysDenyPrivacyPolicyRule';

--- a/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
@@ -1,0 +1,47 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../EntityQueryContext';
+import { ReadonlyEntity } from '../ReadonlyEntity';
+import { ViewerContext } from '../ViewerContext';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+
+export class AllowIfAllSubRulesAllowPrivacyPolicyRule<
+  TFields extends object,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields,
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
+  constructor(
+    private readonly subRules: PrivacyPolicyRule<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >[],
+  ) {
+    super();
+  }
+
+  async evaluateAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    entity: TEntity,
+  ): Promise<RuleEvaluationResult> {
+    const results = await Promise.all(
+      this.subRules.map((subRule) =>
+        subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+      ),
+    );
+    return results.every((result) => result === RuleEvaluationResult.ALLOW)
+      ? RuleEvaluationResult.ALLOW
+      : RuleEvaluationResult.SKIP;
+  }
+}

--- a/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
@@ -1,0 +1,47 @@
+import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../EntityQueryContext';
+import { ReadonlyEntity } from '../ReadonlyEntity';
+import { ViewerContext } from '../ViewerContext';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+
+export class AllowIfAnySubRuleAllowsPrivacyPolicyRule<
+  TFields extends object,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields,
+> extends PrivacyPolicyRule<TFields, TIDField, TViewerContext, TEntity, TSelectedFields> {
+  constructor(
+    private readonly subRules: PrivacyPolicyRule<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >[],
+  ) {
+    super();
+  }
+
+  async evaluateAsync(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+    entity: TEntity,
+  ): Promise<RuleEvaluationResult> {
+    const results = await Promise.all(
+      this.subRules.map((subRule) =>
+        subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+      ),
+    );
+    return results.includes(RuleEvaluationResult.ALLOW)
+      ? RuleEvaluationResult.ALLOW
+      : RuleEvaluationResult.SKIP;
+  }
+}

--- a/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
@@ -1,0 +1,64 @@
+import { anything, instance, mock } from 'ts-mockito';
+
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../EntityQueryContext';
+import { ViewerContext } from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
+import { AllowIfAllSubRulesAllowPrivacyPolicyRule } from '../AllowIfAllSubRulesAllowPrivacyPolicyRule';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
+import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule';
+import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule';
+
+describePrivacyPolicyRule(
+  new AllowIfAllSubRulesAllowPrivacyPolicyRule([
+    new AlwaysAllowPrivacyPolicyRule(),
+    new AlwaysSkipPrivacyPolicyRule(),
+  ]),
+  {
+    skipCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: anything(),
+      },
+    ],
+  },
+);
+
+describePrivacyPolicyRule(
+  new AllowIfAllSubRulesAllowPrivacyPolicyRule([
+    new AlwaysAllowPrivacyPolicyRule(),
+    new AlwaysDenyPrivacyPolicyRule(),
+  ]),
+  {
+    skipCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: anything(),
+      },
+    ],
+  },
+);
+
+describePrivacyPolicyRule(
+  new AllowIfAllSubRulesAllowPrivacyPolicyRule([
+    new AlwaysAllowPrivacyPolicyRule(),
+    new AlwaysAllowPrivacyPolicyRule(),
+  ]),
+  {
+    allowCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: anything(),
+      },
+    ],
+  },
+);

--- a/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
@@ -1,0 +1,64 @@
+import { anything, instance, mock } from 'ts-mockito';
+
+import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../EntityQueryContext';
+import { ViewerContext } from '../../ViewerContext';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
+import { AllowIfAnySubRuleAllowsPrivacyPolicyRule } from '../AllowIfAnySubRuleAllowsPrivacyPolicyRule';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
+import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule';
+import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule';
+
+describePrivacyPolicyRule(
+  new AllowIfAnySubRuleAllowsPrivacyPolicyRule([
+    new AlwaysAllowPrivacyPolicyRule(),
+    new AlwaysSkipPrivacyPolicyRule(),
+  ]),
+  {
+    allowCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: anything(),
+      },
+    ],
+  },
+);
+
+describePrivacyPolicyRule(
+  new AllowIfAnySubRuleAllowsPrivacyPolicyRule([
+    new AlwaysAllowPrivacyPolicyRule(),
+    new AlwaysDenyPrivacyPolicyRule(),
+  ]),
+  {
+    allowCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: anything(),
+      },
+    ],
+  },
+);
+
+describePrivacyPolicyRule(
+  new AllowIfAnySubRuleAllowsPrivacyPolicyRule([
+    new AlwaysSkipPrivacyPolicyRule(),
+    new AlwaysSkipPrivacyPolicyRule(),
+  ]),
+  {
+    skipCases: [
+      {
+        viewerContext: instance(mock(ViewerContext)),
+        queryContext: instance(mock(EntityQueryContext)),
+        evaluationContext:
+          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        entity: anything(),
+      },
+    ],
+  },
+);


### PR DESCRIPTION
# Why

One other set of rules we've found useful in the Expo application for expressing complex privacy logic is a boolean any/all rule that composes an array of rules.

This PR upstreams these rules.

# How

Add rules and tests.

# Test Plan

Run tests.