### PR TITLE
feat: Add raw sqlfragment orderBy capability for pagination

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -14,6 +14,7 @@ import {
   SQLFragment,
   TableFieldMultiValueEqualityCondition,
   TableFieldSingleValueEqualityCondition,
+  TableOrderByClause,
   TableQuerySelectionModifiers,
   TableQuerySelectionModifiersWithOrderByFragment,
 } from '@expo/entity-database-adapter-knex';
@@ -105,10 +106,7 @@ export class StubPostgresDatabaseAdapter<
   }
 
   private static compareByOrderBys(
-    orderBys: {
-      columnName: string;
-      order: OrderByOrdering;
-    }[],
+    orderBys: TableOrderByClause[],
     objectA: { [key: string]: any },
     objectB: { [key: string]: any },
   ): 0 | 1 | -1 {
@@ -117,6 +115,9 @@ export class StubPostgresDatabaseAdapter<
     }
 
     const currentOrderBy = orderBys[0]!;
+    if (!('columnName' in currentOrderBy)) {
+      throw new Error('SQL fragment order by not supported for StubDatabaseAdapter');
+    }
     const aField = objectA[currentOrderBy.columnName];
     const bField = objectB[currentOrderBy.columnName];
     switch (currentOrderBy.order) {

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -782,6 +782,20 @@ describe('compareByOrderBys', () => {
         ),
       ).toEqual(expectedResult);
     });
+    it('throws for SQL fragment order by', () => {
+      expect(() =>
+        StubPostgresDatabaseAdapter['compareByOrderBys'](
+          [
+            {
+              columnFragment: sql`some_function(col)`,
+              order: OrderByOrdering.ASCENDING,
+            },
+          ],
+          { hello: 'a' },
+          { hello: 'b' },
+        ),
+      ).toThrow('SQL fragment order by not supported for StubDatabaseAdapter');
+    });
     it('works for empty', () => {
       expect(
         StubPostgresDatabaseAdapter['compareByOrderBys'](

--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -19,20 +19,33 @@ import { SQLFragment } from './SQLOperator';
 import type { Connection, PageInfo } from './internal/EntityKnexDataManager';
 import { EntityKnexDataManager } from './internal/EntityKnexDataManager';
 
-export interface EntityLoaderOrderByClause<
+export type EntityLoaderOrderByClause<
   TFields extends Record<string, any>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> {
-  /**
-   * The field name to order by.
-   */
-  fieldName: TSelectedFields;
+> =
+  | {
+      /**
+       * The field name to order by.
+       */
+      fieldName: TSelectedFields;
 
-  /**
-   * The OrderByOrdering to order by.
-   */
-  order: OrderByOrdering;
-}
+      /**
+       * The OrderByOrdering to order by.
+       */
+      order: OrderByOrdering;
+    }
+  | {
+      /**
+       * The SQL fragment to order by, which can reference selected fields. Example: `COALESCE(NULLIF(display_name, ''), split_part(full_name, '/', 2))`.
+       * May not contain ASC or DESC, as ordering direction is controlled by the `order` property.
+       */
+      fieldFragment: SQLFragment;
+
+      /**
+       * The OrderByOrdering to order by.
+       */
+      order: OrderByOrdering;
+    };
 
 /**
  * SQL modifiers that only affect the selection but not the projection.

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -147,7 +147,14 @@ export class PostgresEntityDatabaseAdapter<
 
     if (orderBy !== undefined) {
       for (const orderBySpecification of orderBy) {
-        ret = ret.orderBy(orderBySpecification.columnName, orderBySpecification.order);
+        if ('columnName' in orderBySpecification) {
+          ret = ret.orderBy(orderBySpecification.columnName, orderBySpecification.order);
+        } else {
+          ret = ret.orderByRaw(
+            `(${orderBySpecification.columnFragment.sql}) ${orderBySpecification.order}`,
+            orderBySpecification.columnFragment.getKnexBindings(),
+          );
+        }
       }
     }
 

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -16,6 +16,7 @@ import {
   OrderByOrdering,
   TableFieldMultiValueEqualityCondition,
   TableFieldSingleValueEqualityCondition,
+  TableOrderByClause,
   TableQuerySelectionModifiers,
   TableQuerySelectionModifiersWithOrderByFragment,
 } from '../../BasePostgresEntityDatabaseAdapter';
@@ -106,10 +107,7 @@ export class StubPostgresDatabaseAdapter<
   }
 
   private static compareByOrderBys(
-    orderBys: {
-      columnName: string;
-      order: OrderByOrdering;
-    }[],
+    orderBys: TableOrderByClause[],
     objectA: { [key: string]: any },
     objectB: { [key: string]: any },
   ): 0 | 1 | -1 {
@@ -118,6 +116,9 @@ export class StubPostgresDatabaseAdapter<
     }
 
     const currentOrderBy = orderBys[0]!;
+    if (!('columnName' in currentOrderBy)) {
+      throw new Error('SQL fragment order by not supported for StubDatabaseAdapter');
+    }
     const aField = objectA[currentOrderBy.columnName];
     const bField = objectB[currentOrderBy.columnName];
     switch (currentOrderBy.order) {


### PR DESCRIPTION
# Why

One missing piece from pagination is the ability to order by a SQL fragment. This is useful for cases like needing to apply postgres transforms or coalescing to the columns in the order by clause.

Note that this, in combination with `loadBySQL` will completely replace the need for `loadManyByRawWhereClause` (including it's orderByRaw variant), as well as `orderByFragment` in the new pagination code, which is done in a PR upstack.

# How

Make order by specifications either be able to use SQLFragment to specify the field selection but not the ASC/DESC since the framework still needs to retain control of those for pagination purposes.

# Test Plan

Run new added tests.