### PR TITLE
fix!: change adaptor -> adapter for consistency

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,3 +28,4 @@ This is Entity, a privacy-aware data layer for defining, caching, and authorizin
 - Do not use jest's `test.skip`
 - Prefer not to use dynamic imports for now
 - Whenever technically correct, use typescript types for something instead of `any`
+- Prefer American English spellings of words over British English. For example, prefer "Adapter" over "Adaptor".

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
@@ -90,7 +90,7 @@ describe(createWithUniqueConstraintRecoveryAsync, () => {
         name: 'unique',
       };
 
-      const createdEntities = await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+      const createdEntities = await vc1.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           if (parallel) {
@@ -154,7 +154,7 @@ describe(createWithUniqueConstraintRecoveryAsync, () => {
       let createdEntities: [PostgresUniqueTestEntity, PostgresUniqueTestEntity];
       if (parallel) {
         createdEntities = await Promise.all([
-          vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+          vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
             return await createWithUniqueConstraintRecoveryAsync(
               vc1,
               PostgresUniqueTestEntity,
@@ -165,7 +165,7 @@ describe(createWithUniqueConstraintRecoveryAsync, () => {
               queryContext,
             );
           }),
-          vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+          vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
             return await createWithUniqueConstraintRecoveryAsync(
               vc1,
               PostgresUniqueTestEntity,
@@ -179,7 +179,7 @@ describe(createWithUniqueConstraintRecoveryAsync, () => {
         ]);
       } else {
         createdEntities = [
-          await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+          await vc1.runInTransactionForDatabaseAdapterFlavorAsync(
             'postgres',
             async (queryContext) => {
               return await createWithUniqueConstraintRecoveryAsync(
@@ -193,7 +193,7 @@ describe(createWithUniqueConstraintRecoveryAsync, () => {
               );
             },
           ),
-          await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+          await vc1.runInTransactionForDatabaseAdapterFlavorAsync(
             'postgres',
             async (queryContext) => {
               return await createWithUniqueConstraintRecoveryAsync(

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -125,7 +125,7 @@ describe('postgres entity integration', () => {
     const errorToThrow = new Error('Intentional error');
 
     await expect(
-      vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+      vc1.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           // put another in the DB that will be rolled back due to error thrown
@@ -167,7 +167,7 @@ describe('postgres entity integration', () => {
           delay: number,
         ): Promise<{ error?: Error }> => {
           try {
-            await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+            await vc1.runInTransactionForDatabaseAdapterFlavorAsync(
               'postgres',
               async (queryContext) => {
                 const entity = await PostgresTestEntity.loader(vc1, queryContext).loadByIDAsync(
@@ -1311,7 +1311,7 @@ describe('postgres entity integration', () => {
       let preCommitInnerCallCount = 0;
       let postCommitCallCount = 0;
 
-      await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+      await vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
         queryContext.appendPostCommitCallback(async () => {
           postCommitCallCount++;
         });
@@ -1343,7 +1343,7 @@ describe('postgres entity integration', () => {
       });
 
       await expect(
-        vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+        vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
           queryContext.appendPostCommitCallback(async () => {
             postCommitCallCount++;
           });

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -41,7 +41,7 @@ describe(PostgresEntityQueryContextProvider, () => {
       await PostgresUniqueTestEntity.creator(vc1).setField('name', 'wat').createAsync()
     ).getID();
 
-    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+    await vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
       const entity = await PostgresUniqueTestEntity.loader(vc1, queryContext).loadByIDAsync(id);
       await PostgresUniqueTestEntity.updater(entity, queryContext)
         .setField('name', 'wat2')
@@ -81,7 +81,7 @@ describe(PostgresEntityQueryContextProvider, () => {
     const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(entity.getID());
     expect(entityLoaded.getField('name')).toEqual('who');
 
-    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+    await vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
       const entityLoadedOuter = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
         entity.getID(),
       );
@@ -124,7 +124,7 @@ describe(PostgresEntityQueryContextProvider, () => {
     const entityLoaded = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(entity.getID());
     expect(entityLoaded.getField('name')).toEqual('who');
 
-    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+    await vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
       const entityLoadedOuter = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
         entity.getID(),
       );
@@ -181,7 +181,7 @@ describe(PostgresEntityQueryContextProvider, () => {
     });
 
     await Promise.all([
-      vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+      vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
         const entityLoadedOuter = await PostgresUniqueTestEntity.loader(vc1).loadByIDAsync(
           entity.getID(),
         );
@@ -235,7 +235,7 @@ describe(PostgresEntityQueryContextProvider, () => {
       transactionalDataLoaderMode: TransactionalDataLoaderMode,
     ): Promise<void> => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
-      await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await vc1.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (outerQueryContext) => {
           // put it in local dataloader
@@ -334,7 +334,7 @@ describe(PostgresEntityQueryContextProvider, () => {
       transactionalDataLoaderMode: TransactionalDataLoaderMode,
     ): Promise<void> => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
-      await vc1.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await vc1.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (outerQueryContext) => {
           // put it in local dataloader
@@ -432,7 +432,7 @@ describe(PostgresEntityQueryContextProvider, () => {
       await PostgresUniqueTestEntity.creator(vc1).setField('name', 'wat').createAsync()
     ).getID();
 
-    await vc1.runInTransactionForDatabaseAdaptorFlavorAsync('postgres', async (queryContext) => {
+    await vc1.runInTransactionForDatabaseAdapterFlavorAsync('postgres', async (queryContext) => {
       await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
         await innerQueryContext.runInNestedTransactionAsync(async (innerQueryContex2) => {
           await innerQueryContex2.runInNestedTransactionAsync(async (innerQueryContex3) => {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -181,7 +181,7 @@ describe('Entity cache inconsistency', () => {
 
         openBarrier2!();
       })(),
-      viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           await TestEntity.updater(entity1, queryContext)

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -208,13 +208,13 @@ export class EntityCompanionProvider {
     });
   }
 
-  getQueryContextProviderForDatabaseAdaptorFlavor(
+  getQueryContextProviderForDatabaseAdapterFlavor(
     databaseAdapterFlavor: DatabaseAdapterFlavor,
   ): EntityQueryContextProvider {
     const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(databaseAdapterFlavor);
     invariant(
       entityDatabaseAdapterFlavor,
-      `No database adaptor configuration found for flavor: ${databaseAdapterFlavor}`,
+      `No database adapter configuration found for flavor: ${databaseAdapterFlavor}`,
     );
 
     return entityDatabaseAdapterFlavor.queryContextProvider;
@@ -233,7 +233,7 @@ export class EntityCompanionProvider {
       );
       invariant(
         entityDatabaseAdapterFlavor,
-        `No database adaptor configuration found for flavor: ${entityConfiguration.databaseAdapterFlavor}`,
+        `No database adapter configuration found for flavor: ${entityConfiguration.databaseAdapterFlavor}`,
       );
 
       const entityCacheAdapterFlavor = this.cacheAdapterFlavors.get(
@@ -241,7 +241,7 @@ export class EntityCompanionProvider {
       );
       invariant(
         entityCacheAdapterFlavor,
-        `No cache adaptor configuration found for flavor: ${entityConfiguration.cacheAdapterFlavor}`,
+        `No cache adapter configuration found for flavor: ${entityConfiguration.cacheAdapterFlavor}`,
       );
 
       return new EntityTableDataCoordinator(

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -64,30 +64,30 @@ export class ViewerContext {
   }
 
   /**
-   * Get the regular (non-transactional) query context for a database adaptor flavor.
-   * @param databaseAdaptorFlavor - database adaptor flavor
+   * Get the regular (non-transactional) query context for a database adapter flavor.
+   * @param databaseAdapterFlavor - database adapter flavor
    */
-  getQueryContextForDatabaseAdaptorFlavor(
-    databaseAdaptorFlavor: DatabaseAdapterFlavor,
+  getQueryContextForDatabaseAdapterFlavor(
+    databaseAdapterFlavor: DatabaseAdapterFlavor,
   ): EntityQueryContext {
     return this.entityCompanionProvider
-      .getQueryContextProviderForDatabaseAdaptorFlavor(databaseAdaptorFlavor)
+      .getQueryContextProviderForDatabaseAdapterFlavor(databaseAdapterFlavor)
       .getQueryContext();
   }
 
   /**
-   * Run a transaction of specified database adaptor flavor and execute the provided
+   * Run a transaction of specified database adapter flavor and execute the provided
    * transaction-scoped closure within the transaction.
-   * @param databaseAdaptorFlavor - databaseAdaptorFlavor
+   * @param databaseAdapterFlavor - databaseAdapterFlavor
    * @param transactionScope - async callback to execute within the transaction
    */
-  async runInTransactionForDatabaseAdaptorFlavorAsync<TResult>(
-    databaseAdaptorFlavor: DatabaseAdapterFlavor,
+  async runInTransactionForDatabaseAdapterFlavorAsync<TResult>(
+    databaseAdapterFlavor: DatabaseAdapterFlavor,
     transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<TResult>,
     transactionConfig?: TransactionConfig,
   ): Promise<TResult> {
     return await this.entityCompanionProvider
-      .getQueryContextProviderForDatabaseAdaptorFlavor(databaseAdaptorFlavor)
+      .getQueryContextProviderForDatabaseAdapterFlavor(databaseAdapterFlavor)
       .getQueryContext()
       .runInTransactionIfNotInTransactionAsync(transactionScope, transactionConfig);
   }

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -49,7 +49,7 @@ describe(EntityQueryContext, () => {
         );
       });
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           queryContext.appendPostCommitCallback(postCommitCallback);
@@ -76,7 +76,7 @@ describe(EntityQueryContext, () => {
       const postCommitCallback = jest.fn(async (): Promise<void> => {});
 
       await expect(
-        viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
           'postgres',
           async (queryContext) => {
             queryContext.appendPostCommitCallback(postCommitCallback);
@@ -105,7 +105,7 @@ describe(EntityQueryContext, () => {
       const postCommitCallback = jest.fn(async (): Promise<void> => {});
       const postCommitNestedCallback = jest.fn(async (): Promise<void> => {});
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           queryContext.appendPostCommitCallback(postCommitCallback);
@@ -152,13 +152,13 @@ describe(EntityQueryContext, () => {
       const viewerContext = new ViewerContext(companionProvider);
 
       const queryContextProvider =
-        companionProvider.getQueryContextProviderForDatabaseAdaptorFlavor('postgres');
+        companionProvider.getQueryContextProviderForDatabaseAdapterFlavor('postgres');
       const queryContextProviderSpy = jest.spyOn(queryContextProvider, 'runInTransactionAsync');
 
       const transactionScopeFn = async (): Promise<any> => {};
       const transactionConfig = { isolationLevel: TransactionIsolationLevel.SERIALIZABLE };
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         transactionScopeFn,
         transactionConfig,
@@ -171,7 +171,7 @@ describe(EntityQueryContext, () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
@@ -182,7 +182,7 @@ describe(EntityQueryContext, () => {
         { transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED },
       );
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
@@ -193,7 +193,7 @@ describe(EntityQueryContext, () => {
         { transactionalDataLoaderMode: TransactionalDataLoaderMode.ENABLED_BATCH_ONLY },
       );
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
@@ -252,7 +252,7 @@ describe(EntityQueryContext, () => {
       );
       const viewerContext = new ViewerContext(companionProvider);
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
@@ -263,7 +263,7 @@ describe(EntityQueryContext, () => {
         { transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED },
       );
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());
@@ -274,7 +274,7 @@ describe(EntityQueryContext, () => {
         { transactionalDataLoaderMode: TransactionalDataLoaderMode.ENABLED_BATCH_ONLY },
       );
 
-      await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
         'postgres',
         async (queryContext) => {
           assert(queryContext.isInTransaction());

--- a/packages/entity/src/__tests__/ViewerContext-test.ts
+++ b/packages/entity/src/__tests__/ViewerContext-test.ts
@@ -5,22 +5,22 @@ import { ViewerContext } from '../ViewerContext';
 import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
 
 describe(ViewerContext, () => {
-  describe('getQueryContextForDatabaseAdaptorFlavor', () => {
+  describe('getQueryContextForDatabaseAdapterFlavor', () => {
     it('creates a new regular query context', () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
-      const queryContext = viewerContext.getQueryContextForDatabaseAdaptorFlavor('postgres');
+      const queryContext = viewerContext.getQueryContextForDatabaseAdapterFlavor('postgres');
       expect(queryContext).toBeInstanceOf(EntityQueryContext);
       expect(queryContext.isInTransaction()).toBe(false);
     });
   });
 
-  describe('runInTransactionForDatabaseAdaptorFlavorAsync', () => {
+  describe('runInTransactionForDatabaseAdapterFlavorAsync', () => {
     it('creates a new transactional query context', async () => {
       const companionProvider = createUnitTestEntityCompanionProvider();
       const viewerContext = new ViewerContext(companionProvider);
       const didCreateTransaction =
-        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
           'postgres',
           async (queryContext) => {
             return queryContext.isInTransaction();

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -120,7 +120,7 @@ describe(EntityDataManager, () => {
     cacheSpy.mockClear();
   });
 
-  it('loads from a caching adaptor', async () => {
+  it('loads from a caching adapter', async () => {
     const objects = getObjects();
     const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
       testEntityConfiguration,

--- a/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
@@ -40,7 +40,7 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
       );
 
       if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
           'postgres',
           async (queryContext) => {
             await createOrGetExistingAsync(
@@ -92,7 +92,7 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
       );
 
       if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
           'postgres',
           async (queryContext) => {
             await createOrGetExistingAsync(
@@ -146,7 +146,7 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
       );
 
       if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
           'postgres',
           async (queryContext) => {
             await createWithUniqueConstraintRecoveryAsync(
@@ -204,7 +204,7 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
       );
 
       if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
           'postgres',
           async (queryContext) => {
             await createWithUniqueConstraintRecoveryAsync(
@@ -261,7 +261,7 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
 
       if (inTransaction) {
         await expect(
-          viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
             'postgres',
             async (queryContext) => {
               return await createWithUniqueConstraintRecoveryAsync(
@@ -321,7 +321,7 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
 
       if (inTransaction) {
         await expect(
-          viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+          viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
             'postgres',
             async (queryContext) => {
               return await createWithUniqueConstraintRecoveryAsync(

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -232,7 +232,7 @@ describe(canViewerDeleteAsync, () => {
   it('supports running within a transaction', async () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new ViewerContext(companionProvider);
-    const canViewerDelete = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+    const canViewerDelete = await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
       'postgres',
       async (queryContext) => {
         const testEntity = await SimpleTestDenyUpdateEntity.creator(
@@ -248,7 +248,7 @@ describe(canViewerDeleteAsync, () => {
     );
     expect(canViewerDelete).toBe(true);
 
-    const canViewerDeleteResult = await viewerContext.runInTransactionForDatabaseAdaptorFlavorAsync(
+    const canViewerDeleteResult = await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
       'postgres',
       async (queryContext) => {
         const testEntity = await SimpleTestDenyUpdateEntity.creator(


### PR DESCRIPTION
# Why

As part of #451, claude noticed that we used both american and british english variants of "adapter"/"adaptor". This makes them consistent by making them all "adapter".

# How

Update name. Technically this is a breaking change but the nature of the library allows `tsc` to catch it in all application code that uses the library.

# Test Plan

`yarn tsc`
