### PR TITLE
feat: allow nulls specification for extraOrderBy

### DIFF
--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -19,7 +19,6 @@ import { PaginationStrategy } from './PaginationStrategy';
 import { SQLFragment } from './SQLOperator';
 import type { Connection, PageInfo } from './internal/EntityKnexDataManager';
 import { EntityKnexDataManager } from './internal/EntityKnexDataManager';
-import { NonNullableKeys } from './internal/utilityTypes';
 
 export type EntityLoaderBaseOrderByClause = {
   /**
@@ -93,7 +92,7 @@ interface SearchSpecificationBase<
   /**
    * The fields to search within. Must be a non-empty array.
    */
-  fields: (TSelectedFields & NonNullableKeys<TFields>)[];
+  fields: TSelectedFields[];
 }
 
 interface ILikeSearchSpecification<
@@ -132,11 +131,13 @@ interface TrigramSearchSpecification<
   threshold: number;
 
   /**
-   * Optional additional fields to order by after similarity score and before ID for tie-breaking.
-   * These fields are independent of search fields and can be used to provide meaningful
+   * Optional additional order by clauses to apply after similarity score and before ID for tie-breaking.
+   * These clauses are independent of search fields and can be used to provide meaningful
    * ordering when multiple results have the same similarity score.
+   *
+   * Each clause specifies a field name or SQL fragment, ordering direction, and optional nulls ordering.
    */
-  extraOrderByFields?: (TSelectedFields & NonNullableKeys<TFields>)[];
+  extraOrderBy?: EntityLoaderOrderByClause<TFields, TSelectedFields>[];
 }
 
 interface StandardPaginationSpecification<

--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -80,41 +80,37 @@ export enum OrderByOrdering {
   DESCENDING = 'desc',
 }
 
+export type PostgresBaseOrderByClause = {
+  /**
+   * The OrderByOrdering to order by.
+   */
+  order: OrderByOrdering;
+
+  /**
+   * Optional nulls ordering. If not provided, the database default is used
+   * (NULLS LAST for ASC, NULLS FIRST for DESC in PostgreSQL).
+   */
+  nulls?: NullsOrdering | undefined;
+};
+
+export type PostgresFieldOrderByClause<TFields extends Record<string, any>> =
+  PostgresBaseOrderByClause & {
+    /**
+     * The field name to order by.
+     */
+    fieldName: keyof TFields;
+  };
+
+export type PostgresFragmentOrderByClause = PostgresBaseOrderByClause & {
+  /**
+   * A raw SQL fragment to order by. Must not contain ASC or DESC, as ordering direction is determined by the `order` property.
+   */
+  fieldFragment: SQLFragment;
+};
+
 export type PostgresOrderByClause<TFields extends Record<string, any>> =
-  | {
-      /**
-       * The field name to order by.
-       */
-      fieldName: keyof TFields;
-
-      /**
-       * The OrderByOrdering to order by.
-       */
-      order: OrderByOrdering;
-
-      /**
-       * Optional nulls ordering. If not provided, the database default is used
-       * (NULLS LAST for ASC, NULLS FIRST for DESC in PostgreSQL).
-       */
-      nulls?: NullsOrdering | undefined;
-    }
-  | {
-      /**
-       * A raw SQL fragment to order by. May not contain ASC or DESC, as ordering direction is determined by the `order` property.
-       */
-      fieldFragment: SQLFragment;
-
-      /**
-       * The OrderByOrdering to order by.
-       */
-      order: OrderByOrdering;
-
-      /**
-       * Optional nulls ordering. If not provided, the database default is used
-       * (NULLS LAST for ASC, NULLS FIRST for DESC in PostgreSQL).
-       */
-      nulls?: NullsOrdering | undefined;
-    };
+  | PostgresFieldOrderByClause<TFields>
+  | PostgresFragmentOrderByClause;
 
 /**
  * SQL modifiers that only affect the selection but not the projection.

--- a/packages/entity-database-adapter-knex/src/__tests__/AuthorizationResultBasedKnexEntityLoader-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/AuthorizationResultBasedKnexEntityLoader-test.ts
@@ -915,7 +915,7 @@ describe(AuthorizationResultBasedKnexEntityLoader, () => {
           term: 'Johnson',
           fields: ['name'],
           threshold: 0.3,
-          extraOrderByFields: ['score'],
+          extraOrderBy: [{ fieldName: 'score', order: OrderByOrdering.DESCENDING }],
         },
       });
 


### PR DESCRIPTION
# Why

This demonstrates what it would look like if support was added to handle nulls in columns being searched or extraOrderBy'd.

# How

Claude.

# Test Plan

N/A. Not going to land this.