### PR TITLE
feat: Add authorization action to EntityPrivacyPolicyRuleEvaluationContext

### DIFF
--- a/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity-testing-utils/src/PrivacyPolicyRuleTestUtils.ts
@@ -1,10 +1,10 @@
 import {
-  EntityPrivacyPolicyEvaluationContext,
   EntityQueryContext,
   ReadonlyEntity,
   ViewerContext,
   PrivacyPolicyRule,
   RuleEvaluationResult,
+  EntityPrivacyPolicyRuleEvaluationContext,
 } from '@expo/entity';
 import { describe, expect, test } from '@jest/globals';
 
@@ -17,7 +17,7 @@ export interface Case<
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
-  evaluationContext: EntityPrivacyPolicyEvaluationContext<
+  evaluationContext: EntityPrivacyPolicyRuleEvaluationContext<
     TFields,
     TIDField,
     TViewerContext,

--- a/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
@@ -1,9 +1,9 @@
 import {
-  EntityPrivacyPolicyEvaluationContext,
   EntityQueryContext,
   ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   AlwaysDenyPrivacyPolicyRule,
+  EntityPrivacyPolicyRuleEvaluationContext,
 } from '@expo/entity';
 import { describe } from '@jest/globals';
 import { anything, instance, mock } from 'ts-mockito';
@@ -20,7 +20,7 @@ describe(describePrivacyPolicyRuleWithAsyncTestCase, () => {
             viewerContext: instance(mock(ViewerContext)),
             queryContext: instance(mock(EntityQueryContext)),
             evaluationContext:
-              instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+              instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
             entity: anything(),
           }),
         ],
@@ -35,7 +35,7 @@ describe(describePrivacyPolicyRuleWithAsyncTestCase, () => {
             viewerContext: instance(mock(ViewerContext)),
             queryContext: instance(mock(EntityQueryContext)),
             evaluationContext:
-              instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+              instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
             entity: anything(),
           }),
         ],

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -32,6 +32,25 @@ export type EntityPrivacyPolicyEvaluationContext<
   cascadingDeleteCause: EntityCascadingDeletionInfo | null;
 };
 
+export type EntityPrivacyPolicyRuleEvaluationContext<
+  TFields extends Record<string, any>,
+  TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
+  TViewerContext extends ViewerContext,
+  TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
+  TSelectedFields extends keyof TFields = keyof TFields,
+> = EntityPrivacyPolicyEvaluationContext<
+  TFields,
+  TIDField,
+  TViewerContext,
+  TEntity,
+  TSelectedFields
+> & {
+  /**
+   * The CRUD action for which the privacy policy rule is being evaluated.
+   */
+  action: EntityAuthorizationAction;
+};
+
 /**
  * Evaluation mode for a EntityPrivacyPolicy. Useful when transitioning to
  * using Entity for privacy.
@@ -460,7 +479,7 @@ export abstract class EntityPrivacyPolicy<
       const ruleEvaluationResult = await rule.evaluateAsync(
         viewerContext,
         queryContext,
-        evaluationContext,
+        { ...evaluationContext, action },
         entity,
       );
       switch (ruleEvaluationResult) {

--- a/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
@@ -1,4 +1,4 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -26,7 +26,7 @@ export class AllowIfAllSubRulesAllowPrivacyPolicyRule<
   async evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+    evaluationContext: EntityPrivacyPolicyRuleEvaluationContext<
       TFields,
       TIDField,
       TViewerContext,

--- a/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
@@ -1,4 +1,4 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -26,7 +26,7 @@ export class AllowIfAnySubRuleAllowsPrivacyPolicyRule<
   async evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+    evaluationContext: EntityPrivacyPolicyRuleEvaluationContext<
       TFields,
       TIDField,
       TViewerContext,

--- a/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
@@ -1,4 +1,4 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -29,7 +29,7 @@ export class EvaluateIfEntityFieldPredicatePrivacyPolicyRule<
   async evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+    evaluationContext: EntityPrivacyPolicyRuleEvaluationContext<
       TFields,
       TIDField,
       TViewerContext,

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -1,4 +1,4 @@
-import { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../EntityQueryContext';
 import { ReadonlyEntity } from '../ReadonlyEntity';
 import { ViewerContext } from '../ViewerContext';
@@ -46,7 +46,7 @@ export abstract class PrivacyPolicyRule<
   abstract evaluateAsync(
     viewerContext: TViewerContext,
     queryContext: EntityQueryContext,
-    evaluationContext: EntityPrivacyPolicyEvaluationContext<
+    evaluationContext: EntityPrivacyPolicyRuleEvaluationContext<
       TFields,
       TIDField,
       TViewerContext,

--- a/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
@@ -1,6 +1,6 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ViewerContext } from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
@@ -20,7 +20,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
       },
     ],
@@ -38,7 +38,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
       },
     ],
@@ -56,7 +56,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
       },
     ],

--- a/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
@@ -1,6 +1,6 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ViewerContext } from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
@@ -20,7 +20,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
       },
     ],
@@ -38,7 +38,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
       },
     ],
@@ -56,7 +56,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: anything(),
       },
     ],

--- a/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
@@ -1,4 +1,4 @@
-import { instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, when } from 'ts-mockito';
 
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';
 import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
@@ -96,6 +96,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: instance(childEntityMock),
           cascadingDeleteCause: {
             entity: parentEntity,
@@ -109,6 +110,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: instance(childEntityMock),
           cascadingDeleteCause: {
             entity: parentEntity,
@@ -124,6 +126,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: null,
           cascadingDeleteCause: null,
         },
@@ -134,6 +137,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: null,
           cascadingDeleteCause: {
             entity: instance(unrelatedOtherEntityMock),
@@ -147,6 +151,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: null,
           cascadingDeleteCause: {
             entity: otherParentEntity,
@@ -160,6 +165,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: null,
           cascadingDeleteCause: {
             entity: parentEntity,
@@ -173,6 +179,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: null,
           cascadingDeleteCause: {
             entity: parentEntity,
@@ -186,6 +193,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: instance(childEntityDifferentParentMock),
           cascadingDeleteCause: {
             entity: parentEntity,
@@ -232,6 +240,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: instance(childEntityWithNameRefMock),
           cascadingDeleteCause: {
             entity: parentEntityWithName,
@@ -245,6 +254,7 @@ describePrivacyPolicyRule(
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext: {
+          action: anything(),
           previousValue: instance(childEntityWithNameRefMock),
           cascadingDeleteCause: {
             entity: parentEntityWithName,

--- a/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
@@ -1,6 +1,6 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ViewerContext } from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
@@ -12,7 +12,7 @@ describePrivacyPolicyRule(new AlwaysAllowPrivacyPolicyRule(), {
       viewerContext: instance(mock(ViewerContext)),
       queryContext: instance(mock(EntityQueryContext)),
       evaluationContext:
-        instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
       entity: anything(),
     },
   ],

--- a/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
@@ -1,6 +1,6 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ViewerContext } from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
@@ -12,7 +12,7 @@ describePrivacyPolicyRule(new AlwaysDenyPrivacyPolicyRule(), {
       viewerContext: instance(mock(ViewerContext)),
       queryContext: instance(mock(EntityQueryContext)),
       evaluationContext:
-        instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
       entity: anything(),
     },
   ],

--- a/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
@@ -1,6 +1,6 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ViewerContext } from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
@@ -12,7 +12,7 @@ describePrivacyPolicyRule(new AlwaysSkipPrivacyPolicyRule(), {
       viewerContext: instance(mock(ViewerContext)),
       queryContext: instance(mock(EntityQueryContext)),
       evaluationContext:
-        instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+        instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
       entity: anything(),
     },
   ],

--- a/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
@@ -1,6 +1,6 @@
 import { mock, instance, when } from 'ts-mockito';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ViewerContext } from '../../ViewerContext';
 import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
@@ -30,7 +30,7 @@ describePrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: entityBlah,
       },
     ],
@@ -39,7 +39,7 @@ describePrivacyPolicyRule<TestFields, 'customIdField', ViewerContext, TestEntity
         viewerContext: instance(mock(ViewerContext)),
         queryContext: instance(mock(EntityQueryContext)),
         evaluationContext:
-          instance(mock<EntityPrivacyPolicyEvaluationContext<any, any, any, any, any>>()),
+          instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
         entity: entityFoo,
       },
     ],

--- a/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
+import { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
 import { EntityQueryContext } from '../../EntityQueryContext';
 import { ReadonlyEntity } from '../../ReadonlyEntity';
 import { ViewerContext } from '../../ViewerContext';
@@ -15,7 +15,7 @@ export interface Case<
 > {
   viewerContext: TViewerContext;
   queryContext: EntityQueryContext;
-  evaluationContext: EntityPrivacyPolicyEvaluationContext<
+  evaluationContext: EntityPrivacyPolicyRuleEvaluationContext<
     TFields,
     TIDField,
     TViewerContext,


### PR DESCRIPTION
# Why

When a rule is used across multiple authorization actions and the rule wants to have specific behavior for a certain authorization action, writing the code is made simpler by passing the action to the rule evaluation itself. In the past, this required a constructor parameter.

For example, let's say there's a rule that always allows unless the viewerContext is named "bob", but only should disallow bob from doing mutations. It's easiest to write the rule as:
```
PrivacyPolicyRule
  evaluateAsync
    if (viewerContext.name === "bob" && evaluationContext.action !== READ) {
      return SKIP
```

Replaces #462 which added it as a param. This is cleaner.

# How

Add action to the context.

# Test Plan

Run new test.