### PR TITLE
feat: Add action parameter to privacy policy rule evaluation

### DIFF
--- a/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
@@ -5,6 +5,7 @@ import {
   ViewerContext,
   PrivacyPolicyRule,
   RuleEvaluationResult,
+  EntityAuthorizationAction,
 } from '@expo/entity';
 import { describe, expect, test } from '@jest/globals';
 
@@ -25,6 +26,7 @@ export interface Case<
     TSelectedFields
   >;
   entity: TEntity;
+  action: EntityAuthorizationAction;
 }
 
 export type CaseMap<
@@ -60,10 +62,16 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (allowCases && allowCases.size > 0) {
       describe('allow cases', () => {
         test.each(Array.from(allowCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, evaluationContext, entity } =
+          const { viewerContext, queryContext, evaluationContext, entity, action } =
             await allowCases.get(caseKey)!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+            privacyPolicyRule.evaluateAsync(
+              viewerContext,
+              queryContext,
+              evaluationContext,
+              entity,
+              action,
+            ),
           ).resolves.toEqual(RuleEvaluationResult.ALLOW);
         });
       });
@@ -72,10 +80,16 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (skipCases && skipCases.size > 0) {
       describe('skip cases', () => {
         test.each(Array.from(skipCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, evaluationContext, entity } =
+          const { viewerContext, queryContext, evaluationContext, entity, action } =
             await skipCases.get(caseKey)!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+            privacyPolicyRule.evaluateAsync(
+              viewerContext,
+              queryContext,
+              evaluationContext,
+              entity,
+              action,
+            ),
           ).resolves.toEqual(RuleEvaluationResult.SKIP);
         });
       });
@@ -84,10 +98,16 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (denyCases && denyCases.size > 0) {
       describe('deny cases', () => {
         test.each(Array.from(denyCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, evaluationContext, entity } =
+          const { viewerContext, queryContext, evaluationContext, entity, action } =
             await denyCases.get(caseKey)!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+            privacyPolicyRule.evaluateAsync(
+              viewerContext,
+              queryContext,
+              evaluationContext,
+              entity,
+              action,
+            ),
           ).resolves.toEqual(RuleEvaluationResult.DENY);
         });
       });

--- a/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
@@ -4,6 +4,7 @@ import {
   ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   AlwaysDenyPrivacyPolicyRule,
+  EntityAuthorizationAction,
 } from '@expo/entity';
 import { describe } from '@jest/globals';
 import { anything, instance, mock } from 'ts-mockito';
@@ -22,6 +23,7 @@ describe(describePrivacyPolicyRuleWithAsyncTestCase, () => {
             evaluationContext:
               instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
             entity: anything(),
+            action: EntityAuthorizationAction.READ,
           }),
         ],
       ]),
@@ -37,6 +39,7 @@ describe(describePrivacyPolicyRuleWithAsyncTestCase, () => {
             evaluationContext:
               instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
             entity: anything(),
+            action: EntityAuthorizationAction.READ,
           }),
         ],
       ]),

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -25,6 +25,7 @@ export type EntityPrivacyPolicyEvaluationContext<
    * when an entity is updated it is re-LOADed after the update completes.
    */
   previousValue: TEntity | null;
+
   /**
    * When this privacy policy is being evaluated as a result of a cascading deletion, this will be populated
    * with information on the cascading delete.
@@ -462,6 +463,7 @@ export abstract class EntityPrivacyPolicy<
         queryContext,
         evaluationContext,
         entity,
+        action,
       );
       switch (ruleEvaluationResult) {
         case RuleEvaluationResult.DENY:

--- a/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
@@ -1,4 +1,7 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -34,10 +37,11 @@ export class AllowIfAllSubRulesAllowPrivacyPolicyRule<
       TSelectedFields
     >,
     entity: TEntity,
+    action: EntityAuthorizationAction,
   ): Promise<RuleEvaluationResult> {
     const results = await Promise.all(
       this.subRules.map((subRule) =>
-        subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+        subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity, action),
       ),
     );
     return results.every((result) => result === RuleEvaluationResult.ALLOW)

--- a/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
@@ -1,4 +1,7 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -34,10 +37,11 @@ export class AllowIfAnySubRuleAllowsPrivacyPolicyRule<
       TSelectedFields
     >,
     entity: TEntity,
+    action: EntityAuthorizationAction,
   ): Promise<RuleEvaluationResult> {
     const results = await Promise.all(
       this.subRules.map((subRule) =>
-        subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+        subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity, action),
       ),
     );
     return results.includes(RuleEvaluationResult.ALLOW)

--- a/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
@@ -1,4 +1,7 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -37,10 +40,17 @@ export class EvaluateIfEntityFieldPredicatePrivacyPolicyRule<
       TSelectedFields
     >,
     entity: TEntity,
+    action: EntityAuthorizationAction,
   ): Promise<RuleEvaluationResult> {
     const fieldValue = entity.getField(this.fieldName);
     return this.shouldEvaluatePredicate(fieldValue)
-      ? await this.rule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity)
+      ? await this.rule.evaluateAsync(
+          viewerContext,
+          queryContext,
+          evaluationContext,
+          entity,
+          action,
+        )
       : RuleEvaluationResult.SKIP;
   }
 }

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -1,4 +1,7 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -54,5 +57,6 @@ export abstract class PrivacyPolicyRule<
       TSelectedFields
     >,
     entity: TEntity,
+    action: EntityAuthorizationAction,
   ): Promise<RuleEvaluationResult>;
 }

--- a/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
@@ -22,6 +22,7 @@ describePrivacyPolicyRule(
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
+        action: anything(),
       },
     ],
   },
@@ -40,6 +41,7 @@ describePrivacyPolicyRule(
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
+        action: anything(),
       },
     ],
   },
@@ -58,6 +60,7 @@ describePrivacyPolicyRule(
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
+        action: anything(),
       },
     ],
   },

--- a/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
@@ -22,6 +22,7 @@ describePrivacyPolicyRule(
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
+        action: anything(),
       },
     ],
   },
@@ -40,6 +41,7 @@ describePrivacyPolicyRule(
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
+        action: anything(),
       },
     ],
   },
@@ -58,6 +60,7 @@ describePrivacyPolicyRule(
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
+        action: anything(),
       },
     ],
   },

--- a/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
@@ -1,4 +1,4 @@
-import { instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, when } from 'ts-mockito';
 
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
@@ -103,6 +103,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityMock),
+        action: anything(),
       },
       // parent id matches parent being deleted, field null in current version but filled in previous version
       {
@@ -116,6 +117,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityMockWithNullifiedField),
+        action: anything(),
       },
     ],
     skipCases: [
@@ -128,6 +130,7 @@ describePrivacyPolicyRule(
           cascadingDeleteCause: null,
         },
         entity: instance(childEntityMock),
+        action: anything(),
       },
       // cascading delete not from parent entity class
       {
@@ -141,6 +144,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityMock),
+        action: anything(),
       },
       // cascading delete from different parent, field not nullified
       {
@@ -154,6 +158,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityMock),
+        action: anything(),
       },
       // entity belongs to different parent
       {
@@ -167,6 +172,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityDifferentParentMock),
+        action: anything(),
       },
       // parent id field undefined (null) and no previous value
       {
@@ -180,6 +186,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityMockWithNullifiedField),
+        action: anything(),
       },
       // parent id now null but previous value different parent
       {
@@ -193,6 +200,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityMockWithNullifiedField),
+        action: anything(),
       },
     ],
   },
@@ -239,6 +247,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityWithNameRefMock),
+        action: anything(),
       },
       // parent name matches parent being deleted, field null in current version but filled in previous version
       {
@@ -252,6 +261,7 @@ describePrivacyPolicyRule(
           },
         },
         entity: instance(childEntityWithNameRefMockWithNullifiedField),
+        action: anything(),
       },
     ],
   },

--- a/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
@@ -14,6 +14,7 @@ describePrivacyPolicyRule(new AlwaysAllowPrivacyPolicyRule(), {
       evaluationContext:
         instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
       entity: anything(),
+      action: anything(),
     },
   ],
 });

--- a/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
@@ -14,6 +14,7 @@ describePrivacyPolicyRule(new AlwaysDenyPrivacyPolicyRule(), {
       evaluationContext:
         instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
       entity: anything(),
+      action: anything(),
     },
   ],
 });

--- a/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
@@ -14,6 +14,7 @@ describePrivacyPolicyRule(new AlwaysSkipPrivacyPolicyRule(), {
       evaluationContext:
         instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
       entity: anything(),
+      action: anything(),
     },
   ],
 });

--- a/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
@@ -1,4 +1,4 @@
-import { mock, instance, when } from 'ts-mockito';
+import { mock, instance, when, anything } from 'ts-mockito';
 
 import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
@@ -32,6 +32,7 @@ describePrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: entityBlah,
+        action: anything(),
       },
     ],
     skipCases: [
@@ -41,6 +42,7 @@ describePrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity
         evaluationContext:
           instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
         entity: entityFoo,
+        action: anything(),
       },
     ],
   },

--- a/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import {
+  EntityAuthorizationAction,
+  EntityPrivacyPolicyEvaluationContext,
+} from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ReadonlyEntity } from '../../ReadonlyEntity';
 import { ViewerContext } from '../../ViewerContext';
@@ -23,6 +26,7 @@ export interface Case<
     TSelectedFields
   >;
   entity: TEntity;
+  action: EntityAuthorizationAction;
 }
 
 export type CaseMap<
@@ -58,10 +62,16 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (allowCases && allowCases.size > 0) {
       describe('allow cases', () => {
         test.each(Array.from(allowCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, evaluationContext, entity } =
+          const { viewerContext, queryContext, evaluationContext, entity, action } =
             await allowCases.get(caseKey)!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+            privacyPolicyRule.evaluateAsync(
+              viewerContext,
+              queryContext,
+              evaluationContext,
+              entity,
+              action,
+            ),
           ).resolves.toEqual(RuleEvaluationResult.ALLOW);
         });
       });
@@ -70,10 +80,16 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (skipCases && skipCases.size > 0) {
       describe('skip cases', () => {
         test.each(Array.from(skipCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, evaluationContext, entity } =
+          const { viewerContext, queryContext, evaluationContext, entity, action } =
             await skipCases.get(caseKey)!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+            privacyPolicyRule.evaluateAsync(
+              viewerContext,
+              queryContext,
+              evaluationContext,
+              entity,
+              action,
+            ),
           ).resolves.toEqual(RuleEvaluationResult.SKIP);
         });
       });
@@ -82,10 +98,16 @@ export const describePrivacyPolicyRuleWithAsyncTestCase = <
     if (denyCases && denyCases.size > 0) {
       describe('deny cases', () => {
         test.each(Array.from(denyCases.keys()))('%p', async (caseKey) => {
-          const { viewerContext, queryContext, evaluationContext, entity } =
+          const { viewerContext, queryContext, evaluationContext, entity, action } =
             await denyCases.get(caseKey)!();
           await expect(
-            privacyPolicyRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),
+            privacyPolicyRule.evaluateAsync(
+              viewerContext,
+              queryContext,
+              evaluationContext,
+              entity,
+              action,
+            ),
           ).resolves.toEqual(RuleEvaluationResult.DENY);
         });
       });


### PR DESCRIPTION
# Why

When a rule is used across multiple authorization actions and the rule wants to have specific behavior for a certain authorization action, writing the code is made simpler by passing the action to the rule evaluation itself. In the past, this required a constructor parameter.

For example, let's say there's a rule that always allows unless the viewerContext is named "bob", but only should disallow bob from doing mutations. It's easiest to write the rule as:
```
PrivacyPolicyRule
  evaluateAsync
    if (viewerContext.name === "bob" && authoriztionAction !== READ) {
      return SKIP
```

# How

Add action to the params.

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests!
