### PR TITLE
feat: add includeTotal option to pagination

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -298,4 +298,21 @@ export class StubPostgresDatabaseAdapter<
     objectCollection.splice(objectIndex, 1);
     return 1;
   }
+
+  protected async fetchCountBySQLFragmentInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: any,
+  ): Promise<number> {
+    throw new Error('SQL fragments not supported for StubDatabaseAdapter');
+  }
+
+  protected async fetchManyBySQLFragmentWithCountInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: SQLFragment,
+    _querySelectionModifiers: TableQuerySelectionModifiersWithOrderByFragment,
+  ): Promise<{ results: object[]; totalCount: number }> {
+    throw new Error('SQL fragments not supported for StubDatabaseAdapter');
+  }
 }

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -520,6 +520,32 @@ describe(StubPostgresDatabaseAdapter, () => {
     });
   });
 
+  describe('fetchCountBySQLFragmentAsync', () => {
+    it('throws because it is unsupported', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        new Map(),
+      );
+      await expect(
+        databaseAdapter.fetchCountBySQLFragmentAsync(queryContext, sql``),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('fetchManyBySQLFragmentWithCountAsync', () => {
+    it('throws because it is unsupported', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        new Map(),
+      );
+      await expect(
+        databaseAdapter.fetchManyBySQLFragmentWithCountAsync(queryContext, sql``, {}),
+      ).rejects.toThrow();
+    });
+  });
+
   describe('insertAsync', () => {
     it('inserts a record', async () => {
       const queryContext = instance(mock(EntityQueryContext));

--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -92,6 +92,17 @@ interface EntityLoaderBasePaginationArgs<
    * Order the entities by specified columns and orders. If the ID field is not included in the orderBy, it will be automatically included as the last orderBy field to ensure stable pagination.
    */
   orderBy?: EntityLoaderOrderByClause<TFields, TSelectedFields>[];
+
+  /**
+   * Whether to calculate and include the Connection totalCount field containing the total count of entities matching the where SQLFragment.
+   *
+   * Note that this may be an expensive operation, especially for large datasets, as it may require an additional SQL query with a COUNT(*) aggregation.
+   * It is recommended to only set this to true when necessary for the client application, such as when implementing pagination UIs that need to know the total number of pages.
+   *
+   * When true and cursor is non-null, the total count is calculated by running a separate COUNT(*) query with the same WHERE clause.
+   * When true and cursor is null, the total count is calculated by running the main query with a window function to count all matching rows, which is slightly faster but still expensive.
+   */
+  includeTotal?: boolean;
 }
 
 /**
@@ -304,6 +315,7 @@ export class AuthorizationResultBasedKnexEntityLoader<
     return {
       edges,
       pageInfo,
+      ...(pageResult.totalCount !== undefined && { totalCount: pageResult.totalCount }),
     };
   }
 }

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -238,6 +238,7 @@ export class EnforcingKnexEntityLoader<
     return {
       edges,
       pageInfo: pageResult.pageInfo,
+      ...(pageResult.totalCount !== undefined && { totalCount: pageResult.totalCount }),
     };
   }
 }

--- a/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
@@ -126,6 +126,23 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
   ): Promise<number> {
     return this.deleteCount;
   }
+
+  protected async fetchCountBySQLFragmentInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: any,
+  ): Promise<number> {
+    return 0;
+  }
+
+  protected async fetchManyBySQLFragmentWithCountInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: any,
+    _querySelectionModifiers: any,
+  ): Promise<{ results: object[]; totalCount: number }> {
+    return { results: this.fetchSQLFragmentResults, totalCount: 0 };
+  }
 }
 
 describe(BasePostgresEntityDatabaseAdapter, () => {

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -299,4 +299,21 @@ export class StubPostgresDatabaseAdapter<
     objectCollection.splice(objectIndex, 1);
     return 1;
   }
+
+  protected async fetchCountBySQLFragmentInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: any,
+  ): Promise<number> {
+    throw new Error('SQL fragments not supported for StubDatabaseAdapter');
+  }
+
+  protected async fetchManyBySQLFragmentWithCountInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: SQLFragment,
+    _querySelectionModifiers: TableQuerySelectionModifiersWithOrderByFragment,
+  ): Promise<{ results: object[]; totalCount: number }> {
+    throw new Error('SQL fragments not supported for StubDatabaseAdapter');
+  }
 }

--- a/packages/entity/src/metrics/EntityMetricsUtils.ts
+++ b/packages/entity/src/metrics/EntityMetricsUtils.ts
@@ -30,6 +30,30 @@ export const timeAndLogLoadEventAsync =
     return result;
   };
 
+export const timeAndLogLoadEventGenericAsync =
+  <T>(
+    metricsAdapter: IEntityMetricsAdapter,
+    loadType: EntityMetricsLoadType,
+    entityClassName: string,
+    queryContext: EntityQueryContext,
+    countExtractor: (result: T) => number,
+  ) =>
+  async (promise: Promise<T>) => {
+    const startTime = Date.now();
+    const result = await promise;
+    const endTime = Date.now();
+
+    metricsAdapter.logDataManagerLoadEvent({
+      type: loadType,
+      isInTransaction: queryContext.isInTransaction(),
+      entityClassName,
+      duration: endTime - startTime,
+      count: countExtractor(result),
+    });
+
+    return result;
+  };
+
 export const timeAndLogLoadOneEventAsync =
   (
     metricsAdapter: IEntityMetricsAdapter,

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -11,6 +11,8 @@ export enum EntityMetricsLoadType {
   LOAD_MANY_SQL,
   LOAD_ONE,
   LOAD_PAGE,
+  LOAD_PAGE_AND_TOTAL_COUNT,
+  LOAD_TOTAL_COUNT,
 }
 
 /**

--- a/packages/entity/src/metrics/__tests__/EntityMetricsUtils-test.ts
+++ b/packages/entity/src/metrics/__tests__/EntityMetricsUtils-test.ts
@@ -4,6 +4,8 @@ import { anyNumber, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import {
   timeAndLogLoadEventAsync,
+  timeAndLogLoadOneEventAsync,
+  timeAndLogLoadEventGenericAsync,
   timeAndLogLoadMapEventAsync,
   timeAndLogMutationEventAsync,
 } from '../EntityMetricsUtils';
@@ -41,6 +43,105 @@ describe(timeAndLogLoadEventAsync, () => {
           entityClassName: 'TestEntity',
           duration: anyNumber(),
           count: expectedResult.length,
+        }),
+      ),
+    ).once();
+  });
+});
+
+describe(timeAndLogLoadOneEventAsync, () => {
+  it('returns the result from the wrapped promise and logs with count 1 when result is not null', async () => {
+    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+    const metricsAdapter = instance(metricsAdapterMock);
+
+    const queryContextMock = mock<EntityQueryContext>();
+    when(queryContextMock.isInTransaction()).thenReturn(true);
+    const queryContext = instance(queryContextMock);
+
+    const expectedResult = { id: 1 };
+
+    const result = await timeAndLogLoadOneEventAsync(
+      metricsAdapter,
+      EntityMetricsLoadType.LOAD_ONE,
+      'TestEntity',
+      queryContext,
+    )(Promise.resolve(expectedResult));
+
+    expect(result).toBe(expectedResult);
+
+    verify(
+      metricsAdapterMock.logDataManagerLoadEvent(
+        deepEqual({
+          type: EntityMetricsLoadType.LOAD_ONE,
+          isInTransaction: true,
+          entityClassName: 'TestEntity',
+          duration: anyNumber(),
+          count: 1,
+        }),
+      ),
+    ).once();
+  });
+
+  it('logs with count 0 when result is null', async () => {
+    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+    const metricsAdapter = instance(metricsAdapterMock);
+
+    const queryContextMock = mock<EntityQueryContext>();
+    when(queryContextMock.isInTransaction()).thenReturn(true);
+    const queryContext = instance(queryContextMock);
+
+    const result = await timeAndLogLoadOneEventAsync(
+      metricsAdapter,
+      EntityMetricsLoadType.LOAD_ONE,
+      'TestEntity',
+      queryContext,
+    )(Promise.resolve(null));
+
+    expect(result).toBeNull();
+
+    verify(
+      metricsAdapterMock.logDataManagerLoadEvent(
+        deepEqual({
+          type: EntityMetricsLoadType.LOAD_ONE,
+          isInTransaction: true,
+          entityClassName: 'TestEntity',
+          duration: anyNumber(),
+          count: 0,
+        }),
+      ),
+    ).once();
+  });
+});
+
+describe(timeAndLogLoadEventGenericAsync, () => {
+  it('returns the result from the wrapped promise and logs with count extracted from result', async () => {
+    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+    const metricsAdapter = instance(metricsAdapterMock);
+
+    const queryContextMock = mock<EntityQueryContext>();
+    when(queryContextMock.isInTransaction()).thenReturn(false);
+    const queryContext = instance(queryContextMock);
+
+    const expectedResult = { items: [{ id: 1 }, { id: 2 }, { id: 3 }] };
+
+    const result = await timeAndLogLoadEventGenericAsync<{ items: { id: number }[] }>(
+      metricsAdapter,
+      EntityMetricsLoadType.LOAD_PAGE,
+      'TestEntity',
+      queryContext,
+      (r) => r.items.length,
+    )(Promise.resolve(expectedResult));
+
+    expect(result).toBe(expectedResult);
+
+    verify(
+      metricsAdapterMock.logDataManagerLoadEvent(
+        deepEqual({
+          type: EntityMetricsLoadType.LOAD_PAGE,
+          isInTransaction: false,
+          entityClassName: 'TestEntity',
+          duration: anyNumber(),
+          count: expectedResult.items.length,
         }),
       ),
     ).once();


### PR DESCRIPTION
# Why

A frequent operation that is needed during pagination is computation of the total number of pages. Some relay-style paginators (connections, edges) expose a `totalCount` field on the Connection type.

This PR adds this feature. Note that I'm not a strong proponent for this, but claude is and it wouldn't stop trying to implement it or suggest it in code review throughout this process. So we built it, but I'm open to not landing it if we think it'll be abused (query on every page, for example). Claude and my research seem to think that it makes sense and is aligned with other libraries like apollo.

# How

See docblock for `includeTotal` for summary, but at a high level this does either a postgres window function or a `count(*)` to get the count. Window functions are more efficient since the postgres execution can fetch that information in the same query, but they only work when cursors are not used (otherwise the window function would apply over the rows selected by the cursor condition).

# Test Plan

Full test coverage, many tests.