### PR TITLE
chore: deprecate loadManyByRawWhereClause

### DIFF
--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -299,6 +299,8 @@ export class AuthorizationResultBasedKnexEntityLoader<
    * Authorization-result-based version of the EnforcingKnexEntityLoader method by the same name.
    * @returns array of entity results that match the query, where result error can be UnauthorizedError
    * @throws Error when rawWhereClause or bindings are invalid
+   *
+   * @deprecated Use loadManyBySQL instead for safer value bindings and more flexible query building.
    */
   async loadManyByRawWhereClauseAsync(
     rawWhereClause: string,

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -132,6 +132,8 @@ export class EnforcingKnexEntityLoader<
    * @returns entities matching the WHERE clause
    * @throws EntityNotAuthorizedError when viewer is not authorized to view one or more of the returned entities
    * @throws Error when rawWhereClause or bindings are invalid
+   *
+   * @deprecated Use loadManyBySQL instead for safer value bindings and more flexible query building.
    */
   async loadManyByRawWhereClauseAsync(
     rawWhereClause: string,


### PR DESCRIPTION
# Why

Now that `loadManyBySQL` supports all the features of this method (including raw order by), deprecate it.

# How

Mark as deprecated in docblock.

# Test Plan

`yarn tsc`