### PR TITLE
feat: add support for nulls ordering in order by clauses

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -10,6 +10,7 @@ import {
 } from '@expo/entity';
 import {
   BasePostgresEntityDatabaseAdapter,
+  NullsOrdering,
   OrderByOrdering,
   SQLFragment,
   TableFieldMultiValueEqualityCondition,
@@ -119,17 +120,25 @@ export class StubPostgresDatabaseAdapter<
     }
     const aField = objectA[currentOrderBy.columnName];
     const bField = objectB[currentOrderBy.columnName];
+
+    // Determine effective nulls ordering:
+    // - If explicitly set, use that
+    // - Otherwise use PostgreSQL defaults: NULLS LAST for ASC, NULLS FIRST for DESC
+    const nullsFirst =
+      currentOrderBy.nulls !== undefined
+        ? currentOrderBy.nulls === NullsOrdering.FIRST
+        : currentOrderBy.order === OrderByOrdering.DESCENDING;
+
+    if (aField === null && bField === null) {
+      return this.compareByOrderBys(orderBys.slice(1), objectA, objectB);
+    } else if (aField === null) {
+      return nullsFirst ? -1 : 1;
+    } else if (bField === null) {
+      return nullsFirst ? 1 : -1;
+    }
+
     switch (currentOrderBy.order) {
       case OrderByOrdering.DESCENDING: {
-        // simulate NULLS FIRST for DESC
-        if (aField === null && bField === null) {
-          return 0;
-        } else if (aField === null) {
-          return -1;
-        } else if (bField === null) {
-          return 1;
-        }
-
         return aField > bField
           ? -1
           : aField < bField
@@ -137,15 +146,6 @@ export class StubPostgresDatabaseAdapter<
             : this.compareByOrderBys(orderBys.slice(1), objectA, objectB);
       }
       case OrderByOrdering.ASCENDING: {
-        // simulate NULLS LAST for ASC
-        if (aField === null && bField === null) {
-          return 0;
-        } else if (bField === null) {
-          return -1;
-        } else if (aField === null) {
-          return 1;
-        }
-
         return bField > aField
           ? -1
           : bField < aField

--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -58,6 +58,11 @@ export interface TableFieldMultiValueEqualityCondition {
   tableValues: readonly any[];
 }
 
+export enum NullsOrdering {
+  FIRST = 'first',
+  LAST = 'last',
+}
+
 /**
  * Ordering options for `orderBy` clauses.
  */
@@ -86,6 +91,12 @@ export type PostgresOrderByClause<TFields extends Record<string, any>> =
        * The OrderByOrdering to order by.
        */
       order: OrderByOrdering;
+
+      /**
+       * Optional nulls ordering. If not provided, the database default is used
+       * (NULLS LAST for ASC, NULLS FIRST for DESC in PostgreSQL).
+       */
+      nulls?: NullsOrdering | undefined;
     }
   | {
       /**
@@ -97,6 +108,12 @@ export type PostgresOrderByClause<TFields extends Record<string, any>> =
        * The OrderByOrdering to order by.
        */
       order: OrderByOrdering;
+
+      /**
+       * Optional nulls ordering. If not provided, the database default is used
+       * (NULLS LAST for ASC, NULLS FIRST for DESC in PostgreSQL).
+       */
+      nulls?: NullsOrdering | undefined;
     };
 
 /**
@@ -123,10 +140,12 @@ export type TableOrderByClause =
   | {
       columnName: string;
       order: OrderByOrdering;
+      nulls: NullsOrdering | undefined;
     }
   | {
       columnFragment: SQLFragment;
       order: OrderByOrdering;
+      nulls: NullsOrdering | undefined;
     };
 
 export interface TableQuerySelectionModifiers {
@@ -280,11 +299,13 @@ export abstract class BasePostgresEntityDatabaseAdapter<
                     orderBySpecification.fieldName,
                   ),
                   order: orderBySpecification.order,
+                  nulls: orderBySpecification.nulls,
                 };
               } else {
                 return {
                   columnFragment: orderBySpecification.fieldFragment,
                   order: orderBySpecification.order,
+                  nulls: orderBySpecification.nulls,
                 };
               }
             })

--- a/packages/entity-database-adapter-knex/src/BaseSQLQueryBuilder.ts
+++ b/packages/entity-database-adapter-knex/src/BaseSQLQueryBuilder.ts
@@ -2,7 +2,7 @@ import {
   EntityLoaderOrderByClause,
   EntityLoaderQuerySelectionModifiers,
 } from './AuthorizationResultBasedKnexEntityLoader';
-import { OrderByOrdering } from './BasePostgresEntityDatabaseAdapter';
+import { NullsOrdering, OrderByOrdering } from './BasePostgresEntityDatabaseAdapter';
 import { SQLFragment } from './SQLOperator';
 
 /**
@@ -43,8 +43,12 @@ export abstract class BaseSQLQueryBuilder<
   /**
    * Order by a field. Can be called multiple times to add multiple order bys.
    */
-  orderBy(fieldName: TSelectedFields, order: OrderByOrdering = OrderByOrdering.ASCENDING): this {
-    this.modifiers.orderBy = [...(this.modifiers.orderBy ?? []), { fieldName, order }];
+  orderBy(
+    fieldName: TSelectedFields,
+    order: OrderByOrdering = OrderByOrdering.ASCENDING,
+    nulls: NullsOrdering | undefined = undefined,
+  ): this {
+    this.modifiers.orderBy = [...(this.modifiers.orderBy ?? []), { fieldName, order, nulls }];
     return this;
   }
 
@@ -66,10 +70,14 @@ export abstract class BaseSQLQueryBuilder<
    * @param fragment - The SQL fragment to order by. Must not include the ASC/DESC keyword, as ordering direction is determined by the `order` parameter.
    * @param order - The ordering direction (ascending or descending). Defaults to ascending.
    */
-  orderBySQL(fragment: SQLFragment, order: OrderByOrdering = OrderByOrdering.ASCENDING): this {
+  orderBySQL(
+    fragment: SQLFragment,
+    order: OrderByOrdering = OrderByOrdering.ASCENDING,
+    nulls: NullsOrdering | undefined = undefined,
+  ): this {
     this.modifiers.orderBy = [
       ...(this.modifiers.orderBy ?? []),
-      { fieldFragment: fragment, order },
+      { fieldFragment: fragment, order, nulls },
     ];
     return this;
   }

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 
 import {
   BasePostgresEntityDatabaseAdapter,
+  NullsOrdering,
   TableFieldMultiValueEqualityCondition,
   TableFieldSingleValueEqualityCondition,
   TableQuerySelectionModifiers,
@@ -127,10 +128,17 @@ export class PostgresEntityDatabaseAdapter<
     if (orderBy !== undefined) {
       for (const orderBySpecification of orderBy) {
         if ('columnName' in orderBySpecification) {
-          ret = ret.orderBy(orderBySpecification.columnName, orderBySpecification.order);
+          ret = ret.orderBy(
+            orderBySpecification.columnName,
+            orderBySpecification.order,
+            orderBySpecification.nulls,
+          );
         } else {
+          const nullsSuffix = orderBySpecification.nulls
+            ? ` NULLS ${orderBySpecification.nulls === NullsOrdering.FIRST ? 'FIRST' : 'LAST'}`
+            : '';
           ret = ret.orderByRaw(
-            `(${orderBySpecification.columnFragment.sql}) ${orderBySpecification.order}`,
+            `(${orderBySpecification.columnFragment.sql}) ${orderBySpecification.order}${nullsSuffix}`,
             orderBySpecification.columnFragment.getKnexBindings(),
           );
         }

--- a/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
@@ -20,6 +20,7 @@ import { PostgresEntity } from '../PostgresEntity';
 type PostgresTestEntityFields = {
   id: string;
   name: string | null;
+  label: string;
   hasADog: boolean | null;
   hasACat: boolean | null;
   stringArray: string[] | null;
@@ -60,6 +61,7 @@ export class PostgresTestEntity extends PostgresEntity<
       await knex.schema.createTable(tableName, (table) => {
         table.uuid('id').defaultTo(knex.raw('gen_random_uuid()')).primary();
         table.string('name');
+        table.string('label').notNullable().defaultTo('');
         table.boolean('has_a_dog');
         table.boolean('has_a_cat');
         table.specificType('string_array', 'text[]');
@@ -137,6 +139,9 @@ export const postgresTestEntityConfiguration = new EntityConfiguration<
     }),
     name: new StringField({
       columnName: 'name',
+    }),
+    label: new StringField({
+      columnName: 'label',
     }),
     hasADog: new BooleanField({
       columnName: 'has_a_dog',

--- a/packages/entity-database-adapter-knex/src/index.ts
+++ b/packages/entity-database-adapter-knex/src/index.ts
@@ -22,4 +22,5 @@ export * from './errors/wrapNativePostgresCallAsync';
 export * from './internal/EntityKnexDataManager';
 export * from './internal/getKnexDataManager';
 export * from './internal/getKnexEntityLoaderFactory';
+export * from './internal/utilityTypes';
 export * from './internal/weakMaps';

--- a/packages/entity-database-adapter-knex/src/internal/utilityTypes.ts
+++ b/packages/entity-database-adapter-knex/src/internal/utilityTypes.ts
@@ -1,0 +1,11 @@
+/* c8 ignore start - types only */
+
+export type NonNullableKeys<T> = {
+  [K in keyof T]: T[K] extends NonNullable<T[K]> ? K : never;
+}[keyof T];
+
+export type PickNonNullable<T> = Pick<T, NonNullableKeys<T>>;
+
+export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
+/* c8 ignore stop - types only */


### PR DESCRIPTION
# Why

This is the last piece of ORDER BY clauses that entity order by doesn't support, and was the last use case that required a `orderByRaw` (which was removed in the last PR).

https://www.postgresql.org/docs/current/queries-order.html

# How

Add support for nulls first/last to order by.

Note that we explicitly don't add this to the search pagination order bys (extraOrderByFields, searchFields) since allowing non-default null behavior there complicates things significantly (see stacked PR which implements this as an exercise).

# Test Plan

Run tests.