### PR TITLE
fix: pass in augmentable classes to installation

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapterProvider.ts
@@ -17,11 +17,21 @@ export class StubPostgresDatabaseAdapterProvider implements IEntityDatabaseAdapt
     return 'StubPostgresDatabaseAdapterProvider';
   }
 
-  installExtensions(): void {
-    installEntityCompanionExtensions();
-    installEntityTableDataCoordinatorExtensions();
-    installViewerScopedEntityCompanionExtensions();
-    installReadonlyEntityExtensions();
+  installExtensions({
+    EntityCompanionClass,
+    EntityTableDataCoordinatorClass,
+    ViewerScopedEntityCompanionClass,
+    ReadonlyEntityClass,
+  }: {
+    EntityCompanionClass: typeof import('@expo/entity').EntityCompanion;
+    EntityTableDataCoordinatorClass: typeof import('@expo/entity').EntityTableDataCoordinator;
+    ViewerScopedEntityCompanionClass: typeof import('@expo/entity').ViewerScopedEntityCompanion;
+    ReadonlyEntityClass: typeof import('@expo/entity').ReadonlyEntity;
+  }): void {
+    installEntityCompanionExtensions({ EntityCompanionClass });
+    installEntityTableDataCoordinatorExtensions({ EntityTableDataCoordinatorClass });
+    installViewerScopedEntityCompanionExtensions({ ViewerScopedEntityCompanionClass });
+    installReadonlyEntityExtensions({ ReadonlyEntityClass });
   }
 
   private readonly objectCollection = new Map();

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
@@ -24,11 +24,21 @@ export class PostgresEntityDatabaseAdapterProvider implements IEntityDatabaseAda
     return 'PostgresEntityDatabaseAdapterProvider';
   }
 
-  installExtensions(): void {
-    installEntityCompanionExtensions();
-    installEntityTableDataCoordinatorExtensions();
-    installViewerScopedEntityCompanionExtensions();
-    installReadonlyEntityExtensions();
+  installExtensions({
+    EntityCompanionClass,
+    EntityTableDataCoordinatorClass,
+    ViewerScopedEntityCompanionClass,
+    ReadonlyEntityClass,
+  }: {
+    EntityCompanionClass: typeof import('@expo/entity').EntityCompanion;
+    EntityTableDataCoordinatorClass: typeof import('@expo/entity').EntityTableDataCoordinator;
+    ViewerScopedEntityCompanionClass: typeof import('@expo/entity').ViewerScopedEntityCompanion;
+    ReadonlyEntityClass: typeof import('@expo/entity').ReadonlyEntity;
+  }): void {
+    installEntityCompanionExtensions({ EntityCompanionClass });
+    installEntityTableDataCoordinatorExtensions({ EntityTableDataCoordinatorClass });
+    installViewerScopedEntityCompanionExtensions({ ViewerScopedEntityCompanionClass });
+    installReadonlyEntityExtensions({ ReadonlyEntityClass });
   }
 
   getDatabaseAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapterProvider.ts
@@ -15,11 +15,21 @@ export class StubPostgresDatabaseAdapterProvider implements IEntityDatabaseAdapt
     return 'StubPostgresDatabaseAdapterProvider';
   }
 
-  installExtensions(): void {
-    installEntityCompanionExtensions();
-    installEntityTableDataCoordinatorExtensions();
-    installViewerScopedEntityCompanionExtensions();
-    installReadonlyEntityExtensions();
+  installExtensions({
+    EntityCompanionClass,
+    EntityTableDataCoordinatorClass,
+    ViewerScopedEntityCompanionClass,
+    ReadonlyEntityClass,
+  }: {
+    EntityCompanionClass: typeof import('@expo/entity').EntityCompanion;
+    EntityTableDataCoordinatorClass: typeof import('@expo/entity').EntityTableDataCoordinator;
+    ViewerScopedEntityCompanionClass: typeof import('@expo/entity').ViewerScopedEntityCompanion;
+    ReadonlyEntityClass: typeof import('@expo/entity').ReadonlyEntity;
+  }): void {
+    installEntityCompanionExtensions({ EntityCompanionClass });
+    installEntityTableDataCoordinatorExtensions({ EntityTableDataCoordinatorClass });
+    installViewerScopedEntityCompanionExtensions({ ViewerScopedEntityCompanionClass });
+    installReadonlyEntityExtensions({ ReadonlyEntityClass });
   }
 
   private readonly objectCollection = new Map();

--- a/packages/entity-database-adapter-knex/src/extensions/EntityCompanionExtensions.ts
+++ b/packages/entity-database-adapter-knex/src/extensions/EntityCompanionExtensions.ts
@@ -41,8 +41,12 @@ declare module '@expo/entity' {
   }
 }
 
-export function installEntityCompanionExtensions(): void {
-  EntityCompanion.prototype.getKnexLoaderFactory = function <
+export function installEntityCompanionExtensions({
+  EntityCompanionClass,
+}: {
+  EntityCompanionClass: typeof EntityCompanion;
+}): void {
+  EntityCompanionClass.prototype.getKnexLoaderFactory = function <
     TFields extends Record<string, any>,
     TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
     TViewerContext extends ViewerContext,

--- a/packages/entity-database-adapter-knex/src/extensions/EntityTableDataCoordinatorExtensions.ts
+++ b/packages/entity-database-adapter-knex/src/extensions/EntityTableDataCoordinatorExtensions.ts
@@ -29,8 +29,12 @@ function requireBasePostgresAdapter<
   return databaseAdapter;
 }
 
-export function installEntityTableDataCoordinatorExtensions(): void {
-  EntityTableDataCoordinator.prototype.getKnexDataManager = function <
+export function installEntityTableDataCoordinatorExtensions({
+  EntityTableDataCoordinatorClass,
+}: {
+  EntityTableDataCoordinatorClass: typeof EntityTableDataCoordinator;
+}): void {
+  EntityTableDataCoordinatorClass.prototype.getKnexDataManager = function <
     TFields extends Record<string, any>,
     TIDField extends keyof TFields,
   >(this: EntityTableDataCoordinator<TFields, TIDField>): EntityKnexDataManager<TFields, TIDField> {

--- a/packages/entity-database-adapter-knex/src/extensions/ReadonlyEntityExtensions.ts
+++ b/packages/entity-database-adapter-knex/src/extensions/ReadonlyEntityExtensions.ts
@@ -172,8 +172,12 @@ class ReadonlyEntityExtensions {
   }
 }
 
-export function installReadonlyEntityExtensions(): void {
-  ReadonlyEntity.knexLoader = ReadonlyEntityExtensions.knexLoader;
-  ReadonlyEntity.knexLoaderWithAuthorizationResults =
+export function installReadonlyEntityExtensions({
+  ReadonlyEntityClass,
+}: {
+  ReadonlyEntityClass: typeof ReadonlyEntity;
+}): void {
+  ReadonlyEntityClass.knexLoader = ReadonlyEntityExtensions.knexLoader;
+  ReadonlyEntityClass.knexLoaderWithAuthorizationResults =
     ReadonlyEntityExtensions.knexLoaderWithAuthorizationResults;
 }

--- a/packages/entity-database-adapter-knex/src/extensions/ViewerScopedEntityCompanionExtensions.ts
+++ b/packages/entity-database-adapter-knex/src/extensions/ViewerScopedEntityCompanionExtensions.ts
@@ -33,8 +33,12 @@ declare module '@expo/entity' {
   }
 }
 
-export function installViewerScopedEntityCompanionExtensions(): void {
-  ViewerScopedEntityCompanion.prototype.getKnexLoaderFactory = function <
+export function installViewerScopedEntityCompanionExtensions({
+  ViewerScopedEntityCompanionClass,
+}: {
+  ViewerScopedEntityCompanionClass: typeof ViewerScopedEntityCompanion;
+}): void {
+  ViewerScopedEntityCompanionClass.prototype.getKnexLoaderFactory = function <
     TFields extends Record<string, any>,
     TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
     TViewerContext extends ViewerContext,

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -11,6 +11,7 @@ import { IEntityCacheAdapterProvider } from './IEntityCacheAdapterProvider';
 import { IEntityDatabaseAdapterProvider } from './IEntityDatabaseAdapterProvider';
 import { ReadonlyEntity } from './ReadonlyEntity';
 import { ViewerContext } from './ViewerContext';
+import { ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion';
 import { EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator';
 import { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
 import { computeIfAbsent } from './utils/collections/maps';
@@ -167,7 +168,12 @@ export class EntityCompanionProvider {
           flavorDefinition.adapterProvider.getExtensionsKey(),
         )
       ) {
-        flavorDefinition.adapterProvider.installExtensions();
+        flavorDefinition.adapterProvider.installExtensions({
+          EntityCompanionClass: EntityCompanion,
+          EntityTableDataCoordinatorClass: EntityTableDataCoordinator,
+          ViewerScopedEntityCompanionClass: ViewerScopedEntityCompanion,
+          ReadonlyEntityClass: ReadonlyEntity,
+        });
         EntityCompanionProvider.installedExtensions.add(
           flavorDefinition.adapterProvider.getExtensionsKey(),
         );

--- a/packages/entity/src/IEntityDatabaseAdapterProvider.ts
+++ b/packages/entity/src/IEntityDatabaseAdapterProvider.ts
@@ -1,7 +1,11 @@
 /* c8 ignore start - interface only */
 
+import { EntityCompanion } from './EntityCompanion';
 import { EntityConfiguration } from './EntityConfiguration';
 import { EntityDatabaseAdapter } from './EntityDatabaseAdapter';
+import { ReadonlyEntity } from './ReadonlyEntity';
+import { ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion';
+import { EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator';
 
 /**
  * A database adapter provider vends database adapters for a particular database adapter type.
@@ -16,7 +20,17 @@ export interface IEntityDatabaseAdapterProvider {
   /**
    * Install any necessary extensions to the Entity system.
    */
-  installExtensions(): void;
+  installExtensions({
+    EntityCompanionClass,
+    EntityTableDataCoordinatorClass,
+    ViewerScopedEntityCompanionClass,
+    ReadonlyEntityClass,
+  }: {
+    EntityCompanionClass: typeof EntityCompanion;
+    EntityTableDataCoordinatorClass: typeof EntityTableDataCoordinator;
+    ViewerScopedEntityCompanionClass: typeof ViewerScopedEntityCompanion;
+    ReadonlyEntityClass: typeof ReadonlyEntity;
+  }): void;
 
   /**
    * Vend a database adapter.


### PR DESCRIPTION
# Why

An idea proposed by @ide in https://github.com/expo/entity/pull/410#pullrequestreview-3765893898.

This makes it more testable and clearer about what objects installations are "allowed" to augment.

# How

Pass in the classes explicitly.

# Test Plan

`yarn tsc`