### PR TITLE
fix: Reorganize constructionUtils to make non-public

### DIFF
--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -1,9 +1,11 @@
 import {
   AlwaysAllowPrivacyPolicyRule,
+  AuthorizationResultBasedEntityLoader,
   Entity,
   EntityCompanionDefinition,
   EntityCompanionProvider,
   EntityConfiguration,
+  EntityConstructionUtils,
   EntityPrivacyPolicy,
   EntitySecondaryCacheLoader,
   IEntityMetricsAdapter,
@@ -161,6 +163,32 @@ class TestSecondaryLocalMemoryCacheLoader extends EntitySecondaryCacheLoader<
 > {
   public databaseLoadCount = 0;
 
+  constructor(
+    secondaryEntityCache: LocalMemorySecondaryEntityCache<
+      LocalMemoryTestEntityFields,
+      'id',
+      TestLoadParams
+    >,
+    constructionUtils: EntityConstructionUtils<
+      LocalMemoryTestEntityFields,
+      'id',
+      TestViewerContext,
+      LocalMemoryTestEntity,
+      LocalMemoryTestEntityPrivacyPolicy,
+      keyof LocalMemoryTestEntityFields
+    >,
+    private readonly entityLoader: AuthorizationResultBasedEntityLoader<
+      LocalMemoryTestEntityFields,
+      'id',
+      TestViewerContext,
+      LocalMemoryTestEntity,
+      LocalMemoryTestEntityPrivacyPolicy,
+      keyof LocalMemoryTestEntityFields
+    >,
+  ) {
+    super(secondaryEntityCache, constructionUtils);
+  }
+
   protected async fetchObjectsFromDatabaseAsync(
     loadParamsArray: readonly Readonly<TestLoadParams>[],
   ): Promise<ReadonlyMap<Readonly<TestLoadParams>, Readonly<LocalMemoryTestEntityFields> | null>> {
@@ -192,6 +220,10 @@ describe(LocalMemorySecondaryEntityCache, () => {
       new LocalMemorySecondaryEntityCache(
         localMemoryTestEntityConfiguration,
         createTTLCache<LocalMemoryTestEntityFields>(),
+      ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(
+        LocalMemoryTestEntity,
+        viewerContext,
       ),
       LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
@@ -228,6 +260,10 @@ describe(LocalMemorySecondaryEntityCache, () => {
       new LocalMemorySecondaryEntityCache(
         localMemoryTestEntityConfiguration,
         createTTLCache<LocalMemoryTestEntityFields>(),
+      ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(
+        LocalMemoryTestEntity,
+        viewerContext,
       ),
       LocalMemoryTestEntity.loaderWithAuthorizationResults(viewerContext),
     );

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -1,4 +1,10 @@
-import { EntitySecondaryCacheLoader, mapMapAsync, ViewerContext } from '@expo/entity';
+import {
+  AuthorizationResultBasedEntityLoader,
+  EntityConstructionUtils,
+  EntitySecondaryCacheLoader,
+  mapMapAsync,
+  ViewerContext,
+} from '@expo/entity';
 import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
@@ -32,6 +38,28 @@ class TestSecondaryRedisCacheLoader extends EntitySecondaryCacheLoader<
   RedisTestEntityPrivacyPolicy
 > {
   public databaseLoadCount = 0;
+
+  constructor(
+    secondaryEntityCache: RedisSecondaryEntityCache<RedisTestEntityFields, 'id', TestLoadParams>,
+    constructionUtils: EntityConstructionUtils<
+      RedisTestEntityFields,
+      'id',
+      TestViewerContext,
+      RedisTestEntity,
+      RedisTestEntityPrivacyPolicy,
+      keyof RedisTestEntityFields
+    >,
+    private readonly entityLoader: AuthorizationResultBasedEntityLoader<
+      RedisTestEntityFields,
+      'id',
+      TestViewerContext,
+      RedisTestEntity,
+      RedisTestEntityPrivacyPolicy,
+      keyof RedisTestEntityFields
+    >,
+  ) {
+    super(secondaryEntityCache, constructionUtils);
+  }
 
   protected async fetchObjectsFromDatabaseAsync(
     loadParamsArray: readonly Readonly<TestLoadParams>[],
@@ -93,6 +121,7 @@ describe(RedisSecondaryEntityCache, () => {
         genericRedisCacheContext,
         (loadParams) => `test-key-${loadParams.id}`,
       ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(RedisTestEntity, viewerContext),
       RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 
@@ -132,6 +161,7 @@ describe(RedisSecondaryEntityCache, () => {
         genericRedisCacheContext,
         (loadParams) => `test-key-${loadParams.id}`,
       ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(RedisTestEntity, viewerContext),
       RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 

--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -9,7 +9,6 @@ import {
   EntityConfiguration,
 } from './EntityConfiguration';
 import { EntityConstructionUtils } from './EntityConstructionUtils';
-import { EntityInvalidationUtils } from './EntityInvalidationUtils';
 import { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import { ReadonlyEntity } from './ReadonlyEntity';
@@ -19,7 +18,6 @@ import { CompositeFieldHolder, CompositeFieldValueHolder } from './internal/Comp
 import { CompositeFieldValueMap } from './internal/CompositeFieldValueMap';
 import { EntityDataManager } from './internal/EntityDataManager';
 import { SingleFieldHolder, SingleFieldValueHolder } from './internal/SingleFieldHolder';
-import { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
 import { mapKeys, mapMap } from './utils/collections/maps';
 import { areSetsEqual } from './utils/collections/sets';
 
@@ -55,16 +53,7 @@ export class AuthorizationResultBasedEntityLoader<
       TSelectedFields
     >,
     private readonly dataManager: EntityDataManager<TFields, TIDField>,
-    protected readonly metricsAdapter: IEntityMetricsAdapter,
-    public readonly invalidationUtils: EntityInvalidationUtils<
-      TFields,
-      TIDField,
-      TViewerContext,
-      TEntity,
-      TPrivacyPolicy,
-      TSelectedFields
-    >,
-    public readonly constructionUtils: EntityConstructionUtils<
+    private readonly constructionUtils: EntityConstructionUtils<
       TFields,
       TIDField,
       TViewerContext,

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -1,8 +1,6 @@
 import { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
 import { EnforcingEntityLoader } from './EnforcingEntityLoader';
 import { IEntityClass } from './Entity';
-import { EntityConstructionUtils } from './EntityConstructionUtils';
-import { EntityInvalidationUtils } from './EntityInvalidationUtils';
 import { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
 import { ReadonlyEntity } from './ReadonlyEntity';
@@ -73,35 +71,5 @@ export class EntityLoader<
       .getViewerScopedEntityCompanionForClass(this.entityClass)
       .getLoaderFactory()
       .forLoad(this.queryContext, { previousValue: null, cascadingDeleteCause: null });
-  }
-
-  /**
-   * Entity cache invalidation utilities.
-   * Calling into these should only be necessary in rare cases.
-   */
-  public invalidationUtils(): EntityInvalidationUtils<
-    TFields,
-    TIDField,
-    TViewerContext,
-    TEntity,
-    TPrivacyPolicy,
-    TSelectedFields
-  > {
-    return this.withAuthorizationResults().invalidationUtils;
-  }
-
-  /**
-   * Entity construction and validation utilities.
-   * Calling into these should only be necessary in rare cases.
-   */
-  public constructionUtils(): EntityConstructionUtils<
-    TFields,
-    TIDField,
-    TViewerContext,
-    TEntity,
-    TPrivacyPolicy,
-    TSelectedFields
-  > {
-    return this.withAuthorizationResults().constructionUtils;
   }
 }

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -39,6 +39,52 @@ export class EntityLoaderFactory<
     protected readonly metricsAdapter: IEntityMetricsAdapter,
   ) {}
 
+  invalidationUtils(): EntityInvalidationUtils<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new EntityInvalidationUtils(
+      this.entityCompanion.entityCompanionDefinition.entityConfiguration,
+      this.entityCompanion.entityCompanionDefinition.entityClass,
+      this.dataManager,
+      this.metricsAdapter,
+    );
+  }
+
+  constructionUtils(
+    viewerContext: TViewerContext,
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+  ): EntityConstructionUtils<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return new EntityConstructionUtils(
+      viewerContext,
+      queryContext,
+      privacyPolicyEvaluationContext,
+      this.entityCompanion.entityCompanionDefinition.entityConfiguration,
+      this.entityCompanion.entityCompanionDefinition.entityClass,
+      this.entityCompanion.entityCompanionDefinition.entitySelectedFields,
+      this.entityCompanion.privacyPolicy,
+      this.metricsAdapter,
+    );
+  }
+
   /**
    * Vend loader for loading an entity in a given query context.
    * @param viewerContext - viewer context of loading user
@@ -62,21 +108,10 @@ export class EntityLoaderFactory<
     TPrivacyPolicy,
     TSelectedFields
   > {
-    const invalidationUtils = new EntityInvalidationUtils(
-      this.entityCompanion.entityCompanionDefinition.entityConfiguration,
-      this.entityCompanion.entityCompanionDefinition.entityClass,
-      this.dataManager,
-      this.metricsAdapter,
-    );
-    const constructionUtils = new EntityConstructionUtils(
+    const constructionUtils = this.constructionUtils(
       viewerContext,
       queryContext,
       privacyPolicyEvaluationContext,
-      this.entityCompanion.entityCompanionDefinition.entityConfiguration,
-      this.entityCompanion.entityCompanionDefinition.entityClass,
-      this.entityCompanion.entityCompanionDefinition.entitySelectedFields,
-      this.entityCompanion.privacyPolicy,
-      this.metricsAdapter,
     );
 
     return new AuthorizationResultBasedEntityLoader(
@@ -84,8 +119,6 @@ export class EntityLoaderFactory<
       this.entityCompanion.entityCompanionDefinition.entityConfiguration,
       this.entityCompanion.entityCompanionDefinition.entityClass,
       this.dataManager,
-      this.metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
   }

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -6,7 +6,6 @@ import { EnforcingEntityAssociationLoader } from './EnforcingEntityAssociationLo
 import { EnforcingEntityLoader } from './EnforcingEntityLoader';
 import { IEntityClass } from './Entity';
 import { EntityAssociationLoader } from './EntityAssociationLoader';
-import { EntityConstructionUtils } from './EntityConstructionUtils';
 import { EntityInvalidationUtils } from './EntityInvalidationUtils';
 import { EntityLoader } from './EntityLoader';
 import { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
@@ -232,7 +231,7 @@ export abstract class ReadonlyEntity<
 
   /**
    * Utilities for entity invalidation.
-   * Calling into these should only be necessary in rare cases.
+   * Call these manually to keep entity cache consistent when performing operations outside of the entity framework.
    */
   static invalidationUtils<
     TMFields extends object,
@@ -258,10 +257,6 @@ export abstract class ReadonlyEntity<
       TMSelectedFields
     >,
     viewerContext: TMViewerContext2,
-    queryContext: EntityQueryContext = viewerContext
-      .getViewerScopedEntityCompanionForClass(this)
-      .getQueryContextProvider()
-      .getQueryContext(),
   ): EntityInvalidationUtils<
     TMFields,
     TMIDField,
@@ -270,49 +265,9 @@ export abstract class ReadonlyEntity<
     TMPrivacyPolicy,
     TMSelectedFields
   > {
-    return new EntityLoader(viewerContext, queryContext, this).invalidationUtils();
-  }
-
-  /**
-   * Utilities for entity construction.
-   * Calling into these should only be necessary in rare cases.
-   */
-  static constructionUtils<
-    TMFields extends object,
-    TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
-    TMViewerContext extends ViewerContext,
-    TMViewerContext2 extends TMViewerContext,
-    TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
-    TMPrivacyPolicy extends EntityPrivacyPolicy<
-      TMFields,
-      TMIDField,
-      TMViewerContext,
-      TMEntity,
-      TMSelectedFields
-    >,
-    TMSelectedFields extends keyof TMFields = keyof TMFields,
-  >(
-    this: IEntityClass<
-      TMFields,
-      TMIDField,
-      TMViewerContext,
-      TMEntity,
-      TMPrivacyPolicy,
-      TMSelectedFields
-    >,
-    viewerContext: TMViewerContext2,
-    queryContext: EntityQueryContext = viewerContext
+    return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
-      .getQueryContextProvider()
-      .getQueryContext(),
-  ): EntityConstructionUtils<
-    TMFields,
-    TMIDField,
-    TMViewerContext,
-    TMEntity,
-    TMPrivacyPolicy,
-    TMSelectedFields
-  > {
-    return new EntityLoader(viewerContext, queryContext, this).constructionUtils();
+      .getLoaderFactory()
+      .invalidationUtils();
   }
 }

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -1,4 +1,6 @@
 import { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
+import { EntityConstructionUtils } from './EntityConstructionUtils';
+import { EntityInvalidationUtils } from './EntityInvalidationUtils';
 import { EntityLoaderFactory } from './EntityLoaderFactory';
 import { EntityPrivacyPolicy, EntityPrivacyPolicyEvaluationContext } from './EntityPrivacyPolicy';
 import { EntityQueryContext } from './EntityQueryContext';
@@ -33,6 +35,41 @@ export class ViewerScopedEntityLoaderFactory<
     >,
     private readonly viewerContext: TViewerContext,
   ) {}
+
+  invalidationUtils(): EntityInvalidationUtils<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return this.entityLoaderFactory.invalidationUtils();
+  }
+
+  constructionUtils(
+    queryContext: EntityQueryContext,
+    privacyPolicyEvaluationContext: EntityPrivacyPolicyEvaluationContext<
+      TFields,
+      TIDField,
+      TViewerContext,
+      TEntity,
+      TSelectedFields
+    >,
+  ): EntityConstructionUtils<
+    TFields,
+    TIDField,
+    TViewerContext,
+    TEntity,
+    TPrivacyPolicy,
+    TSelectedFields
+  > {
+    return this.entityLoaderFactory.constructionUtils(
+      this.viewerContext,
+      queryContext,
+      privacyPolicyEvaluationContext,
+    );
+  }
 
   forLoad(
     queryContext: EntityQueryContext,

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
@@ -7,7 +7,6 @@ import { EntityCompanionDefinition } from '../EntityCompanionProvider';
 import { EntityConfiguration } from '../EntityConfiguration';
 import { EntityConstructionUtils } from '../EntityConstructionUtils';
 import { StringField } from '../EntityFields';
-import { EntityInvalidationUtils } from '../EntityInvalidationUtils';
 import { EntityPrivacyPolicy, EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
 import { ViewerContext } from '../ViewerContext';
 import { EntityDataManager } from '../internal/EntityDataManager';
@@ -165,12 +164,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       metricsAdapter,
       TestEntity.name,
     );
-    const invalidationUtils = new EntityInvalidationUtils(
-      testEntityConfiguration,
-      TestEntity,
-      dataManager,
-      metricsAdapter,
-    );
     const constructionUtils = new EntityConstructionUtils(
       viewerContext,
       queryContext,
@@ -186,8 +179,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       testEntityConfiguration,
       TestEntity,
       dataManager,
-      metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
 

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -90,12 +90,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       instance(mock<IEntityMetricsAdapter>()),
       TestEntity.name,
     );
-    const invalidationUtils = new EntityInvalidationUtils(
-      testEntityConfiguration,
-      TestEntity,
-      dataManager,
-      metricsAdapter,
-    );
     const constructionUtils = new EntityConstructionUtils(
       viewerContext,
       queryContext,
@@ -111,8 +105,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       testEntityConfiguration,
       TestEntity,
       dataManager,
-      metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
 
@@ -240,12 +232,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       instance(mock<IEntityMetricsAdapter>()),
       TestEntity.name,
     );
-    const invalidationUtils = new EntityInvalidationUtils(
-      testEntityConfiguration,
-      TestEntity,
-      dataManager,
-      metricsAdapter,
-    );
     const constructionUtils = new EntityConstructionUtils(
       viewerContext,
       queryContext,
@@ -261,8 +247,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       testEntityConfiguration,
       TestEntity,
       dataManager,
-      metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
 
@@ -385,12 +369,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       instance(mock<IEntityMetricsAdapter>()),
       TestEntity.name,
     );
-    const invalidationUtils = new EntityInvalidationUtils(
-      testEntityConfiguration,
-      TestEntity,
-      dataManager,
-      metricsAdapter,
-    );
     const constructionUtils = new EntityConstructionUtils(
       viewerContext,
       queryContext,
@@ -406,8 +384,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       testEntityConfiguration,
       TestEntity,
       dataManager,
-      metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
     const entity = await enforceAsyncResult(entityLoader.loadByIDAsync(id1));
@@ -423,21 +399,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
   });
 
   it('invalidates upon invalidate one', async () => {
-    const viewerContext = instance(mock(ViewerContext));
-    const privacyPolicyEvaluationContext =
-      instance(
-        mock<
-          EntityPrivacyPolicyEvaluationContext<
-            TestFields,
-            'customIdField',
-            ViewerContext,
-            TestEntity
-          >
-        >(),
-      );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
-    const queryContext = new StubQueryContextProvider().getQueryContext();
-    const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
     const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
     const dataManagerInstance = instance(dataManagerMock);
 
@@ -448,29 +410,10 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       dataManagerInstance,
       metricsAdapter,
     );
-    const constructionUtils = new EntityConstructionUtils(
-      viewerContext,
-      queryContext,
-      privacyPolicyEvaluationContext,
-      testEntityConfiguration,
-      TestEntity,
-      /* entitySelectedFields */ undefined,
-      privacyPolicy,
-      metricsAdapter,
-    );
-    const entityLoader = new AuthorizationResultBasedEntityLoader(
-      queryContext,
-      testEntityConfiguration,
-      TestEntity,
-      dataManagerInstance,
-      metricsAdapter,
-      invalidationUtils,
-      constructionUtils,
-    );
 
     const date = new Date();
 
-    await entityLoader.invalidationUtils.invalidateFieldsAsync({
+    await invalidationUtils.invalidateFieldsAsync({
       customIdField: id1,
       testIndexedField: 'h1',
       intField: 5,
@@ -522,21 +465,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
   });
 
   it('invalidates upon invalidate by entity', async () => {
-    const viewerContext = instance(mock(ViewerContext));
-    const privacyPolicyEvaluationContext =
-      instance(
-        mock<
-          EntityPrivacyPolicyEvaluationContext<
-            TestFields,
-            'customIdField',
-            ViewerContext,
-            TestEntity
-          >
-        >(),
-      );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
-    const queryContext = new StubQueryContextProvider().getQueryContext();
-    const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
     const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
     const dataManagerInstance = instance(dataManagerMock);
 
@@ -560,26 +489,8 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       dataManagerInstance,
       metricsAdapter,
     );
-    const constructionUtils = new EntityConstructionUtils(
-      viewerContext,
-      queryContext,
-      privacyPolicyEvaluationContext,
-      testEntityConfiguration,
-      TestEntity,
-      /* entitySelectedFields */ undefined,
-      privacyPolicy,
-      metricsAdapter,
-    );
-    const entityLoader = new AuthorizationResultBasedEntityLoader(
-      queryContext,
-      testEntityConfiguration,
-      TestEntity,
-      dataManagerInstance,
-      metricsAdapter,
-      invalidationUtils,
-      constructionUtils,
-    );
-    await entityLoader.invalidationUtils.invalidateEntityAsync(entityInstance);
+
+    await invalidationUtils.invalidateEntityAsync(entityInstance);
 
     verify(dataManagerMock.invalidateKeyValuePairsAsync(anything())).once();
     verify(
@@ -624,21 +535,8 @@ describe(AuthorizationResultBasedEntityLoader, () => {
   });
 
   it('invalidates upon invalidate by entity within transaction', async () => {
-    const viewerContext = instance(mock(ViewerContext));
-    const privacyPolicyEvaluationContext =
-      instance(
-        mock<
-          EntityPrivacyPolicyEvaluationContext<
-            TestFields,
-            'customIdField',
-            ViewerContext,
-            TestEntity
-          >
-        >(),
-      );
     const metricsAdapter = instance(mock<IEntityMetricsAdapter>());
 
-    const privacyPolicy = instance(mock(TestEntityPrivacyPolicy));
     const dataManagerMock = mock<EntityDataManager<TestFields, 'customIdField'>>();
     const dataManagerInstance = instance(dataManagerMock);
 
@@ -663,26 +561,7 @@ describe(AuthorizationResultBasedEntityLoader, () => {
         dataManagerInstance,
         metricsAdapter,
       );
-      const constructionUtils = new EntityConstructionUtils(
-        viewerContext,
-        queryContext,
-        privacyPolicyEvaluationContext,
-        testEntityConfiguration,
-        TestEntity,
-        /* entitySelectedFields */ undefined,
-        privacyPolicy,
-        metricsAdapter,
-      );
-      const entityLoader = new AuthorizationResultBasedEntityLoader(
-        queryContext,
-        testEntityConfiguration,
-        TestEntity,
-        dataManagerInstance,
-        metricsAdapter,
-        invalidationUtils,
-        constructionUtils,
-      );
-      entityLoader.invalidationUtils.invalidateEntityForTransaction(queryContext, entityInstance);
+      invalidationUtils.invalidateEntityForTransaction(queryContext, entityInstance);
 
       verify(
         dataManagerMock.invalidateKeyValuePairsForTransaction(queryContext, anything()),
@@ -781,12 +660,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const privacyPolicy = instance(privacyPolicyMock);
     const dataManagerInstance = instance(dataManagerMock);
 
-    const invalidationUtils = new EntityInvalidationUtils(
-      testEntityConfiguration,
-      TestEntity,
-      dataManagerInstance,
-      metricsAdapter,
-    );
     const constructionUtils = new EntityConstructionUtils(
       viewerContext,
       queryContext,
@@ -802,8 +675,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       testEntityConfiguration,
       TestEntity,
       dataManagerInstance,
-      metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
 
@@ -839,12 +710,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
 
     const dataManagerInstance = instance(dataManagerMock);
 
-    const invalidationUtils = new EntityInvalidationUtils(
-      testEntityConfiguration,
-      TestEntity,
-      dataManagerInstance,
-      metricsAdapter,
-    );
     const constructionUtils = new EntityConstructionUtils(
       viewerContext,
       queryContext,
@@ -860,8 +725,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
       testEntityConfiguration,
       TestEntity,
       dataManagerInstance,
-      metricsAdapter,
-      invalidationUtils,
       constructionUtils,
     );
 

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from '@jest/globals';
 
 import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
 import { EnforcingEntityLoader } from '../EnforcingEntityLoader';
-import { EntityConstructionUtils } from '../EntityConstructionUtils';
 import { EntityInvalidationUtils } from '../EntityInvalidationUtils';
 import { EntityLoader } from '../EntityLoader';
 import { ViewerContext } from '../ViewerContext';
@@ -34,16 +33,6 @@ describe(EntityLoader, () => {
       const viewerContext = new ViewerContext(companionProvider);
       expect(SimpleTestEntity.invalidationUtils(viewerContext)).toBeInstanceOf(
         EntityInvalidationUtils,
-      );
-    });
-  });
-
-  describe('constructionUtils', () => {
-    it('returns a instance of EntityConstructionUtils', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.constructionUtils(viewerContext)).toBeInstanceOf(
-        EntityConstructionUtils,
       );
     });
   });

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -1511,7 +1511,6 @@ describe(EntityMutatorFactory, () => {
         >
       >(EntityConstructionUtils);
     when(entityConstructionUtilsMock.constructEntity(anything())).thenReturn(fakeEntity);
-    when(entityLoaderMock.constructionUtils).thenReturn(instance(entityConstructionUtilsMock));
     const entityLoader = instance(entityLoaderMock);
 
     const entityLoaderFactoryMock =
@@ -1532,6 +1531,13 @@ describe(EntityMutatorFactory, () => {
         anything(),
       ),
     ).thenReturn(entityLoader);
+    when(
+      entityLoaderFactoryMock.constructionUtils(
+        viewerContext,
+        anyOfClass(EntityTransactionalQueryContext),
+        anything(),
+      ),
+    ).thenReturn(instance(entityConstructionUtilsMock));
     const entityLoaderFactory = instance(entityLoaderFactoryMock);
 
     const rejectionError = new Error();
@@ -1646,7 +1652,6 @@ describe(EntityMutatorFactory, () => {
         >
       >(EntityConstructionUtils);
     when(entityConstructionUtilsMock.constructEntity(anything())).thenReturn(fakeEntity);
-    when(entityLoaderMock.constructionUtils).thenReturn(instance(entityConstructionUtilsMock));
     const entityLoader = instance(entityLoaderMock);
 
     const entityLoaderFactoryMock =
@@ -1667,6 +1672,13 @@ describe(EntityMutatorFactory, () => {
         anything(),
       ),
     ).thenReturn(entityLoader);
+    when(
+      entityLoaderFactoryMock.constructionUtils(
+        viewerContext,
+        anyOfClass(EntityTransactionalQueryContext),
+        anything(),
+      ),
+    ).thenReturn(instance(entityConstructionUtilsMock));
     const entityLoaderFactory = instance(entityLoaderFactoryMock);
 
     const rejectionError = new Error();

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -46,7 +46,7 @@ describe(EntitySecondaryCacheLoader, () => {
 
       const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
         secondaryEntityCache,
-        SimpleTestEntity.loaderWithAuthorizationResults(vc1),
+        EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(SimpleTestEntity, vc1),
       );
 
       await secondaryCacheLoader.loadManyAsync([loadParams]);
@@ -70,8 +70,11 @@ describe(EntitySecondaryCacheLoader, () => {
       const secondaryEntityCache = instance(secondaryEntityCacheMock);
 
       const loader = SimpleTestEntity.loaderWithAuthorizationResults(vc1);
-      const spiedPrivacyPolicy = spy(loader.constructionUtils['privacyPolicy']);
-      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(secondaryEntityCache, loader);
+      const spiedPrivacyPolicy = spy(loader['constructionUtils']['privacyPolicy']);
+      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
+        secondaryEntityCache,
+        EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(SimpleTestEntity, vc1),
+      );
 
       const result = await secondaryCacheLoader.loadManyAsync([loadParams]);
       expect(result.get(loadParams)?.enforceValue().getID()).toEqual(createdEntity.getID());
@@ -98,8 +101,10 @@ describe(EntitySecondaryCacheLoader, () => {
       const secondaryEntityCacheMock =
         mock<ISecondaryEntityCache<SimpleTestFields, TestLoadParams>>();
       const secondaryEntityCache = instance(secondaryEntityCacheMock);
-      const loader = SimpleTestEntity.loaderWithAuthorizationResults(vc1);
-      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(secondaryEntityCache, loader);
+      const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
+        secondaryEntityCache,
+        EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(SimpleTestEntity, vc1),
+      );
       await secondaryCacheLoader.invalidateManyAsync([loadParams]);
 
       verify(secondaryEntityCacheMock.invalidateManyAsync(deepEqual([loadParams]))).once();

--- a/packages/entity/src/__tests__/GenericSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/GenericSecondaryEntityCache-test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from '@jest/globals';
 import nullthrows from 'nullthrows';
 
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
+import { EntityConstructionUtils } from '../EntityConstructionUtils';
 import { EntitySecondaryCacheLoader } from '../EntitySecondaryCacheLoader';
 import { GenericSecondaryEntityCache } from '../GenericSecondaryEntityCache';
 import { IEntityGenericCacher } from '../IEntityGenericCacher';
@@ -100,6 +102,28 @@ class TestSecondaryCacheLoader extends EntitySecondaryCacheLoader<
 > {
   public databaseLoadCount = 0;
 
+  constructor(
+    secondaryEntityCache: TestSecondaryEntityCache<TestFields, 'customIdField', TestLoadParams>,
+    constructionUtils: EntityConstructionUtils<
+      TestFields,
+      'customIdField',
+      ViewerContext,
+      TestEntity,
+      TestEntityPrivacyPolicy,
+      keyof TestFields
+    >,
+    private readonly entityLoader: AuthorizationResultBasedEntityLoader<
+      TestFields,
+      'customIdField',
+      ViewerContext,
+      TestEntity,
+      TestEntityPrivacyPolicy,
+      keyof TestFields
+    >,
+  ) {
+    super(secondaryEntityCache, constructionUtils);
+  }
+
   protected override async fetchObjectsFromDatabaseAsync(
     loadParamsArray: readonly Readonly<TestLoadParams>[],
   ): Promise<ReadonlyMap<Readonly<Readonly<TestLoadParams>>, Readonly<TestFields> | null>> {
@@ -129,6 +153,7 @@ describe(GenericSecondaryEntityCache, () => {
         new TestGenericCacher(),
         (params) => `intValue.${params.intValue}`,
       ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(TestEntity, viewerContext),
       TestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 
@@ -165,6 +190,7 @@ describe(GenericSecondaryEntityCache, () => {
         new TestGenericCacher(),
         (params) => `intValue.${params.intValue}`,
       ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(TestEntity, viewerContext),
       TestEntity.loaderWithAuthorizationResults(viewerContext),
     );
 

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -5,7 +5,6 @@ import { AuthorizationResultBasedEntityAssociationLoader } from '../Authorizatio
 import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
 import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader';
 import { EnforcingEntityLoader } from '../EnforcingEntityLoader';
-import { EntityConstructionUtils } from '../EntityConstructionUtils';
 import { EntityInvalidationUtils } from '../EntityInvalidationUtils';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -221,16 +220,6 @@ describe(ReadonlyEntity, () => {
       const viewerContext = new ViewerContext(companionProvider);
       expect(SimpleTestEntity.invalidationUtils(viewerContext)).toBeInstanceOf(
         EntityInvalidationUtils,
-      );
-    });
-  });
-
-  describe('constructionUtils', () => {
-    it('creates a new EntityConstructionUtils', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
-      expect(SimpleTestEntity.constructionUtils(viewerContext)).toBeInstanceOf(
-        EntityConstructionUtils,
       );
     });
   });

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -355,7 +355,12 @@ async function canViewerDeleteInternalAsync<
         .entityConfiguration;
 
     const entityCompanion = viewerContext.getViewerScopedEntityCompanionForClass(inboundEdge);
-    const loader = entityCompanion.getLoaderFactory().forLoad(queryContext, {
+    const loaderFactory = entityCompanion.getLoaderFactory();
+    const loader = loaderFactory.forLoad(queryContext, {
+      previousValue: null,
+      cascadingDeleteCause: newCascadingDeleteCause,
+    });
+    const constructionUtils = loaderFactory.constructionUtils(queryContext, {
       previousValue: null,
       cascadingDeleteCause: newCascadingDeleteCause,
     });
@@ -443,14 +448,6 @@ async function canViewerDeleteInternalAsync<
           // privacy policy as it would be after the cascading SET NULL operation
           const previousAndSyntheticEntitiesForInboundEdge = entitiesForInboundEdge.map(
             (entity) => {
-              const entityLoader = viewerContext
-                .getViewerScopedEntityCompanionForClass(inboundEdge)
-                .getLoaderFactory()
-                .forLoad(queryContext, {
-                  previousValue: entity,
-                  cascadingDeleteCause: newCascadingDeleteCause,
-                });
-
               const allFields = entity.getAllDatabaseFields();
               const syntheticFields = {
                 ...allFields,
@@ -459,8 +456,7 @@ async function canViewerDeleteInternalAsync<
 
               return {
                 previousValue: entity,
-                syntheticallyUpdatedValue:
-                  entityLoader.constructionUtils.constructEntity(syntheticFields),
+                syntheticallyUpdatedValue: constructionUtils.constructEntity(syntheticFields),
               };
             },
           );


### PR DESCRIPTION
# Why

In #410 we split out `EntityLoaderUtils` into two classes:
- EntityInvalidationUtils - functions for invalidating entity caches from application code when underlying data is mutated outside of the entity framework
- EntityConstructorUtils - functions for constructing and authorizing entities.

Originally, these were both public due to them being the same class. Now, with them separated, we can better restrict access to entity construction which should only be done within the framework itself.

# How

Make constructor utils private everywhere except EntityLoaderFactory, which is deep enough in the abstraction that it's not immediately usable by top-level entity APIs (static methods on Entity/ReadonlyEntity, loader classes).

# Test Plan

`yarn tsc`, CI