### PR TITLE
feat: Add ilike and trigram similarity search to pagination

### DIFF
--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -191,37 +191,14 @@ export class EnforcingKnexEntityLoader<
   /**
    * Load a page of entities with Relay-style cursor pagination.
    *
-   * @param args - Pagination arguments with either first/after or last/before
-   *
-   * @example
-   * ```typescript
-   * // Forward pagination - get first 10 items
-   * const users = await TestEntity.knexLoader(vc)
-   *   .loadPageBySQLAsync({
-   *     first: 10,
-   *     where: sql`age > ${18}`,
-   *     orderBy: 'created_at'
-   *   });
-   *
-   * // Backward pagination with cursor - get last 10 items before the cursor
-   * const lastResults = await TestEntity.knexLoader(vc)
-   *   .loadPageBySQLAsync({
-   *     last: 10,
-   *     where: sql`status = ${'active'}`,
-   *     before: cursor,
-   *   });
-   * ```
-   *
+   * @param args - Pagination arguments with pagination and either first/after or last/before
+   * @returns a page of entities matching the pagination arguments
    * @throws EntityNotAuthorizedError if viewer is not authorized to view any returned entity
    */
-  async loadPageBySQLAsync(
+  async loadPageAsync(
     args: EntityLoaderLoadPageArgs<TFields, TSelectedFields>,
   ): Promise<Connection<TEntity>> {
-    const pageResult = await this.knexDataManager.loadPageBySQLFragmentAsync(
-      this.queryContext,
-      args,
-    );
-
+    const pageResult = await this.knexDataManager.loadPageAsync(this.queryContext, args);
     const edges = await Promise.all(
       pageResult.edges.map(async (edge) => {
         const entityResult = await this.constructionUtils.constructAndAuthorizeEntityAsync(

--- a/packages/entity-database-adapter-knex/src/PaginationStrategy.ts
+++ b/packages/entity-database-adapter-knex/src/PaginationStrategy.ts
@@ -1,0 +1,32 @@
+/**
+ * Search strategy for SQL-based pagination.
+ */
+export enum PaginationStrategy {
+  /**
+   * Standard pagination with ORDER BY. Results are ordered by the specified orderBy fields, with ID field automatically included for stable pagination if not already present.
+   */
+  STANDARD = 'standard',
+
+  /**
+   * Case-insensitive pattern matching search using SQL ILIKE operator.
+   * Results are ordered by the fields being searched within in the order specified, then by ID for tie-breaking and stable pagination.
+   */
+  ILIKE_SEARCH = 'ilike-search',
+
+  /**
+   * Similarity search using PostgreSQL trigram similarity. Results are ordered by exact match priority, then by similarity score, then by specified extra order by fields if provided, then by ID for tie-breaking and stable pagination.
+   *
+   * Performance considerations:
+   * - Trigram search can be significantly slower than ILIKE search, especially on large datasets without appropriate indexes.
+   * - Consider using ILIKE search for smaller datasets or when exact substring matching is sufficient
+   * - For larger datasets, ensure proper indexing or consider dedicated full-text search solutions.
+   * - For optimal performance, create GIN or GIST indexes on searchable columns:
+   * ```sql
+   *   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+   *   CREATE INDEX idx_table_field_trigram ON table_name USING gin(field_name gin_trgm_ops);
+   *   -- Or for multiple columns:
+   *   CREATE INDEX idx_table_search ON table_name USING gin((field1 || ' ' || field2) gin_trgm_ops);
+   * ```
+   */
+  TRIGRAM_SEARCH = 'trigram',
+}

--- a/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
@@ -31,6 +31,7 @@ type PostgresTestEntityFields = {
   maybeJsonArrayField: string[] | { hello: string } | null;
   bigintField: string | null;
   binaryField: Buffer | null;
+  createdAt: Date;
 };
 
 export class PostgresTestEntity extends Entity<PostgresTestEntityFields, 'id', ViewerContext> {
@@ -64,6 +65,7 @@ export class PostgresTestEntity extends Entity<PostgresTestEntityFields, 'id', V
         table.jsonb('maybe_json_array_field');
         table.bigint('bigint_field');
         table.binary('binary_field');
+        table.dateTime('created_at', { useTz: true }).defaultTo(knex.fn.now());
       });
     }
     await knex.into(tableName).truncate();
@@ -158,6 +160,9 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<
     }),
     binaryField: new BufferField({
       columnName: 'binary_field',
+    }),
+    createdAt: new DateField({
+      columnName: 'created_at',
     }),
   },
   databaseAdapterFlavor: 'postgres',

--- a/packages/entity-database-adapter-knex/src/__tests__/AuthorizationResultBasedKnexEntityLoader-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/AuthorizationResultBasedKnexEntityLoader-test.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader';
 import { OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
+import { PaginationStrategy } from '../PaginationStrategy';
 import { sql } from '../SQLOperator';
 import {
   TestEntity,
@@ -436,7 +437,7 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
     });
   });
 
-  describe('loads entities with loadPageBySQLAsync', () => {
+  describe('loads entities with loadPageAsync', () => {
     it('returns paginated entities with forward pagination', async () => {
       const privacyPolicy = new TestEntityPrivacyPolicy();
       const spiedPrivacyPolicy = spy(privacyPolicy);
@@ -460,7 +461,7 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
 
       const id1 = uuidv4();
       const id2 = uuidv4();
-      when(knexDataManagerMock.loadPageBySQLFragmentAsync(queryContext, anything())).thenResolve({
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
         edges: [
           {
             cursor: 'cursor1',
@@ -511,10 +512,13 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
         constructionUtils,
       );
 
-      const connection = await knexEntityLoader.loadPageBySQLAsync({
+      const connection = await knexEntityLoader.loadPageAsync({
         first: 10,
         where: sql`intField > ${0}`,
-        orderBy: [{ fieldName: 'intField', order: OrderByOrdering.ASCENDING }],
+        pagination: {
+          strategy: PaginationStrategy.STANDARD,
+          orderBy: [{ fieldName: 'intField', order: OrderByOrdering.ASCENDING }],
+        },
       });
 
       expect(connection.edges).toHaveLength(2);
@@ -564,7 +568,7 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
       const id1 = uuidv4();
       const id2 = uuidv4();
       const id3 = uuidv4();
-      when(knexDataManagerMock.loadPageBySQLFragmentAsync(queryContext, anything())).thenResolve({
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
         edges: [
           {
             cursor: 'cursor1',
@@ -623,10 +627,13 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
         constructionUtils,
       );
 
-      const connection = await knexEntityLoader.loadPageBySQLAsync({
+      const connection = await knexEntityLoader.loadPageAsync({
         first: 10,
         where: sql`score > ${0}`,
-        orderBy: [{ fieldName: 'createdAt', order: OrderByOrdering.ASCENDING }],
+        pagination: {
+          strategy: PaginationStrategy.STANDARD,
+          orderBy: [{ fieldName: 'createdAt', order: OrderByOrdering.ASCENDING }],
+        },
       });
 
       // Should only have 2 entities (unauthorized one filtered out)
@@ -666,7 +673,7 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
       const knexDataManagerMock =
         mock<EntityKnexDataManager<TestFields, 'customIdField'>>(EntityKnexDataManager);
 
-      when(knexDataManagerMock.loadPageBySQLFragmentAsync(queryContext, anything())).thenResolve({
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
         edges: [
           {
             cursor: 'cursor5',
@@ -706,15 +713,455 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
         constructionUtils,
       );
 
-      const connection = await knexEntityLoader.loadPageBySQLAsync({
+      const connection = await knexEntityLoader.loadPageAsync({
         last: 5,
         before: 'someCursor',
-        orderBy: [{ fieldName: 'intField', order: OrderByOrdering.ASCENDING }],
+        pagination: {
+          strategy: PaginationStrategy.STANDARD,
+          orderBy: [{ fieldName: 'intField', order: OrderByOrdering.ASCENDING }],
+        },
       });
 
       expect(connection.edges).toHaveLength(1);
       expect(connection.pageInfo.hasPreviousPage).toBe(true);
       expect(connection.pageInfo.hasNextPage).toBe(false);
+    });
+  });
+
+  describe('loads entities with loadPageAsync (search)', () => {
+    it('performs ILIKE search and filters unauthorized entities', async () => {
+      const privacyPolicy = new TestPaginationPrivacyPolicy();
+      const viewerContext = instance(mock(ViewerContext));
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestPaginationFields,
+              'id',
+              ViewerContext,
+              TestPaginationEntity
+            >
+          >(),
+        );
+      const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
+      const queryContext = instance(mock<EntityQueryContext>());
+
+      const knexDataManagerMock =
+        mock<EntityKnexDataManager<TestPaginationFields, 'id'>>(EntityKnexDataManager);
+
+      const id1 = uuidv4();
+      const id2 = uuidv4();
+      const id3 = uuidv4();
+
+      // Mock data manager to return 3 entities from search
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
+        edges: [
+          {
+            cursor: 'cursor1',
+            node: {
+              id: id1,
+              name: 'Alice Johnson',
+              status: 'active',
+              createdAt: new Date(),
+              score: 1,
+            },
+          },
+          {
+            cursor: 'cursor2',
+            node: {
+              id: id2,
+              name: 'Bob Johnson',
+              status: 'unauthorized', // This will fail authorization per TestPaginationPrivacyPolicy
+              createdAt: new Date(),
+              score: 2,
+            },
+          },
+          {
+            cursor: 'cursor3',
+            node: {
+              id: id3,
+              name: 'Charlie Johnson',
+              status: 'active',
+              createdAt: new Date(),
+              score: 3,
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: 'cursor1',
+          endCursor: 'cursor3',
+        },
+      });
+
+      const constructionUtils = new EntityConstructionUtils(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        testPaginationEntityConfiguration,
+        TestPaginationEntity,
+        /* entitySelectedFields */ undefined,
+        privacyPolicy,
+        metricsAdapter,
+      );
+
+      const knexEntityLoader = new AuthorizationResultBasedKnexEntityLoader(
+        queryContext,
+        instance(knexDataManagerMock),
+        metricsAdapter,
+        constructionUtils,
+      );
+
+      const connection = await knexEntityLoader.loadPageAsync({
+        first: 10,
+        pagination: {
+          strategy: PaginationStrategy.ILIKE_SEARCH,
+          term: 'Johnson',
+          fields: ['name'],
+        },
+      });
+
+      // Should only have 2 edges (Bob was filtered out)
+      expect(connection.edges).toHaveLength(2);
+      expect(connection.edges[0]?.node.getField('id')).toBe(id1);
+      expect(connection.edges[0]?.node.getField('name')).toBe('Alice Johnson');
+      expect(connection.edges[1]?.node.getField('id')).toBe(id3);
+      expect(connection.edges[1]?.node.getField('name')).toBe('Charlie Johnson');
+
+      // Cursors should be updated to reflect only authorized entities
+      expect(connection.pageInfo.startCursor).toBe('cursor1');
+      expect(connection.pageInfo.endCursor).toBe('cursor3');
+    });
+
+    it('performs TRIGRAM search with cursor pagination', async () => {
+      const privacyPolicy = new TestPaginationPrivacyPolicy();
+      const viewerContext = instance(mock(ViewerContext));
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestPaginationFields,
+              'id',
+              ViewerContext,
+              TestPaginationEntity
+            >
+          >(),
+        );
+      const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
+      const queryContext = instance(mock<EntityQueryContext>());
+
+      const knexDataManagerMock =
+        mock<EntityKnexDataManager<TestPaginationFields, 'id'>>(EntityKnexDataManager);
+
+      const id1 = uuidv4();
+      const id2 = uuidv4();
+
+      // Mock first page of TRIGRAM search results
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
+        edges: [
+          {
+            cursor: 'cursor1',
+            node: {
+              id: id1,
+              name: 'Johnson', // Exact match
+              status: 'active',
+              createdAt: new Date(),
+              score: 1,
+            },
+          },
+          {
+            cursor: 'cursor2',
+            node: {
+              id: id2,
+              name: 'Jonson', // Similar match
+              status: 'active',
+              createdAt: new Date(),
+              score: 2,
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          hasPreviousPage: false,
+          startCursor: 'cursor1',
+          endCursor: 'cursor2',
+        },
+      });
+
+      const constructionUtils = new EntityConstructionUtils(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        testPaginationEntityConfiguration,
+        TestPaginationEntity,
+        /* entitySelectedFields */ undefined,
+        privacyPolicy,
+        metricsAdapter,
+      );
+
+      const knexEntityLoader = new AuthorizationResultBasedKnexEntityLoader(
+        queryContext,
+        instance(knexDataManagerMock),
+        metricsAdapter,
+        constructionUtils,
+      );
+
+      const connection = await knexEntityLoader.loadPageAsync({
+        first: 2,
+        after: 'someCursor',
+        pagination: {
+          strategy: PaginationStrategy.TRIGRAM_SEARCH,
+          term: 'Johnson',
+          fields: ['name'],
+          threshold: 0.3,
+          extraOrderByFields: ['score'],
+        },
+      });
+
+      expect(connection.edges).toHaveLength(2);
+      expect(connection.edges[0]?.node.getField('name')).toBe('Johnson');
+      expect(connection.edges[1]?.node.getField('name')).toBe('Jonson');
+      expect(connection.pageInfo.hasNextPage).toBe(true);
+    });
+
+    it('handles backward pagination with search', async () => {
+      const privacyPolicy = new TestPaginationPrivacyPolicy();
+      const viewerContext = instance(mock(ViewerContext));
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestPaginationFields,
+              'id',
+              ViewerContext,
+              TestPaginationEntity
+            >
+          >(),
+        );
+      const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
+      const queryContext = instance(mock<EntityQueryContext>());
+
+      const knexDataManagerMock =
+        mock<EntityKnexDataManager<TestPaginationFields, 'id'>>(EntityKnexDataManager);
+
+      const id1 = uuidv4();
+      const id2 = uuidv4();
+
+      // Mock backward pagination results
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
+        edges: [
+          {
+            cursor: 'cursor1',
+            node: {
+              id: id1,
+              name: 'Charlie Smith',
+              status: 'active',
+              createdAt: new Date(),
+              score: 3,
+            },
+          },
+          {
+            cursor: 'cursor2',
+            node: {
+              id: id2,
+              name: 'David Smith',
+              status: 'active',
+              createdAt: new Date(),
+              score: 4,
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: true,
+          startCursor: 'cursor1',
+          endCursor: 'cursor2',
+        },
+      });
+
+      const constructionUtils = new EntityConstructionUtils(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        testPaginationEntityConfiguration,
+        TestPaginationEntity,
+        /* entitySelectedFields */ undefined,
+        privacyPolicy,
+        metricsAdapter,
+      );
+
+      const knexEntityLoader = new AuthorizationResultBasedKnexEntityLoader(
+        queryContext,
+        instance(knexDataManagerMock),
+        metricsAdapter,
+        constructionUtils,
+      );
+
+      const connection = await knexEntityLoader.loadPageAsync({
+        last: 2,
+        before: 'someCursor',
+        pagination: {
+          strategy: PaginationStrategy.ILIKE_SEARCH,
+          term: 'Smith',
+          fields: ['name'],
+        },
+      });
+
+      expect(connection.edges).toHaveLength(2);
+      expect(connection.pageInfo.hasPreviousPage).toBe(true);
+      expect(connection.pageInfo.hasNextPage).toBe(false);
+    });
+
+    it('handles empty search results', async () => {
+      const privacyPolicy = new TestPaginationPrivacyPolicy();
+      const viewerContext = instance(mock(ViewerContext));
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestPaginationFields,
+              'id',
+              ViewerContext,
+              TestPaginationEntity
+            >
+          >(),
+        );
+      const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
+      const queryContext = instance(mock<EntityQueryContext>());
+
+      const knexDataManagerMock =
+        mock<EntityKnexDataManager<TestPaginationFields, 'id'>>(EntityKnexDataManager);
+
+      // Mock empty search results
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
+        edges: [],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+      });
+
+      const constructionUtils = new EntityConstructionUtils(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        testPaginationEntityConfiguration,
+        TestPaginationEntity,
+        /* entitySelectedFields */ undefined,
+        privacyPolicy,
+        metricsAdapter,
+      );
+
+      const knexEntityLoader = new AuthorizationResultBasedKnexEntityLoader(
+        queryContext,
+        instance(knexDataManagerMock),
+        metricsAdapter,
+        constructionUtils,
+      );
+
+      const connection = await knexEntityLoader.loadPageAsync({
+        first: 10,
+        pagination: {
+          strategy: PaginationStrategy.ILIKE_SEARCH,
+          term: 'NonexistentTerm',
+          fields: ['name'],
+        },
+      });
+
+      expect(connection.edges).toHaveLength(0);
+      expect(connection.pageInfo.startCursor).toBeNull();
+      expect(connection.pageInfo.endCursor).toBeNull();
+    });
+
+    it('handles all entities failing authorization', async () => {
+      const privacyPolicy = new TestPaginationPrivacyPolicy();
+      const viewerContext = instance(mock(ViewerContext));
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestPaginationFields,
+              'id',
+              ViewerContext,
+              TestPaginationEntity
+            >
+          >(),
+        );
+      const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
+      const queryContext = instance(mock<EntityQueryContext>());
+
+      const knexDataManagerMock =
+        mock<EntityKnexDataManager<TestPaginationFields, 'id'>>(EntityKnexDataManager);
+
+      const id1 = uuidv4();
+      const id2 = uuidv4();
+
+      // Mock search results
+      when(knexDataManagerMock.loadPageAsync(queryContext, anything())).thenResolve({
+        edges: [
+          {
+            cursor: 'cursor1',
+            node: {
+              id: id1,
+              name: 'Alice',
+              status: 'unauthorized', // This will fail authorization
+              createdAt: new Date(),
+              score: 1,
+            },
+          },
+          {
+            cursor: 'cursor2',
+            node: {
+              id: id2,
+              name: 'Bob',
+              status: 'unauthorized', // This will fail authorization
+              createdAt: new Date(),
+              score: 2,
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: 'cursor1',
+          endCursor: 'cursor2',
+        },
+      });
+
+      const constructionUtils = new EntityConstructionUtils(
+        viewerContext,
+        queryContext,
+        privacyPolicyEvaluationContext,
+        testPaginationEntityConfiguration,
+        TestPaginationEntity,
+        /* entitySelectedFields */ undefined,
+        privacyPolicy,
+        metricsAdapter,
+      );
+
+      const knexEntityLoader = new AuthorizationResultBasedKnexEntityLoader(
+        queryContext,
+        instance(knexDataManagerMock),
+        metricsAdapter,
+        constructionUtils,
+      );
+
+      const connection = await knexEntityLoader.loadPageAsync({
+        first: 10,
+        pagination: {
+          strategy: PaginationStrategy.ILIKE_SEARCH,
+          term: 'test',
+          fields: ['name'],
+        },
+      });
+
+      // All entities filtered out due to failed authorization
+      expect(connection.edges).toHaveLength(0);
+      expect(connection.pageInfo.startCursor).toBeNull();
+      expect(connection.pageInfo.endCursor).toBeNull();
     });
   });
 });

--- a/packages/entity-database-adapter-knex/src/__tests__/EnforcingKnexEntityLoader-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/EnforcingKnexEntityLoader-test.ts
@@ -8,6 +8,7 @@ import {
   AuthorizationResultBasedSQLQueryBuilder,
 } from '../AuthorizationResultBasedKnexEntityLoader';
 import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader';
+import { PaginationStrategy } from '../PaginationStrategy';
 import { sql } from '../SQLOperator';
 import { EntityKnexDataManager } from '../internal/EntityKnexDataManager';
 
@@ -248,7 +249,7 @@ describe(EnforcingKnexEntityLoader, () => {
     });
   });
 
-  describe('loadPageBySQLAsync', () => {
+  describe('loadPageAsync', () => {
     it('throws when result is unsuccessful', async () => {
       const queryContext = instance(mock(EntityQueryContext));
       const knexDataManagerMock = mock<EntityKnexDataManager<any, any>>(EntityKnexDataManager);
@@ -257,7 +258,7 @@ describe(EnforcingKnexEntityLoader, () => {
       const rejection = new Error('Entity not authorized');
 
       // Mock the data manager to return a connection with field objects
-      when(knexDataManagerMock.loadPageBySQLFragmentAsync(anything(), anything())).thenResolve({
+      when(knexDataManagerMock.loadPageAsync(anything(), anything())).thenResolve({
         edges: [
           {
             cursor: 'cursor1',
@@ -286,9 +287,12 @@ describe(EnforcingKnexEntityLoader, () => {
       );
 
       await expect(
-        enforcingKnexEntityLoader.loadPageBySQLAsync({
+        enforcingKnexEntityLoader.loadPageAsync({
           first: 10,
-          orderBy: [],
+          pagination: {
+            strategy: PaginationStrategy.STANDARD,
+            orderBy: [],
+          },
         }),
       ).rejects.toThrow(rejection);
     });
@@ -301,7 +305,7 @@ describe(EnforcingKnexEntityLoader, () => {
       const entity1 = { id: '1', name: 'Entity 1', getID: () => '1' };
       const entity2 = { id: '2', name: 'Entity 2', getID: () => '2' };
 
-      when(knexDataManagerMock.loadPageBySQLFragmentAsync(anything(), anything())).thenResolve({
+      when(knexDataManagerMock.loadPageAsync(anything(), anything())).thenResolve({
         edges: [
           {
             cursor: 'cursor1',
@@ -339,9 +343,12 @@ describe(EnforcingKnexEntityLoader, () => {
         instance(constructionUtilsMock),
       );
 
-      const connection = await enforcingKnexEntityLoader.loadPageBySQLAsync({
+      const connection = await enforcingKnexEntityLoader.loadPageAsync({
         first: 10,
-        orderBy: [],
+        pagination: {
+          strategy: PaginationStrategy.STANDARD,
+          orderBy: [],
+        },
       });
 
       expect(connection.edges).toHaveLength(2);

--- a/packages/entity-database-adapter-knex/src/index.ts
+++ b/packages/entity-database-adapter-knex/src/index.ts
@@ -11,6 +11,7 @@ export * from './EnforcingKnexEntityLoader';
 export * from './EntityFields';
 export * from './KnexEntityLoader';
 export * from './KnexEntityLoaderFactory';
+export * from './PaginationStrategy';
 export * from './PostgresEntityDatabaseAdapter';
 export * from './PostgresEntityDatabaseAdapterProvider';
 export * from './PostgresEntityQueryContextProvider';


### PR DESCRIPTION
# Why

This PR adds search capabilities to the existing cursor-based pagination system added in #422 which only supported orderBy ordering.

This adds:
1. Case-insensitive pattern matching (ILIKE) - Useful for basic text search across entity fields
2. Trigram similarity search - Provides fuzzy matching capabilities for more advanced search use cases like handling typos or finding similar text

This enables building user-facing search features while maintaining the benefits of cursor-based pagination (stable results, efficient queries).

# How

The implementation introduces a unified PaginationSpecification that supports three strategies:

  1. Standard pagination - The existing orderBy-based pagination
  2. ILIKE search - Pattern matching with automatic wildcard escaping
  3. Trigram search - PostgreSQL trigram similarity with configurable threshold

  Key implementation details:
  - Search terms are properly parameterized to prevent SQL injection
  - ILIKE special characters (%, _, \) are escaped to prevent pattern injection
  - Results maintain stable cursor-based pagination with proper ordering:
    - ILIKE: Ordered by search fields, then ID
    - Trigram: Ordered by exact match priority, similarity score, optional extra fields, then ID

# Test Plan

  The PR includes comprehensive test coverage:

  - Unit tests for both AuthorizationResultBasedKnexEntityLoader and
  EnforcingKnexEntityLoader
  - Integration tests covering:
    - Forward/backward pagination with search
    - Multi-field search
    - Case-insensitive matching
    - Trigram similarity with various thresholds
    - Cursor stability across pages
    - Edge cases (empty results, special characters)
    - Combined with WHERE clauses
    - Security validation ensuring proper escaping and parameterization

All existing tests pass, confirming backward compatibility for standard pagination when using the new API.