### PR TITLE
fix: Type idField in EntityConfiguration as TIDField

### DIFF
--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -67,7 +67,9 @@ export class CompositeFieldInfo<
           keyDefinition.compositeField.length === new Set(keyDefinition.compositeField).size,
           'Composite field must have unique sub-fields',
         );
-        const compositeFieldHolder = new CompositeFieldHolder(keyDefinition.compositeField);
+        const compositeFieldHolder = new CompositeFieldHolder<TFields, TIDField>(
+          keyDefinition.compositeField,
+        );
         return [
           compositeFieldHolder.serialize(),
           { compositeFieldHolder, cache: keyDefinition.cache ?? false },
@@ -79,8 +81,9 @@ export class CompositeFieldInfo<
   public getCompositeFieldHolderForCompositeField(
     compositeField: EntityCompositeField<TFields>,
   ): CompositeFieldHolder<TFields, TIDField> | undefined {
-    return this.compositeFieldInfoMap.get(new CompositeFieldHolder(compositeField).serialize())
-      ?.compositeFieldHolder;
+    return this.compositeFieldInfoMap.get(
+      new CompositeFieldHolder<TFields, TIDField>(compositeField).serialize(),
+    )?.compositeFieldHolder;
   }
 
   public getAllCompositeFieldHolders(): readonly CompositeFieldHolder<TFields, TIDField>[] {
@@ -89,7 +92,7 @@ export class CompositeFieldInfo<
 
   public canCacheCompositeField(compositeField: EntityCompositeField<TFields>): boolean {
     const compositeFieldInfo = this.compositeFieldInfoMap.get(
-      new CompositeFieldHolder(compositeField).serialize(),
+      new CompositeFieldHolder<TFields, TIDField>(compositeField).serialize(),
     );
     invariant(
       compositeFieldInfo,
@@ -107,7 +110,7 @@ export class EntityConfiguration<
   TFields extends Record<string, any>,
   TIDField extends keyof TFields,
 > {
-  readonly idField: keyof TFields;
+  readonly idField: TIDField;
   readonly tableName: string;
   readonly cacheableKeys: ReadonlySet<keyof TFields>;
   readonly compositeFieldInfo: CompositeFieldInfo<TFields, TIDField>;

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -506,11 +506,14 @@ describe(AuthorizationResultBasedEntityLoader, () => {
             new SingleFieldValueHolder<TestFields, 'dateField'>(date),
           ],
           [
-            new CompositeFieldHolder(['stringField', 'intField']),
+            new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
             new CompositeFieldValueHolder({ stringField: 'huh', intField: 5 }),
           ],
           [
-            new CompositeFieldHolder(['stringField', 'testIndexedField']),
+            new CompositeFieldHolder<TestFields, 'customIdField'>([
+              'stringField',
+              'testIndexedField',
+            ]),
             new CompositeFieldValueHolder({ stringField: 'huh', testIndexedField: 'h1' }),
           ],
         ]),
@@ -605,11 +608,14 @@ describe(AuthorizationResultBasedEntityLoader, () => {
             new SingleFieldValueHolder<TestFields, 'dateField'>(date),
           ],
           [
-            new CompositeFieldHolder(['stringField', 'intField']),
+            new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
             new CompositeFieldValueHolder({ stringField: 'huh', intField: 5 }),
           ],
           [
-            new CompositeFieldHolder(['stringField', 'testIndexedField']),
+            new CompositeFieldHolder<TestFields, 'customIdField'>([
+              'stringField',
+              'testIndexedField',
+            ]),
             new CompositeFieldValueHolder({ stringField: 'huh', testIndexedField: 'h1' }),
           ],
         ]),
@@ -708,11 +714,14 @@ describe(AuthorizationResultBasedEntityLoader, () => {
               new SingleFieldValueHolder<TestFields, 'dateField'>(date),
             ],
             [
-              new CompositeFieldHolder(['stringField', 'intField']),
+              new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
               new CompositeFieldValueHolder({ stringField: 'huh', intField: 5 }),
             ],
             [
-              new CompositeFieldHolder(['stringField', 'testIndexedField']),
+              new CompositeFieldHolder<TestFields, 'customIdField'>([
+                'stringField',
+                'testIndexedField',
+              ]),
               new CompositeFieldValueHolder({ stringField: 'huh', testIndexedField: 'h1' }),
             ],
           ]),

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -46,8 +46,8 @@ describe(EntityConfiguration, () => {
       expect(blahEntityConfiguration.databaseAdapterFlavor).toEqual('postgres');
       expect(blahEntityConfiguration.cacheAdapterFlavor).toEqual('redis');
       expect(blahEntityConfiguration.compositeFieldInfo.getAllCompositeFieldHolders()).toEqual([
-        new CompositeFieldHolder(['id', 'cacheable']),
-        new CompositeFieldHolder(['id', 'uniqueButNotCacheable']),
+        new CompositeFieldHolder<BlahT, 'id'>(['id', 'cacheable']),
+        new CompositeFieldHolder<BlahT, 'id'>(['id', 'uniqueButNotCacheable']),
       ]);
     });
 

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -87,7 +87,7 @@ describe(EntityDatabaseAdapter, () => {
       const adapter = new TestEntityDatabaseAdapter({ fetchResults: [{ string_field: 'hello' }] });
       const result = await adapter.fetchManyWhereAsync(
         queryContext,
-        new SingleFieldHolder('stringField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
         [new SingleFieldValueHolder('hello')],
       );
       expect(result.get(new SingleFieldValueHolder('hello'))).toEqual([{ stringField: 'hello' }]);
@@ -100,7 +100,7 @@ describe(EntityDatabaseAdapter, () => {
       });
       const result = await adapter.fetchManyWhereAsync(
         queryContext,
-        new SingleFieldHolder('stringField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
         [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('wat')],
       );
       expect(result.get(new SingleFieldValueHolder('hello'))).toEqual([{ stringField: 'hello' }]);
@@ -140,7 +140,7 @@ describe(EntityDatabaseAdapter, () => {
       const adapter = new TestEntityDatabaseAdapter({});
       const result = await adapter.fetchManyWhereAsync(
         queryContext,
-        new SingleFieldHolder('stringField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
         [new SingleFieldValueHolder('what'), new SingleFieldValueHolder('who')],
       );
       expect(Array.from(result.keys()).map((v) => v.fieldValue)).toEqual(['what', 'who']);
@@ -152,9 +152,11 @@ describe(EntityDatabaseAdapter, () => {
         fetchResults: [{ string_field: null }],
       });
       await expect(
-        adapter.fetchManyWhereAsync(queryContext, new SingleFieldHolder('stringField'), [
-          new SingleFieldValueHolder('hello'),
-        ]),
+        adapter.fetchManyWhereAsync(
+          queryContext,
+          new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
+          [new SingleFieldValueHolder('hello')],
+        ),
       ).rejects.toThrow(
         'One or more fields from the object is invalid for key SingleField(stringField); {"stringField":null}. This may indicate a faulty database adapter implementation.',
       );
@@ -166,9 +168,11 @@ describe(EntityDatabaseAdapter, () => {
         fetchResults: [{ string_field: undefined }],
       });
       await expect(
-        adapter.fetchManyWhereAsync(queryContext, new SingleFieldHolder('stringField'), [
-          new SingleFieldValueHolder('hello'),
-        ]),
+        adapter.fetchManyWhereAsync(
+          queryContext,
+          new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
+          [new SingleFieldValueHolder('hello')],
+        ),
       ).rejects.toThrow(
         'One or more fields from the object is invalid for key SingleField(stringField); {}. This may indicate a faulty database adapter implementation.',
       );

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -772,7 +772,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         'id'
       >;
       const childCachedBefore = await childCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<ChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(parent.getID())],
       );
       expect(childCachedBefore.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
@@ -783,9 +783,9 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         GrandChildEntity,
       )['entityCompanion']['tableDataCoordinator'][
         'cacheAdapter'
-      ] as InMemoryFullCacheStubCacheAdapter<ChildFields, 'id'>;
+      ] as InMemoryFullCacheStubCacheAdapter<GrandChildFields, 'id'>;
       const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<GrandChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(child.getID())],
       );
       expect(grandChildCachedBefore.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
@@ -797,7 +797,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       const childCachedAfter = await childCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<ChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(parent.getID())],
       );
       expect(childCachedAfter.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
@@ -805,7 +805,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       );
 
       const grandChildCachedAfter = await grandChildCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<GrandChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(child.getID())],
       );
       expect(grandChildCachedAfter.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
@@ -922,7 +922,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         'id'
       >;
       const childCachedBefore = await childCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<ChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(parent.getID())],
       );
       expect(childCachedBefore.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
@@ -933,9 +933,9 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
         GrandChildEntity,
       )['entityCompanion']['tableDataCoordinator'][
         'cacheAdapter'
-      ] as InMemoryFullCacheStubCacheAdapter<ChildFields, 'id'>;
+      ] as InMemoryFullCacheStubCacheAdapter<GrandChildFields, 'id'>;
       const grandChildCachedBefore = await grandChildCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<GrandChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(child.getID())],
       );
       expect(grandChildCachedBefore.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(
@@ -947,7 +947,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       privacyPolicyEvaluationRecords.shouldRecord = false;
 
       const childCachedAfter = await childCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<ChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(parent.getID())],
       );
       expect(childCachedAfter.get(new SingleFieldValueHolder(parent.getID()))?.status).toEqual(
@@ -955,7 +955,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       );
 
       const grandChildCachedAfter = await grandChildCacheAdapter.loadManyAsync(
-        new SingleFieldHolder('parent_id'),
+        new SingleFieldHolder<GrandChildFields, 'id', 'parent_id'>('parent_id'),
         [new SingleFieldValueHolder(child.getID())],
       );
       expect(grandChildCachedAfter.get(new SingleFieldValueHolder(child.getID()))?.status).toEqual(

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -376,10 +376,10 @@ const createEntityMutatorFactory = (
 
     installExtensions: () => {},
 
-    getDatabaseAdapter<TFields extends Record<'customIdField', any>>(
-      _entityConfiguration: EntityConfiguration<TFields, 'customIdField'>,
-    ): EntityDatabaseAdapter<TFields, 'customIdField'> {
-      return databaseAdapter as any as EntityDatabaseAdapter<TFields, 'customIdField'>;
+    getDatabaseAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(
+      _entityConfiguration: EntityConfiguration<TFields, TIDField>,
+    ): EntityDatabaseAdapter<TFields, TIDField> {
+      return databaseAdapter as any as EntityDatabaseAdapter<TFields, TIDField>;
     },
   };
   const metricsAdapter = new NoOpEntityMetricsAdapter();

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -250,7 +250,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
       'cacheAdapter'
     ] as InMemoryFullCacheStubCacheAdapter<CategoryFields, 'id'>;
     const subCategoryCachedBefore = await categoryCacheAdapter.loadManyAsync(
-      new SingleFieldHolder('parent_category_id'),
+      new SingleFieldHolder<CategoryFields, 'id', 'parent_category_id'>('parent_category_id'),
       [new SingleFieldValueHolder(parentCategory.getID())],
     );
     expect(
@@ -258,7 +258,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     ).toEqual(CacheStatus.HIT);
 
     const subSubCategoryCachedBefore = await categoryCacheAdapter.loadManyAsync(
-      new SingleFieldHolder('parent_category_id'),
+      new SingleFieldHolder<CategoryFields, 'id', 'parent_category_id'>('parent_category_id'),
       [new SingleFieldValueHolder(subCategory.getID())],
     );
     expect(
@@ -268,7 +268,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     await CategoryEntity.deleter(parentCategory).deleteAsync();
 
     const subCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync(
-      new SingleFieldHolder('parent_category_id'),
+      new SingleFieldHolder<CategoryFields, 'id', 'parent_category_id'>('parent_category_id'),
       [new SingleFieldValueHolder(parentCategory.getID())],
     );
     expect(
@@ -276,7 +276,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     ).toEqual(CacheStatus.MISS);
 
     const subSubCategoryCachedAfter = await categoryCacheAdapter.loadManyAsync(
-      new SingleFieldHolder('parent_category_id'),
+      new SingleFieldHolder<CategoryFields, 'id', 'parent_category_id'>('parent_category_id'),
       [new SingleFieldValueHolder(subCategory.getID())],
     );
     expect(
@@ -329,7 +329,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
       'cacheAdapter'
     ] as InMemoryFullCacheStubCacheAdapter<CategoryFields, 'id'>;
     const categoriesCachedBefore = await categoryCacheAdapter.loadManyAsync(
-      new SingleFieldHolder('parent_category_id'),
+      new SingleFieldHolder<CategoryFields, 'id', 'parent_category_id'>('parent_category_id'),
       [
         new SingleFieldValueHolder(categoryA.getID()),
         new SingleFieldValueHolder(categoryB.getID()),
@@ -345,7 +345,7 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     await CategoryEntity.deleter(categoryA).deleteAsync();
 
     const categoriesCachedAfter = await categoryCacheAdapter.loadManyAsync(
-      new SingleFieldHolder('parent_category_id'),
+      new SingleFieldHolder<CategoryFields, 'id', 'parent_category_id'>('parent_category_id'),
       [
         new SingleFieldValueHolder(categoryA.getID()),
         new SingleFieldValueHolder(categoryB.getID()),

--- a/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
@@ -22,7 +22,7 @@ describe(GenericEntityCacheAdapter, () => {
       const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           anything(),
         ),
       ).thenCall((fieldHolder, fieldValueHolder) => {
@@ -38,11 +38,14 @@ describe(GenericEntityCacheAdapter, () => {
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
 
-      const results = await cacheAdapter.loadManyAsync(new SingleFieldHolder('id'), [
-        new SingleFieldValueHolder('wat'),
-        new SingleFieldValueHolder('who'),
-        new SingleFieldValueHolder('why'),
-      ]);
+      const results = await cacheAdapter.loadManyAsync(
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
+        [
+          new SingleFieldValueHolder('wat'),
+          new SingleFieldValueHolder('who'),
+          new SingleFieldValueHolder('why'),
+        ],
+      );
       expect(results.get(new SingleFieldValueHolder('wat'))).toMatchObject({
         status: CacheStatus.HIT,
         item: { id: 'wat' },
@@ -74,7 +77,7 @@ describe(GenericEntityCacheAdapter, () => {
       const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           anything(),
         ),
       ).thenCall((fieldHolder, fieldValueHolder) => {
@@ -85,7 +88,7 @@ describe(GenericEntityCacheAdapter, () => {
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
       await expect(
-        cacheAdapter.loadManyAsync(new SingleFieldHolder('id'), [
+        cacheAdapter.loadManyAsync(new SingleFieldHolder<BlahFields, 'id', 'id'>('id'), [
           new SingleFieldValueHolder('wat'),
         ]),
       ).rejects.toThrow(expectedError);
@@ -99,7 +102,7 @@ describe(GenericEntityCacheAdapter, () => {
       const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           anything(),
         ),
       ).thenCall((fieldHolder, fieldValueHolder) => {
@@ -108,7 +111,7 @@ describe(GenericEntityCacheAdapter, () => {
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
       await cacheAdapter.cacheManyAsync(
-        new SingleFieldHolder('id'),
+        new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
         new Map([[new SingleFieldValueHolder('wat'), { id: 'wat' }]]),
       );
 
@@ -123,7 +126,7 @@ describe(GenericEntityCacheAdapter, () => {
       const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeyForStorage(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           anything(),
         ),
       ).thenCall((fieldHolder, fieldValueHolder) => {
@@ -131,7 +134,7 @@ describe(GenericEntityCacheAdapter, () => {
       });
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
-      await cacheAdapter.cacheDBMissesAsync(new SingleFieldHolder('id'), [
+      await cacheAdapter.cacheDBMissesAsync(new SingleFieldHolder<BlahFields, 'id', 'id'>('id'), [
         new SingleFieldValueHolder('wat'),
       ]);
 
@@ -144,7 +147,7 @@ describe(GenericEntityCacheAdapter, () => {
       const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeysForInvalidation(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           anything(),
         ),
       ).thenCall((fieldHolder, fieldValueHolder) => {
@@ -152,7 +155,7 @@ describe(GenericEntityCacheAdapter, () => {
       });
 
       const cacheAdapter = new GenericEntityCacheAdapter(instance(mockGenericCacher));
-      await cacheAdapter.invalidateManyAsync(new SingleFieldHolder('id'), [
+      await cacheAdapter.invalidateManyAsync(new SingleFieldHolder<BlahFields, 'id', 'id'>('id'), [
         new SingleFieldValueHolder('wat'),
       ]);
 
@@ -163,7 +166,7 @@ describe(GenericEntityCacheAdapter, () => {
       const mockGenericCacher = mock<IEntityGenericCacher<BlahFields, 'id'>>();
       when(
         mockGenericCacher.makeCacheKeysForInvalidation(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           anything(),
         ),
       ).thenCall((fieldHolder, fieldValueHolder) => {

--- a/packages/entity/src/internal/__tests__/CompositeFieldHolder-test.ts
+++ b/packages/entity/src/internal/__tests__/CompositeFieldHolder-test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from '@jest/globals';
 
 import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder';
 
+type TestFields = {
+  id: string;
+  field1: string;
+  field2: string;
+};
+
 describe(CompositeFieldHolder, () => {
   it('is order-agnostic for serialization', () => {
-    const compositeFieldHolder = new CompositeFieldHolder(['field1', 'field2']);
-    const compositeFieldHolder2 = new CompositeFieldHolder(['field2', 'field1']);
+    const compositeFieldHolder = new CompositeFieldHolder<TestFields, 'id'>(['field1', 'field2']);
+    const compositeFieldHolder2 = new CompositeFieldHolder<TestFields, 'id'>(['field2', 'field1']);
 
     expect(compositeFieldHolder.serialize()).toEqual(compositeFieldHolder2.serialize());
   });

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -96,7 +96,7 @@ describe(EntityDataManager, () => {
 
     const entityDatas = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('customIdField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
       [new SingleFieldValueHolder('2')],
     );
     expect(entityDatas.get(new SingleFieldValueHolder('2'))).toHaveLength(1);
@@ -108,7 +108,7 @@ describe(EntityDataManager, () => {
 
     const entityDatas2 = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder('unique2'), new SingleFieldValueHolder('unique3')],
     );
     expect(entityDatas2.get(new SingleFieldValueHolder('unique2'))).toHaveLength(1);
@@ -147,7 +147,7 @@ describe(EntityDataManager, () => {
 
     const entityDatas = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('customIdField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
       [new SingleFieldValueHolder('1')],
     );
     expect(entityDatas.get(new SingleFieldValueHolder('1'))).toHaveLength(1);
@@ -159,7 +159,7 @@ describe(EntityDataManager, () => {
 
     const entityDatas2 = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder('unique2'), new SingleFieldValueHolder('unique3')],
     );
     expect(entityDatas2.get(new SingleFieldValueHolder('unique2'))).toHaveLength(1);
@@ -206,12 +206,12 @@ describe(EntityDataManager, () => {
 
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder('unique2')],
     );
     await entityDataManager2.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder('unique2')],
     );
 
@@ -249,12 +249,12 @@ describe(EntityDataManager, () => {
 
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder('unique2')],
     );
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder('unique2')],
     );
 
@@ -292,12 +292,12 @@ describe(EntityDataManager, () => {
 
     const entityData = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('stringField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
       [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
     );
     const entityData2 = await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('stringField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
       [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
     );
 
@@ -341,12 +341,12 @@ describe(EntityDataManager, () => {
         const [entityData, entityData2] = await Promise.all([
           entityDataManager.loadManyEqualingAsync(
             queryContext,
-            new SingleFieldHolder('stringField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
             [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
           ),
           entityDataManager.loadManyEqualingAsync(
             queryContext,
-            new SingleFieldHolder('stringField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
             [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
           ),
         ]);
@@ -354,7 +354,7 @@ describe(EntityDataManager, () => {
           async (innerQueryContext) => {
             const entityData3 = await entityDataManager.loadManyEqualingAsync(
               innerQueryContext,
-              new SingleFieldHolder('stringField'),
+              new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
               [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
             );
 
@@ -362,7 +362,7 @@ describe(EntityDataManager, () => {
               async (innerInnerQueryContext) => {
                 return await entityDataManager.loadManyEqualingAsync(
                   innerInnerQueryContext,
-                  new SingleFieldHolder('stringField'),
+                  new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
                   [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
                 );
               },
@@ -417,19 +417,19 @@ describe(EntityDataManager, () => {
       await new StubQueryContextProvider().runInTransactionAsync(async (queryContext) => {
         const entityData = await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('stringField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
           [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
         );
         const entityData2 = await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('stringField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
           [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
         );
         const [entityData3, entityData4] = await queryContext.runInNestedTransactionAsync(
           async (innerQueryContext) => {
             const entityData3 = await entityDataManager.loadManyEqualingAsync(
               innerQueryContext,
-              new SingleFieldHolder('stringField'),
+              new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
               [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
             );
 
@@ -437,7 +437,7 @@ describe(EntityDataManager, () => {
               async (innerInnerQueryContext) => {
                 return await entityDataManager.loadManyEqualingAsync(
                   innerInnerQueryContext,
-                  new SingleFieldHolder('stringField'),
+                  new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
                   [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
                 );
               },
@@ -493,19 +493,19 @@ describe(EntityDataManager, () => {
         async (queryContext) => {
           const entityData = await entityDataManager.loadManyEqualingAsync(
             queryContext,
-            new SingleFieldHolder('stringField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
             [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
           );
           const entityData2 = await entityDataManager.loadManyEqualingAsync(
             queryContext,
-            new SingleFieldHolder('stringField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
             [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
           );
           const [entityData3, entityData4] = await queryContext.runInNestedTransactionAsync(
             async (innerQueryContext) => {
               const entityData3 = await entityDataManager.loadManyEqualingAsync(
                 innerQueryContext,
-                new SingleFieldHolder('stringField'),
+                new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>('stringField'),
                 [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
               );
 
@@ -513,7 +513,9 @@ describe(EntityDataManager, () => {
                 async (innerInnerQueryContext) => {
                   return await entityDataManager.loadManyEqualingAsync(
                     innerInnerQueryContext,
-                    new SingleFieldHolder('stringField'),
+                    new SingleFieldHolder<TestFields, 'customIdField', 'stringField'>(
+                      'stringField',
+                    ),
                     [new SingleFieldValueHolder('hello'), new SingleFieldValueHolder('world')],
                   );
                 },
@@ -572,18 +574,18 @@ describe(EntityDataManager, () => {
 
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
     );
     await entityDataManager.invalidateKeyValuePairsAsync([
       [
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
       ],
     ]);
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
     );
 
@@ -623,18 +625,18 @@ describe(EntityDataManager, () => {
 
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('testIndexedField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
       [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
     );
     await entityDataManager.invalidateKeyValuePairsAsync([
       [
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
       ],
     ]);
     await entityDataManager.loadManyEqualingAsync(
       queryContext,
-      new SingleFieldHolder('customIdField'),
+      new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
       [new SingleFieldValueHolder(objectInQuestion['customIdField'])],
     );
 
@@ -674,18 +676,20 @@ describe(EntityDataManager, () => {
 
       await entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
       );
       entityDataManager.invalidateKeyValuePairsForTransaction(queryContext, [
         [
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
         ],
       ]);
       await entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
       );
 
@@ -698,18 +702,24 @@ describe(EntityDataManager, () => {
       await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
         await entityDataManager.loadManyEqualingAsync(
           innerQueryContext,
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
         );
         entityDataManager.invalidateKeyValuePairsForTransaction(innerQueryContext, [
           [
-            new SingleFieldHolder('testIndexedField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+              'testIndexedField',
+            ),
             new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
           ],
         ]);
         await entityDataManager.loadManyEqualingAsync(
           innerQueryContext,
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
         );
 
@@ -752,18 +762,24 @@ describe(EntityDataManager, () => {
 
         await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
         );
         entityDataManager.invalidateKeyValuePairsForTransaction(queryContext, [
           [
-            new SingleFieldHolder('testIndexedField'),
+            new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+              'testIndexedField',
+            ),
             new SingleFieldValueHolder(objectInQuestion['testIndexedField']),
           ],
         ]);
         await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           [new SingleFieldValueHolder(objectInQuestion['testIndexedField'])],
         );
 
@@ -807,7 +823,7 @@ describe(EntityDataManager, () => {
       async (queryContext) => {
         return await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('customIdField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
           [new SingleFieldValueHolder('1')],
         );
       },
@@ -845,7 +861,7 @@ describe(EntityDataManager, () => {
     await expect(
       entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('customIdField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
         [new SingleFieldValueHolder('2')],
       ),
     ).rejects.toThrow();
@@ -881,7 +897,7 @@ describe(EntityDataManager, () => {
       // for dataloader, cache, and database
       await entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         [new SingleFieldValueHolder('unique1')],
       );
       verify(
@@ -936,7 +952,7 @@ describe(EntityDataManager, () => {
       // entity is in local dataloader
       await entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         [new SingleFieldValueHolder('unique1')],
       );
       verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).once();
@@ -966,7 +982,7 @@ describe(EntityDataManager, () => {
       );
       await entityDataManager2.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('testIndexedField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>('testIndexedField'),
         [new SingleFieldValueHolder('unique1'), new SingleFieldValueHolder('unique2')],
       );
       verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).thrice();
@@ -1034,7 +1050,9 @@ describe(EntityDataManager, () => {
         // for dataloader, cache, and database
         await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           [new SingleFieldValueHolder('unique1')],
         );
         verify(
@@ -1078,7 +1096,9 @@ describe(EntityDataManager, () => {
         // entity is in local dataloader
         await entityDataManager.loadManyEqualingAsync(
           queryContext,
-          new SingleFieldHolder('testIndexedField'),
+          new SingleFieldHolder<TestFields, 'customIdField', 'testIndexedField'>(
+            'testIndexedField',
+          ),
           [new SingleFieldValueHolder('unique1')],
         );
         verify(metricsAdapterMock.incrementDataManagerLoadCount(anything())).once();
@@ -1122,7 +1142,7 @@ describe(EntityDataManager, () => {
     await expect(
       entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('nullableField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'nullableField'>('nullableField'),
         [new SingleFieldValueHolder(null as any)],
       ),
     ).rejects.toThrow('Invalid load: TestEntity (nullableField = null)');
@@ -1130,7 +1150,7 @@ describe(EntityDataManager, () => {
     await expect(
       entityDataManager.loadManyEqualingAsync(
         queryContext,
-        new SingleFieldHolder('nullableField'),
+        new SingleFieldHolder<TestFields, 'customIdField', 'nullableField'>('nullableField'),
         [new SingleFieldValueHolder(undefined as any)],
       ),
     ).rejects.toThrow('Invalid load: TestEntity (nullableField = undefined)');

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -76,7 +76,7 @@ describe(ReadThroughEntityCache, () => {
 
       when(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -102,7 +102,7 @@ describe(ReadThroughEntityCache, () => {
 
       verify(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -111,7 +111,7 @@ describe(ReadThroughEntityCache, () => {
       ).once();
       verify(
         cacheAdapterMock.cacheManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware(
             new SingleFieldValueHolderMap(
               new Map([
@@ -146,7 +146,7 @@ describe(ReadThroughEntityCache, () => {
 
       when(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -170,7 +170,7 @@ describe(ReadThroughEntityCache, () => {
 
       verify(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -179,7 +179,7 @@ describe(ReadThroughEntityCache, () => {
       ).once();
       verify(
         cacheAdapterMock.cacheManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware(
             new SingleFieldValueHolderMap(
               new Map([
@@ -216,7 +216,7 @@ describe(ReadThroughEntityCache, () => {
 
       when(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('why')]),
         ),
       ).thenResolve(
@@ -233,19 +233,19 @@ describe(ReadThroughEntityCache, () => {
 
       verify(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('why')]),
         ),
       ).once();
       verify(
         cacheAdapterMock.cacheManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware(new SingleFieldValueHolderMap(new Map())),
         ),
       ).once();
       verify(
         cacheAdapterMock.cacheDBMissesAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('why')]),
         ),
       ).once();
@@ -260,7 +260,7 @@ describe(ReadThroughEntityCache, () => {
 
       when(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('why')]),
         ),
       ).thenResolve(
@@ -276,12 +276,22 @@ describe(ReadThroughEntityCache, () => {
       );
       verify(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('why')]),
         ),
       ).once();
-      verify(cacheAdapterMock.cacheManyAsync(new SingleFieldHolder('id'), anything())).never();
-      verify(cacheAdapterMock.cacheDBMissesAsync(new SingleFieldHolder('id'), anything())).never();
+      verify(
+        cacheAdapterMock.cacheManyAsync(
+          new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
+          anything(),
+        ),
+      ).never();
+      verify(
+        cacheAdapterMock.cacheDBMissesAsync(
+          new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
+          anything(),
+        ),
+      ).never();
       expect(result).toEqual(new SingleFieldValueHolderMap(new Map()));
     });
 
@@ -293,7 +303,7 @@ describe(ReadThroughEntityCache, () => {
 
       when(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -324,7 +334,7 @@ describe(ReadThroughEntityCache, () => {
       );
       verify(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -335,7 +345,7 @@ describe(ReadThroughEntityCache, () => {
       ).once();
       verify(
         cacheAdapterMock.cacheManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware(
             new SingleFieldValueHolderMap(
               new Map([[new SingleFieldValueHolder('wat'), { id: 'wat' }]]),
@@ -345,7 +355,7 @@ describe(ReadThroughEntityCache, () => {
       ).once();
       verify(
         cacheAdapterMock.cacheDBMissesAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('how')]),
         ),
       ).once();
@@ -372,7 +382,12 @@ describe(ReadThroughEntityCache, () => {
         [new SingleFieldValueHolder<BlahFields, 'id'>('wat')],
         fetcher,
       );
-      verify(cacheAdapterMock.loadManyAsync(new SingleFieldHolder('id'), anything())).never();
+      verify(
+        cacheAdapterMock.loadManyAsync(
+          new SingleFieldHolder<BlahFields, 'id', 'id'>('id'),
+          anything(),
+        ),
+      ).never();
       expect(result).toEqual(
         new SingleFieldValueHolderMap(
           new Map([[new SingleFieldValueHolder('wat'), [{ id: 'wat' }]]]),
@@ -390,7 +405,7 @@ describe(ReadThroughEntityCache, () => {
 
       when(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -416,7 +431,7 @@ describe(ReadThroughEntityCache, () => {
 
       verify(
         cacheAdapterMock.loadManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([
             new SingleFieldValueHolder('wat'),
             new SingleFieldValueHolder('who'),
@@ -425,7 +440,7 @@ describe(ReadThroughEntityCache, () => {
       ).once();
       verify(
         cacheAdapterMock.cacheManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware(
             new Map([
               [new SingleFieldValueHolder('wat'), { id: 'wat' }],
@@ -456,12 +471,12 @@ describe(ReadThroughEntityCache, () => {
       const cacheAdapterMock = mock<IEntityCacheAdapter<BlahFields, 'id'>>();
       const cacheAdapter = instance(cacheAdapterMock);
       const entityCache = new ReadThroughEntityCache(makeEntityConfiguration(true), cacheAdapter);
-      await entityCache.invalidateManyAsync(new SingleFieldHolder('id'), [
+      await entityCache.invalidateManyAsync(new SingleFieldHolder<BlahFields, 'id', 'id'>('id'), [
         new SingleFieldValueHolder('wat'),
       ]);
       verify(
         cacheAdapterMock.invalidateManyAsync(
-          deepEqualEntityAware(new SingleFieldHolder('id')),
+          deepEqualEntityAware(new SingleFieldHolder<BlahFields, 'id', 'id'>('id')),
           deepEqualEntityAware([new SingleFieldValueHolder('wat')]),
         ),
       ).once();


### PR DESCRIPTION
# Why

Noticed this was mis-typed in a later PR, hoisted into this one.

# How

Update type of EntityConfiguration.idField to be `TIDField`, which is the most correct and precise type for the field. This will help later on when adding pagination ID field stuff.

The other changes to tests are fixes since these previously were underspecified and changing the field type exposed these missing types. (claude informed me of this)

# Test Plan

`yarn tsc`