### PR TITLE
feat!: convert all raw order bys to use same mechanism and syntax

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -16,7 +16,6 @@ import {
   TableFieldSingleValueEqualityCondition,
   TableOrderByClause,
   TableQuerySelectionModifiers,
-  TableQuerySelectionModifiersWithOrderByFragment,
 } from '@expo/entity-database-adapter-knex';
 import invariant from 'invariant';
 import { v7 as uuidv7 } from 'uuid';
@@ -206,7 +205,7 @@ export class StubPostgresDatabaseAdapter<
     _queryInterface: any,
     _tableName: string,
     _sqlFragment: SQLFragment,
-    _querySelectionModifiers: TableQuerySelectionModifiersWithOrderByFragment,
+    _querySelectionModifiers: TableQuerySelectionModifiers,
   ): Promise<object[]> {
     throw new Error('SQL fragments not supported for StubDatabaseAdapter');
   }

--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -70,26 +70,6 @@ export interface EntityLoaderQuerySelectionModifiers<
   limit?: number;
 }
 
-export interface EntityLoaderQuerySelectionModifiersWithOrderByRaw<
-  TFields extends Record<string, any>,
-  TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> {
-  /**
-   * Order the entities by a raw SQL `ORDER BY` clause.
-   */
-  orderByRaw?: string;
-}
-
-export interface EntityLoaderQuerySelectionModifiersWithOrderByFragment<
-  TFields extends Record<string, any>,
-  TSelectedFields extends keyof TFields = keyof TFields,
-> extends EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> {
-  /**
-   * Order the entities by a SQL fragment `ORDER BY` clause.
-   */
-  orderByFragment?: SQLFragment;
-}
-
 interface SearchSpecificationBase<
   TFields extends Record<string, any>,
   TSelectedFields extends keyof TFields = keyof TFields,
@@ -323,10 +303,7 @@ export class AuthorizationResultBasedKnexEntityLoader<
   async loadManyByRawWhereClauseAsync(
     rawWhereClause: string,
     bindings: any[] | object,
-    querySelectionModifiers: EntityLoaderQuerySelectionModifiersWithOrderByRaw<
-      TFields,
-      TSelectedFields
-    > = {},
+    querySelectionModifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): Promise<readonly Result<TEntity>[]> {
     const fieldObjects = await this.knexDataManager.loadManyByRawWhereClauseAsync(
       this.queryContext,
@@ -343,10 +320,7 @@ export class AuthorizationResultBasedKnexEntityLoader<
    */
   loadManyBySQL(
     fragment: SQLFragment,
-    modifiers: EntityLoaderQuerySelectionModifiersWithOrderByFragment<
-      TFields,
-      TSelectedFields
-    > = {},
+    modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): AuthorizationResultBasedSQLQueryBuilder<
     TFields,
     TIDField,
@@ -432,7 +406,7 @@ export class AuthorizationResultBasedSQLQueryBuilder<
     >,
     private readonly queryContext: EntityQueryContext,
     sqlFragment: SQLFragment,
-    modifiers: EntityLoaderQuerySelectionModifiersWithOrderByFragment<TFields, TSelectedFields>,
+    modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields>,
   ) {
     super(sqlFragment, modifiers);
   }

--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -119,24 +119,6 @@ export interface PostgresQuerySelectionModifiers<TFields extends Record<string, 
   limit?: number;
 }
 
-export interface PostgresQuerySelectionModifiersWithOrderByRaw<
-  TFields extends Record<string, any>,
-> extends PostgresQuerySelectionModifiers<TFields> {
-  /**
-   * Order the entities by a raw SQL `ORDER BY` clause.
-   */
-  orderByRaw?: string;
-}
-
-export interface PostgresQuerySelectionModifiersWithOrderByFragment<
-  TFields extends Record<string, any>,
-> extends PostgresQuerySelectionModifiers<TFields> {
-  /**
-   * Order the entities by a SQL fragment `ORDER BY` clause.
-   */
-  orderByFragment?: SQLFragment;
-}
-
 export type TableOrderByClause =
   | {
       columnName: string;
@@ -151,15 +133,6 @@ export interface TableQuerySelectionModifiers {
   orderBy: TableOrderByClause[] | undefined;
   offset: number | undefined;
   limit: number | undefined;
-}
-
-export interface TableQuerySelectionModifiersWithOrderByRaw extends TableQuerySelectionModifiers {
-  orderByRaw: string | undefined;
-  orderByRawBindings?: readonly any[];
-}
-
-export interface TableQuerySelectionModifiersWithOrderByFragment extends TableQuerySelectionModifiers {
-  orderByFragment: SQLFragment | undefined;
 }
 
 export abstract class BasePostgresEntityDatabaseAdapter<
@@ -237,14 +210,14 @@ export abstract class BasePostgresEntityDatabaseAdapter<
     queryContext: EntityQueryContext,
     rawWhereClause: string,
     bindings: any[] | object,
-    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByRaw<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     const results = await this.fetchManyByRawWhereClauseInternalAsync(
       queryContext.getQueryInterface(),
       this.entityConfiguration.tableName,
       rawWhereClause,
       bindings,
-      this.convertToTableQueryModifiersWithOrderByRaw(querySelectionModifiers),
+      this.convertToTableQueryModifiers(querySelectionModifiers),
     );
 
     return results.map((result) =>
@@ -257,7 +230,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
     tableName: string,
     rawWhereClause: string,
     bindings: object | any[],
-    querySelectionModifiers: TableQuerySelectionModifiersWithOrderByRaw,
+    querySelectionModifiers: TableQuerySelectionModifiers,
   ): Promise<object[]>;
 
   /**
@@ -271,13 +244,13 @@ export abstract class BasePostgresEntityDatabaseAdapter<
   async fetchManyBySQLFragmentAsync(
     queryContext: EntityQueryContext,
     sqlFragment: SQLFragment,
-    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByFragment<TFields>,
+    querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     const results = await this.fetchManyBySQLFragmentInternalAsync(
       queryContext.getQueryInterface(),
       this.entityConfiguration.tableName,
       sqlFragment,
-      this.convertToTableQueryModifiersWithOrderByFragment(querySelectionModifiers),
+      this.convertToTableQueryModifiers(querySelectionModifiers),
     );
 
     return results.map((result) =>
@@ -289,26 +262,8 @@ export abstract class BasePostgresEntityDatabaseAdapter<
     queryInterface: Knex,
     tableName: string,
     sqlFragment: SQLFragment,
-    querySelectionModifiers: TableQuerySelectionModifiersWithOrderByFragment,
+    querySelectionModifiers: TableQuerySelectionModifiers,
   ): Promise<object[]>;
-
-  private convertToTableQueryModifiersWithOrderByRaw(
-    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByRaw<TFields>,
-  ): TableQuerySelectionModifiersWithOrderByRaw {
-    return {
-      ...this.convertToTableQueryModifiers(querySelectionModifiers),
-      orderByRaw: querySelectionModifiers.orderByRaw,
-    };
-  }
-
-  private convertToTableQueryModifiersWithOrderByFragment(
-    querySelectionModifiers: PostgresQuerySelectionModifiersWithOrderByFragment<TFields>,
-  ): TableQuerySelectionModifiersWithOrderByFragment {
-    return {
-      ...this.convertToTableQueryModifiers(querySelectionModifiers),
-      orderByFragment: querySelectionModifiers.orderByFragment,
-    };
-  }
 
   private convertToTableQueryModifiers(
     querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -11,8 +11,6 @@ import {
   AuthorizationResultBasedKnexEntityLoader,
   EntityLoaderLoadPageArgs,
   EntityLoaderQuerySelectionModifiers,
-  EntityLoaderQuerySelectionModifiersWithOrderByFragment,
-  EntityLoaderQuerySelectionModifiersWithOrderByRaw,
 } from './AuthorizationResultBasedKnexEntityLoader';
 import { FieldEqualityCondition } from './BasePostgresEntityDatabaseAdapter';
 import { BaseSQLQueryBuilder } from './BaseSQLQueryBuilder';
@@ -130,8 +128,7 @@ export class EnforcingKnexEntityLoader<
    * ```
    * @param rawWhereClause - SQL WHERE clause. Interpolated values should be specified as ?-placeholders or :key_name
    * @param bindings - values to bind to the placeholders in the WHERE clause
-   * @param querySelectionModifiers - limit, offset, and orderBy for the query. If orderBy is specified
-   * as orderByRaw, specify as string orderBy SQL clause with uncheckd literal values or ?-placeholders
+   * @param querySelectionModifiers - limit, offset, and orderBy for the query.
    * @returns entities matching the WHERE clause
    * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
    * @throws Error when rawWhereClause or bindings are invalid
@@ -139,10 +136,7 @@ export class EnforcingKnexEntityLoader<
   async loadManyByRawWhereClauseAsync(
     rawWhereClause: string,
     bindings: any[] | object,
-    querySelectionModifiers: EntityLoaderQuerySelectionModifiersWithOrderByRaw<
-      TFields,
-      TSelectedFields
-    > = {},
+    querySelectionModifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): Promise<readonly TEntity[]> {
     const entityResults = await this.knexEntityLoader.loadManyByRawWhereClauseAsync(
       rawWhereClause,
@@ -173,10 +167,7 @@ export class EnforcingKnexEntityLoader<
    */
   loadManyBySQL(
     fragment: SQLFragment,
-    modifiers: EntityLoaderQuerySelectionModifiersWithOrderByFragment<
-      TFields,
-      TSelectedFields
-    > = {},
+    modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): EnforcingSQLQueryBuilder<
     TFields,
     TIDField,
@@ -247,7 +238,7 @@ export class EnforcingSQLQueryBuilder<
       TSelectedFields
     >,
     sqlFragment: SQLFragment,
-    modifiers: EntityLoaderQuerySelectionModifiersWithOrderByFragment<TFields, TSelectedFields>,
+    modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields>,
   ) {
     super(sqlFragment, modifiers);
   }

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -18,7 +18,6 @@ import {
   TableFieldSingleValueEqualityCondition,
   TableOrderByClause,
   TableQuerySelectionModifiers,
-  TableQuerySelectionModifiersWithOrderByFragment,
 } from '../../BasePostgresEntityDatabaseAdapter';
 import { SQLFragment } from '../../SQLOperator';
 
@@ -207,7 +206,7 @@ export class StubPostgresDatabaseAdapter<
     _queryInterface: any,
     _tableName: string,
     _sqlFragment: SQLFragment,
-    _querySelectionModifiers: TableQuerySelectionModifiersWithOrderByFragment,
+    _querySelectionModifiers: TableQuerySelectionModifiers,
   ): Promise<object[]> {
     throw new Error('SQL fragments not supported for StubDatabaseAdapter');
   }


### PR DESCRIPTION
# Why

#457 added a new mechanism for specifying ORDER BY clauses using SQLFragment that aligns a lot better with the loader APIs than having separate `orderByRaw`/`orderByFragment` fields in the query modifiers.

# How

Replace all with the new consistent order by in order field, update code to handle that.

One neat side-effect is that we no longer need the hard-to-follow direction-specific ordering in deep methods like `buildTrigramExactMatchPriority` since now we can have those just produce a SQLFragment and reverse the ordering the same as all the other pagination methods.

# Test Plan

Run all tests.