### PR TITLE
feat: support nullable search fields with postgres transforms

### DIFF
--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -176,7 +176,7 @@ export abstract class BasePostgresEntityDatabaseAdapter<
    */
   async fetchManyByFieldEqualityConjunctionAsync<N extends keyof TFields>(
     queryContext: EntityQueryContext,
-    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
+    fieldEqualityOperands: readonly FieldEqualityCondition<TFields, N>[],
     querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): Promise<readonly Readonly<TFields>[]> {
     const tableFieldSingleValueOperands: TableFieldSingleValueEqualityCondition[] = [];

--- a/packages/entity-database-adapter-knex/src/SQLOperator.ts
+++ b/packages/entity-database-adapter-knex/src/SQLOperator.ts
@@ -56,7 +56,7 @@ export class SQLFragment {
    * @param fragments - Array of SQL fragments to join
    * @param separator - Separator string (default: ', ')
    */
-  static join(fragments: SQLFragment[], separator = ', '): SQLFragment {
+  static join(fragments: readonly SQLFragment[], separator = ', '): SQLFragment {
     return new SQLFragment(
       fragments.map((f) => f.sql).join(separator),
       fragments.flatMap((f) => f.bindings),

--- a/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
@@ -17,7 +17,7 @@ import { Knex } from 'knex';
 import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
 import { PostgresEntity } from '../PostgresEntity';
 
-type PostgresTestEntityFields = {
+export type PostgresTestEntityFields = {
   id: string;
   name: string | null;
   label: string;


### PR DESCRIPTION
# Why

#468 added nulls support for regular order bys, but explicitly disabled it for search pagination due to it adding quite a lot of complexity. It also fixed a bug where using a nullable field in pagination in general would break the cursor condition and omit rows (any tuple containing NULL would be dropped due to postgres behavior).

But applications still need to be able to search fields that are nullable, they just need to provide a mechanism for dictating how to cast them as non-nullable. This PR provides such a mechanism.

# How

Allow the user to specify a function to craft the search field SQLFragment from nullable fields. This is required to be a somewhat awkward shape since the library needs to retain control over the field name due to table aliasing in the cursor.

# Test Plan

Run new tests.