### PR TITLE
fix: Use TSelectedFields for knex loader order by method

### DIFF
--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -75,24 +75,26 @@ export enum OrderByOrdering {
   DESCENDING = 'desc',
 }
 
+export interface PostgresOrderByClause<TFields extends Record<string, any>> {
+  /**
+   * The field name to order by.
+   */
+  fieldName: keyof TFields;
+
+  /**
+   * The OrderByOrdering to order by.
+   */
+  order: OrderByOrdering;
+}
+
 /**
  * SQL modifiers that only affect the selection but not the projection.
  */
-export interface QuerySelectionModifiers<TFields extends Record<string, any>> {
+export interface PostgresQuerySelectionModifiers<TFields extends Record<string, any>> {
   /**
    * Order the entities by specified columns and orders.
    */
-  orderBy?: {
-    /**
-     * The field name to order by.
-     */
-    fieldName: keyof TFields;
-
-    /**
-     * The OrderByOrdering to order by.
-     */
-    order: OrderByOrdering;
-  }[];
+  orderBy?: readonly PostgresOrderByClause<TFields>[];
 
   /**
    * Skip the specified number of entities queried before returning.
@@ -105,18 +107,18 @@ export interface QuerySelectionModifiers<TFields extends Record<string, any>> {
   limit?: number;
 }
 
-export interface QuerySelectionModifiersWithOrderByRaw<
+export interface PostgresQuerySelectionModifiersWithOrderByRaw<
   TFields extends Record<string, any>,
-> extends QuerySelectionModifiers<TFields> {
+> extends PostgresQuerySelectionModifiers<TFields> {
   /**
    * Order the entities by a raw SQL `ORDER BY` clause.
    */
   orderByRaw?: string;
 }
 
-export interface QuerySelectionModifiersWithOrderByFragment<
+export interface PostgresQuerySelectionModifiersWithOrderByFragment<
   TFields extends Record<string, any>,
-> extends QuerySelectionModifiers<TFields> {
+> extends PostgresQuerySelectionModifiers<TFields> {
   /**
    * Order the entities by a SQL fragment `ORDER BY` clause.
    */
@@ -159,7 +161,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
   async fetchManyByFieldEqualityConjunctionAsync<N extends keyof TFields>(
     queryContext: EntityQueryContext,
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
-    querySelectionModifiers: QuerySelectionModifiers<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     const tableFieldSingleValueOperands: TableFieldSingleValueEqualityCondition[] = [];
     const tableFieldMultipleValueOperands: TableFieldMultiValueEqualityCondition[] = [];
@@ -211,7 +213,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
     queryContext: EntityQueryContext,
     rawWhereClause: string,
     bindings: any[] | object,
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByRaw<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByRaw<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     const results = await this.fetchManyByRawWhereClauseInternalAsync(
       queryContext.getQueryInterface(),
@@ -245,7 +247,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
   async fetchManyBySQLFragmentAsync(
     queryContext: EntityQueryContext,
     sqlFragment: SQLFragment,
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByFragment<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByFragment<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     const results = await this.fetchManyBySQLFragmentInternalAsync(
       queryContext.getQueryInterface(),
@@ -267,7 +269,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
   ): Promise<object[]>;
 
   private convertToTableQueryModifiersWithOrderByRaw(
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByRaw<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByRaw<TFields>,
   ): TableQuerySelectionModifiersWithOrderByRaw {
     return {
       ...this.convertToTableQueryModifiers(querySelectionModifiers),
@@ -276,7 +278,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
   }
 
   private convertToTableQueryModifiersWithOrderByFragment(
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByFragment<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByFragment<TFields>,
   ): TableQuerySelectionModifiersWithOrderByFragment {
     return {
       ...this.convertToTableQueryModifiers(querySelectionModifiers),
@@ -285,7 +287,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
   }
 
   private convertToTableQueryModifiers(
-    querySelectionModifiers: QuerySelectionModifiers<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): TableQuerySelectionModifiers {
     const orderBy = querySelectionModifiers.orderBy;
     return {

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -1,12 +1,12 @@
 import { EntityPrivacyPolicy, ReadonlyEntity, ViewerContext } from '@expo/entity';
 
-import { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader';
 import {
-  FieldEqualityCondition,
-  QuerySelectionModifiers,
-  QuerySelectionModifiersWithOrderByFragment,
-  QuerySelectionModifiersWithOrderByRaw,
-} from './BasePostgresEntityDatabaseAdapter';
+  AuthorizationResultBasedKnexEntityLoader,
+  EntityLoaderQuerySelectionModifiers,
+  EntityLoaderQuerySelectionModifiersWithOrderByFragment,
+  EntityLoaderQuerySelectionModifiersWithOrderByRaw,
+} from './AuthorizationResultBasedKnexEntityLoader';
+import { FieldEqualityCondition } from './BasePostgresEntityDatabaseAdapter';
 import { BaseSQLQueryBuilder } from './BaseSQLQueryBuilder';
 import { SQLFragment } from './SQLOperator';
 
@@ -52,8 +52,11 @@ export class EnforcingKnexEntityLoader<
    */
   async loadFirstByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
-    querySelectionModifiers: Omit<QuerySelectionModifiers<TFields>, 'limit'> &
-      Required<Pick<QuerySelectionModifiers<TFields>, 'orderBy'>>,
+    querySelectionModifiers: Omit<
+      EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields>,
+      'limit'
+    > &
+      Required<Pick<EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields>, 'orderBy'>>,
   ): Promise<TEntity | null> {
     const entityResult = await this.knexEntityLoader.loadFirstByFieldEqualityConjunctionAsync(
       fieldEqualityOperands,
@@ -74,7 +77,7 @@ export class EnforcingKnexEntityLoader<
    */
   async loadManyByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
-    querySelectionModifiers: QuerySelectionModifiers<TFields> = {},
+    querySelectionModifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): Promise<readonly TEntity[]> {
     const entityResults = await this.knexEntityLoader.loadManyByFieldEqualityConjunctionAsync(
       fieldEqualityOperands,
@@ -116,7 +119,10 @@ export class EnforcingKnexEntityLoader<
   async loadManyByRawWhereClauseAsync(
     rawWhereClause: string,
     bindings: any[] | object,
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByRaw<TFields> = {},
+    querySelectionModifiers: EntityLoaderQuerySelectionModifiersWithOrderByRaw<
+      TFields,
+      TSelectedFields
+    > = {},
   ): Promise<readonly TEntity[]> {
     const entityResults = await this.knexEntityLoader.loadManyByRawWhereClauseAsync(
       rawWhereClause,
@@ -147,7 +153,10 @@ export class EnforcingKnexEntityLoader<
    */
   loadManyBySQL(
     fragment: SQLFragment,
-    modifiers: QuerySelectionModifiersWithOrderByFragment<TFields> = {},
+    modifiers: EntityLoaderQuerySelectionModifiersWithOrderByFragment<
+      TFields,
+      TSelectedFields
+    > = {},
   ): EnforcingSQLQueryBuilder<
     TFields,
     TIDField,
@@ -177,7 +186,7 @@ export class EnforcingSQLQueryBuilder<
     TSelectedFields
   >,
   TSelectedFields extends keyof TFields,
-> extends BaseSQLQueryBuilder<TFields, TEntity> {
+> extends BaseSQLQueryBuilder<TFields, TSelectedFields, TEntity> {
   constructor(
     private readonly knexEntityLoader: AuthorizationResultBasedKnexEntityLoader<
       TFields,
@@ -188,7 +197,7 @@ export class EnforcingSQLQueryBuilder<
       TSelectedFields
     >,
     sqlFragment: SQLFragment,
-    modifiers: QuerySelectionModifiersWithOrderByFragment<TFields>,
+    modifiers: EntityLoaderQuerySelectionModifiersWithOrderByFragment<TFields, TSelectedFields>,
   ) {
     super(sqlFragment, modifiers);
   }

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -8,9 +8,9 @@ import {
 import {
   BasePostgresEntityDatabaseAdapter,
   FieldEqualityCondition,
-  QuerySelectionModifiers,
-  QuerySelectionModifiersWithOrderByFragment,
-  QuerySelectionModifiersWithOrderByRaw,
+  PostgresQuerySelectionModifiers,
+  PostgresQuerySelectionModifiersWithOrderByFragment,
+  PostgresQuerySelectionModifiersWithOrderByRaw,
 } from '../BasePostgresEntityDatabaseAdapter';
 import { SQLFragment } from '../SQLOperator';
 
@@ -42,7 +42,7 @@ export class EntityKnexDataManager<
   async loadManyByFieldEqualityConjunctionAsync<N extends keyof TFields>(
     queryContext: EntityQueryContext,
     fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
-    querySelectionModifiers: QuerySelectionModifiers<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     return await timeAndLogLoadEventAsync(
       this.metricsAdapter,
@@ -71,7 +71,7 @@ export class EntityKnexDataManager<
     queryContext: EntityQueryContext,
     rawWhereClause: string,
     bindings: any[] | object,
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByRaw<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByRaw<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     return await timeAndLogLoadEventAsync(
       this.metricsAdapter,
@@ -91,7 +91,7 @@ export class EntityKnexDataManager<
   async loadManyBySQLFragmentAsync(
     queryContext: EntityQueryContext,
     sqlFragment: SQLFragment,
-    querySelectionModifiers: QuerySelectionModifiersWithOrderByFragment<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByFragment<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     return await timeAndLogLoadEventAsync(
       this.metricsAdapter,


### PR DESCRIPTION
# Why

Noticed while creating an upcoming pagination PR that loaders should use `TSelectedFields` for `orderBy` clauses. This was an accidental omission when the selected fields concept was added.

Succinctly, one should only be able to order entities by their fields rather than by all their underlying table's fields.

# How

Create new orderBy clause type that lives at the loader level. It is fully compatible (subset or equal to) the database orderBy clause, so calling the data manager methods directly with the arguments is by design.

# Test Plan

`yarn tsc`