### PR TITLE
fix: move EntityPrivacyUtils back into core package

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -89,6 +89,21 @@ export class StubPostgresDatabaseAdapter<
     return [...results];
   }
 
+  protected async fetchOneWhereInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableColumns: readonly string[],
+    tableTuple: readonly any[],
+  ): Promise<object | null> {
+    const results = await this.fetchManyWhereInternalAsync(
+      queryInterface,
+      tableName,
+      tableColumns,
+      [tableTuple],
+    );
+    return results[0] ?? null;
+  }
+
   private static compareByOrderBys(
     orderBys: {
       columnName: string;

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -181,6 +181,108 @@ describe(StubPostgresDatabaseAdapter, () => {
     });
   });
 
+  describe('fetchOneWhereAsync', () => {
+    it('fetches one where single', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubPostgresDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 5,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'world',
+                  testIndexedField: 'h2',
+                  intField: 3,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const result = await databaseAdapter.fetchOneWhereAsync(
+        queryContext,
+        new SingleFieldHolder('stringField'),
+        new SingleFieldValueHolder('huh'),
+      );
+      expect(result).toMatchObject({
+        stringField: 'huh',
+      });
+    });
+
+    it('returns null when no record found', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        new Map(),
+      );
+
+      const result = await databaseAdapter.fetchOneWhereAsync(
+        queryContext,
+        new SingleFieldHolder('stringField'),
+        new SingleFieldValueHolder('huh'),
+      );
+      expect(result).toBeNull();
+    });
+
+    it('fetches one where composite', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubPostgresDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 5,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'world',
+                  testIndexedField: 'h2',
+                  intField: 5,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const result = await databaseAdapter.fetchOneWhereAsync(
+        queryContext,
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
+        new CompositeFieldValueHolder({ stringField: 'huh', intField: 5 }),
+      );
+      expect(result).toMatchObject({
+        stringField: 'huh',
+        intField: 5,
+      });
+    });
+  });
+
   describe('fetchManyByFieldEqualityConjunctionAsync', () => {
     it('supports conjuntions and query modifiers', async () => {
       const queryContext = instance(mock(EntityQueryContext));

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -87,6 +87,25 @@ export class PostgresEntityDatabaseAdapter<
     );
   }
 
+  protected async fetchOneWhereInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    tableColumns: readonly string[],
+    tableTuple: readonly any[],
+  ): Promise<object | null> {
+    const results = await this.fetchManyByFieldEqualityConjunctionInternalAsync(
+      queryInterface,
+      tableName,
+      tableColumns.map((column, index) => ({
+        tableField: column,
+        tableValue: tableTuple[index],
+      })),
+      [],
+      { limit: 1, orderBy: undefined, offset: undefined },
+    );
+    return results[0] ?? null;
+  }
+
   private applyQueryModifiersToQueryOrderByRaw(
     query: Knex.QueryBuilder,
     querySelectionModifiers: TableQuerySelectionModifiersWithOrderByRaw,

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -306,6 +306,42 @@ describe('postgres entity integration', () => {
     });
   });
 
+  describe('single field value loading (fetchOneWhereInternalAsync)', () => {
+    it('supports one loading', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'hello')
+          .setField('hasACat', false)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'world')
+          .setField('hasACat', false)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'wat')
+          .setField('hasACat', false)
+          .setField('hasADog', false)
+          .createAsync(),
+      );
+
+      const result = await PostgresTestEntity.loaderWithAuthorizationResults(vc1)[
+        'loadOneByFieldEqualingAsync'
+      ]('hasACat', false);
+      expect(result?.enforceValue()).not.toBeNull();
+      expect(result?.enforceValue().getField('hasACat')).toBe(false);
+    });
+  });
+
   it('supports single field and composite field equality loading', async () => {
     const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 

--- a/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
@@ -14,6 +14,7 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
   'customIdField'
 > {
   private readonly fetchResults: object[];
+  private readonly fetchOneResult: object | null;
   private readonly insertResults: object[];
   private readonly updateResults: object[];
   private readonly fetchEqualityConditionResults: object[];
@@ -23,6 +24,7 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
 
   constructor({
     fetchResults = [],
+    fetchOneResult = null,
     insertResults = [],
     updateResults = [],
     fetchEqualityConditionResults = [],
@@ -31,6 +33,7 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
     deleteCount = 0,
   }: {
     fetchResults?: object[];
+    fetchOneResult?: object | null;
     insertResults?: object[];
     updateResults?: object[];
     fetchEqualityConditionResults?: object[];
@@ -40,6 +43,7 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
   }) {
     super(testEntityConfiguration);
     this.fetchResults = fetchResults;
+    this.fetchOneResult = fetchOneResult;
     this.insertResults = insertResults;
     this.updateResults = updateResults;
     this.fetchEqualityConditionResults = fetchEqualityConditionResults;
@@ -59,6 +63,15 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
     _tableTuples: (readonly any[])[],
   ): Promise<object[]> {
     return this.fetchResults;
+  }
+
+  protected async fetchOneWhereInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _tableColumns: readonly string[],
+    _tableTuple: readonly any[],
+  ): Promise<object | null> {
+    return this.fetchOneResult;
   }
 
   protected async fetchManyByRawWhereClauseInternalAsync(

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -90,6 +90,21 @@ export class StubPostgresDatabaseAdapter<
     return [...results];
   }
 
+  protected async fetchOneWhereInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableColumns: readonly string[],
+    tableTuple: readonly any[],
+  ): Promise<object | null> {
+    const results = await this.fetchManyWhereInternalAsync(
+      queryInterface,
+      tableName,
+      tableColumns,
+      [tableTuple],
+    );
+    return results[0] ?? null;
+  }
+
   private static compareByOrderBys(
     orderBys: {
       columnName: string;

--- a/packages/entity-database-adapter-knex/src/index.ts
+++ b/packages/entity-database-adapter-knex/src/index.ts
@@ -22,4 +22,3 @@ export * from './extensions/EntityTableDataCoordinatorExtensions';
 export * from './extensions/ReadonlyEntityExtensions';
 export * from './extensions/ViewerScopedEntityCompanionExtensions';
 export * from './internal/EntityKnexDataManager';
-export * from './utils/EntityPrivacyUtils';

--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -55,6 +55,21 @@ class InMemoryDatabaseAdapter<
     return [...results];
   }
 
+  protected override async fetchOneWhereInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableColumns: readonly string[],
+    tableTuple: readonly any[],
+  ): Promise<object | null> {
+    const results = await this.fetchManyWhereInternalAsync(
+      queryInterface,
+      tableName,
+      tableColumns,
+      [tableTuple],
+    );
+    return results[0] ?? null;
+  }
+
   protected async insertInternalAsync(
     _queryInterface: any,
     _tableName: string,

--- a/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
@@ -79,6 +79,21 @@ export class StubDatabaseAdapter<
     return [...results];
   }
 
+  protected async fetchOneWhereInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableColumns: readonly string[],
+    tableTuple: readonly any[],
+  ): Promise<object | null> {
+    const results = await this.fetchManyWhereInternalAsync(
+      queryInterface,
+      tableName,
+      tableColumns,
+      [tableTuple],
+    );
+    return results[0] ?? null;
+  }
+
   private generateRandomID(): any {
     const idSchemaField = this.entityConfiguration2.schema.get(this.entityConfiguration2.idField);
     invariant(

--- a/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
@@ -124,6 +124,108 @@ describe(StubDatabaseAdapter, () => {
     });
   });
 
+  describe('fetchOneWhereAsync', () => {
+    it('fetches one where single', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 5,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'world',
+                  testIndexedField: 'h2',
+                  intField: 3,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const result = await databaseAdapter.fetchOneWhereAsync(
+        queryContext,
+        new SingleFieldHolder('stringField'),
+        new SingleFieldValueHolder('huh'),
+      );
+      expect(result).toMatchObject({
+        stringField: 'huh',
+      });
+    });
+
+    it('returns null when no record found', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        new Map(),
+      );
+
+      const result = await databaseAdapter.fetchOneWhereAsync(
+        queryContext,
+        new SingleFieldHolder('stringField'),
+        new SingleFieldValueHolder('huh'),
+      );
+      expect(result).toBeNull();
+    });
+
+    it('fetches one where composite', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 5,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'world',
+                  testIndexedField: 'h2',
+                  intField: 5,
+                  stringField: 'huh',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const result = await databaseAdapter.fetchOneWhereAsync(
+        queryContext,
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'intField']),
+        new CompositeFieldValueHolder({ stringField: 'huh', intField: 5 }),
+      );
+      expect(result).toMatchObject({
+        stringField: 'huh',
+        intField: 5,
+      });
+    });
+  });
+
   describe('insertAsync', () => {
     it('inserts a record', async () => {
       const queryContext = instance(mock(EntityQueryContext));

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -447,6 +447,8 @@ describe(EnforcingEntityLoader, () => {
 
     // ensure known differences still exist for sanity check
     const knownLoaderOnlyDifferences = [
+      'loadOneByFieldEqualingAsync', // private method used in EntityPrivacyUtils that is not intended to be part of the public API of AuthorizationResultBasedEntityLoader, and has no equivalent in EnforcingEntityLoader
+      'validateFieldAndValueAndConvertToHolders',
       'validateFieldAndValuesAndConvertToHolders',
       'validateCompositeFieldAndValuesAndConvertToHolders',
       'constructAndAuthorizeEntitiesFromCompositeFieldValueHolderMapAsync',

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -17,23 +17,27 @@ import { TestFields, testEntityConfiguration } from '../utils/__testfixtures__/T
 
 class TestEntityDatabaseAdapter extends EntityDatabaseAdapter<TestFields, 'customIdField'> {
   private readonly fetchResults: object[];
+  private readonly fetchOneResult: object | null;
   private readonly insertResults: object[];
   private readonly updateResults: object[];
   private readonly deleteCount: number;
 
   constructor({
     fetchResults = [],
+    fetchOneResult = null,
     insertResults = [],
     updateResults = [],
     deleteCount = 0,
   }: {
     fetchResults?: object[];
+    fetchOneResult?: object | null;
     insertResults?: object[];
     updateResults?: object[];
     deleteCount?: number;
   }) {
     super(testEntityConfiguration);
     this.fetchResults = fetchResults;
+    this.fetchOneResult = fetchOneResult;
     this.insertResults = insertResults;
     this.updateResults = updateResults;
     this.deleteCount = deleteCount;
@@ -50,6 +54,15 @@ class TestEntityDatabaseAdapter extends EntityDatabaseAdapter<TestFields, 'custo
     _tableTuples: (readonly any[])[],
   ): Promise<object[]> {
     return this.fetchResults;
+  }
+
+  protected async fetchOneWhereInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _tableColumns: readonly string[],
+    _tableTuple: readonly any[],
+  ): Promise<object | null> {
+    return this.fetchOneResult;
   }
 
   protected async insertInternalAsync(

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -76,6 +76,7 @@ export * from './rules/AlwaysSkipPrivacyPolicyRule';
 export * from './rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule';
 export * from './rules/PrivacyPolicyRule';
 export * from './utils/EntityCreationUtils';
+export * from './utils/EntityPrivacyUtils';
 export * from './utils/mergeEntityMutationTriggerConfigurations';
 export * from './utils/collections/maps';
 export * from './utils/collections/SerializableKeyMap';

--- a/packages/entity/src/metrics/EntityMetricsUtils.ts
+++ b/packages/entity/src/metrics/EntityMetricsUtils.ts
@@ -30,6 +30,29 @@ export const timeAndLogLoadEventAsync =
     return result;
   };
 
+export const timeAndLogLoadOneEventAsync =
+  (
+    metricsAdapter: IEntityMetricsAdapter,
+    loadType: EntityMetricsLoadType,
+    entityClassName: string,
+    queryContext: EntityQueryContext,
+  ) =>
+  async <TFields>(promise: Promise<Readonly<TFields> | null>) => {
+    const startTime = Date.now();
+    const result = await promise;
+    const endTime = Date.now();
+
+    metricsAdapter.logDataManagerLoadEvent({
+      type: loadType,
+      isInTransaction: queryContext.isInTransaction(),
+      entityClassName,
+      duration: endTime - startTime,
+      count: result ? 1 : 0,
+    });
+
+    return result;
+  };
+
 export const timeAndLogLoadMapEventAsync =
   (
     metricsAdapter: IEntityMetricsAdapter,

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -9,6 +9,7 @@ export enum EntityMetricsLoadType {
   LOAD_MANY_EQUALITY_CONJUNCTION,
   LOAD_MANY_RAW,
   LOAD_MANY_SQL,
+  LOAD_ONE,
 }
 
 /**

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -78,6 +78,21 @@ export class StubDatabaseAdapter<
     return [...results];
   }
 
+  protected async fetchOneWhereInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableColumns: readonly string[],
+    tableTuple: readonly any[],
+  ): Promise<object | null> {
+    const results = await this.fetchManyWhereInternalAsync(
+      queryInterface,
+      tableName,
+      tableColumns,
+      [tableTuple],
+    );
+    return results[0] ?? null;
+  }
+
   private generateRandomID(): any {
     const idSchemaField = this.entityConfiguration2.schema.get(this.entityConfiguration2.idField);
     invariant(

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -1,23 +1,22 @@
-import {
-  Entity,
-  EntityCompanionDefinition,
-  EntityConfiguration,
-  EntityEdgeDeletionBehavior,
-  UUIDField,
-  EntityAuthorizationAction,
-  EntityPrivacyPolicy,
-  EntityPrivacyPolicyEvaluationContext,
-  EntityQueryContext,
-  ReadonlyEntity,
-  ViewerContext,
-  AlwaysAllowPrivacyPolicyRule,
-  AlwaysDenyPrivacyPolicyRule,
-  RuleEvaluationResult,
-} from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 import nullthrows from 'nullthrows';
 
-import { createUnitTestPostgresEntityCompanionProvider } from '../../__tests__/fixtures/createUnitTestPostgresEntityCompanionProvider';
+import { Entity } from '../../Entity';
+import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
+import { EntityConfiguration } from '../../EntityConfiguration';
+import { EntityEdgeDeletionBehavior } from '../../EntityFieldDefinition';
+import { UUIDField } from '../../EntityFields';
+import {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicy,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../../EntityPrivacyPolicy';
+import { EntityQueryContext } from '../../EntityQueryContext';
+import { ReadonlyEntity } from '../../ReadonlyEntity';
+import { ViewerContext } from '../../ViewerContext';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { AlwaysDenyPrivacyPolicyRule } from '../../rules/AlwaysDenyPrivacyPolicyRule';
+import { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule';
 import {
   canViewerDeleteAsync,
   canViewerUpdateAsync,
@@ -26,6 +25,7 @@ import {
   getCanViewerDeleteResultAsync,
   getCanViewerUpdateResultAsync,
 } from '../EntityPrivacyUtils';
+import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider';
 
 function assertEntityPrivacyEvaluationResultFailure(
   evaluationResult: EntityPrivacyEvaluationResult,
@@ -50,7 +50,7 @@ function expectAuthorizationError(
 
 describe(canViewerUpdateAsync, () => {
   it('appropriately executes update privacy policy', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext).createAsync();
     const canViewerUpdate = await canViewerUpdateAsync(SimpleTestDenyDeleteEntity, testEntity);
@@ -63,7 +63,7 @@ describe(canViewerUpdateAsync, () => {
   });
 
   it('denies when policy denies', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     const canViewerUpdate = await canViewerUpdateAsync(SimpleTestDenyUpdateEntity, testEntity);
@@ -79,7 +79,7 @@ describe(canViewerUpdateAsync, () => {
   });
 
   it('rethrows non-authorization errors', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext).createAsync();
     await expect(canViewerUpdateAsync(SimpleTestThrowOtherErrorEntity, testEntity)).rejects.toThrow(
@@ -93,7 +93,7 @@ describe(canViewerUpdateAsync, () => {
 
 describe(canViewerDeleteAsync, () => {
   it('appropriately executes update privacy policy', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyUpdateEntity, testEntity);
@@ -106,7 +106,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('denies when policy denies', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyDeleteEntity.creator(viewerContext).createAsync();
     const canViewerDelete = await canViewerDeleteAsync(SimpleTestDenyDeleteEntity, testEntity);
@@ -122,7 +122,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('denies when recursive policy denies for CASCADE_DELETE', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     // add another entity referencing testEntity that would cascade deletion to itself when testEntity is deleted
@@ -142,7 +142,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('denies when recursive policy denies for SET_NULL', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     // add another entity referencing testEntity that would set null to its column when testEntity is deleted
@@ -162,7 +162,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('allows when recursive policy allows for CASCADE_DELETE and SET_NULL', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     // add another entity referencing testEntity that would cascade deletion to itself when testEntity is deleted
@@ -184,7 +184,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('rethrows non-authorization errors', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestThrowOtherErrorEntity.creator(viewerContext).createAsync();
     await expect(canViewerDeleteAsync(SimpleTestThrowOtherErrorEntity, testEntity)).rejects.toThrow(
@@ -196,7 +196,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('returns false when edge cannot be read', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     const leafEntity = await LeafDenyReadEntity.creator(viewerContext)
@@ -215,7 +215,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('rethrows non-authorization edge read errors', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await SimpleTestDenyUpdateEntity.creator(viewerContext).createAsync();
     await SimpleTestThrowOtherErrorEntity.creator(viewerContext)
@@ -230,7 +230,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('supports running within a transaction', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const canViewerDelete = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
       'postgres',
@@ -270,7 +270,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('evaluates privacy policy with synthetically nullified field for SET_NULL', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await ParentEntity.creator(viewerContext).createAsync();
 
@@ -289,7 +289,7 @@ describe(canViewerDeleteAsync, () => {
   });
 
   it('denies deletion when privacy policy fails with synthetically nullified field for SET_NULL', async () => {
-    const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+    const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
     const testEntity = await ParentEntity.creator(viewerContext).createAsync();
 

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -1,25 +1,25 @@
-import {
-  Entity,
-  EntityCompanionDefinition,
-  EntityConfiguration,
-  EntityEdgeDeletionAuthorizationInferenceBehavior,
-  EntityEdgeDeletionBehavior,
-  UUIDField,
-  EntityPrivacyPolicy,
-  ReadonlyEntity,
-  ViewerContext,
-  AlwaysAllowPrivacyPolicyRule,
-  AlwaysDenyPrivacyPolicyRule,
-} from '@expo/entity';
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { createUnitTestPostgresEntityCompanionProvider } from '../../__tests__/fixtures/createUnitTestPostgresEntityCompanionProvider';
+import { Entity } from '../../Entity';
+import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
+import { EntityConfiguration } from '../../EntityConfiguration';
+import {
+  EntityEdgeDeletionAuthorizationInferenceBehavior,
+  EntityEdgeDeletionBehavior,
+} from '../../EntityFieldDefinition';
+import { UUIDField } from '../../EntityFields';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
+import { ReadonlyEntity } from '../../ReadonlyEntity';
+import { ViewerContext } from '../../ViewerContext';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { AlwaysDenyPrivacyPolicyRule } from '../../rules/AlwaysDenyPrivacyPolicyRule';
 import { canViewerDeleteAsync } from '../EntityPrivacyUtils';
+import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider';
 
 describe(canViewerDeleteAsync, () => {
   describe('edgeDeletionPermissionInferenceBehavior', () => {
     it('optimizes when EntityEdgeDeletionPermissionInferenceBehavior.ONE_IMPLIES_ALL', async () => {
-      const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+      const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
 
       // create root
@@ -61,7 +61,7 @@ describe(canViewerDeleteAsync, () => {
     });
 
     it('does not optimize when undefined', async () => {
-      const companionProvider = createUnitTestPostgresEntityCompanionProvider();
+      const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
 
       // create root


### PR DESCRIPTION
# Why

As discussed on #407, this moves EntityPrivacyUtils back to the core package since it's a core concept.

# How

Move the files, then...

It required adding a new loader method, `loadOneByFieldEqualingAsync`, which loads one of a set of entities for use with the `EntityEdgeDeletionAuthorizationInferenceBehavior.ONE_IMPLIES_ALL` deletion permission check optimization.

It is unlikely that this method will be used too frequently in application code so I marked it as `@internal`, but it is still in the types same as every other method.

# Test Plan

Full coverage and tests for the EntityPrivacyUtils/canViewerDelete.