### PR TITLE
fix: Apply same viewer context subclass type mechanism to knexLoader and related methods

### DIFF
--- a/packages/entity-database-adapter-knex/src/PostgresEntity.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntity.ts
@@ -35,6 +35,7 @@ export abstract class PostgresEntity<
     TMFields extends object,
     TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
+    TMViewerContext2 extends TMViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
@@ -53,7 +54,7 @@ export abstract class PostgresEntity<
       TMPrivacyPolicy,
       TMSelectedFields
     >,
-    viewerContext: TMViewerContext,
+    viewerContext: TMViewerContext2,
     queryContext: EntityQueryContext = viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()
@@ -80,6 +81,7 @@ export abstract class PostgresEntity<
     TMFields extends object,
     TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
     TMViewerContext extends ViewerContext,
+    TMViewerContext2 extends TMViewerContext,
     TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
     TMPrivacyPolicy extends EntityPrivacyPolicy<
       TMFields,
@@ -98,7 +100,7 @@ export abstract class PostgresEntity<
       TMPrivacyPolicy,
       TMSelectedFields
     >,
-    viewerContext: TMViewerContext,
+    viewerContext: TMViewerContext2,
     queryContext: EntityQueryContext = viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getQueryContextProvider()

--- a/packages/entity-database-adapter-knex/src/internal/getKnexEntityLoaderFactory.ts
+++ b/packages/entity-database-adapter-knex/src/internal/getKnexEntityLoaderFactory.ts
@@ -19,6 +19,7 @@ export function getKnexEntityLoaderFactory<
   TFields extends Record<string, any>,
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
+  TViewerContext2 extends TViewerContext,
   TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
   TPrivacyPolicy extends EntityPrivacyPolicy<
     TFields,
@@ -37,7 +38,7 @@ export function getKnexEntityLoaderFactory<
     TPrivacyPolicy,
     TSelectedFields
   >,
-  viewerContext: TViewerContext,
+  viewerContext: TViewerContext2,
 ): KnexEntityLoaderFactory<
   TFields,
   TIDField,

--- a/packages/entity-database-adapter-knex/src/knexLoader.ts
+++ b/packages/entity-database-adapter-knex/src/knexLoader.ts
@@ -20,6 +20,7 @@ export function knexLoader<
   TMFields extends object,
   TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
   TMViewerContext extends ViewerContext,
+  TMViewerContext2 extends TMViewerContext,
   TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
   TMPrivacyPolicy extends EntityPrivacyPolicy<
     TMFields,
@@ -38,7 +39,7 @@ export function knexLoader<
     TMPrivacyPolicy,
     TMSelectedFields
   >,
-  viewerContext: TMViewerContext,
+  viewerContext: TMViewerContext2,
   queryContext: EntityQueryContext = viewerContext
     .getViewerScopedEntityCompanionForClass(entityClass)
     .getQueryContextProvider()
@@ -69,6 +70,7 @@ export function knexLoaderWithAuthorizationResults<
   TMFields extends object,
   TMIDField extends keyof NonNullable<Pick<TMFields, TMSelectedFields>>,
   TMViewerContext extends ViewerContext,
+  TMViewerContext2 extends TMViewerContext,
   TMEntity extends ReadonlyEntity<TMFields, TMIDField, TMViewerContext, TMSelectedFields>,
   TMPrivacyPolicy extends EntityPrivacyPolicy<
     TMFields,
@@ -87,7 +89,7 @@ export function knexLoaderWithAuthorizationResults<
     TMPrivacyPolicy,
     TMSelectedFields
   >,
-  viewerContext: TMViewerContext,
+  viewerContext: TMViewerContext2,
   queryContext: EntityQueryContext = viewerContext
     .getViewerScopedEntityCompanionForClass(entityClass)
     .getQueryContextProvider()


### PR DESCRIPTION
# Why

When these were installed extension functions, we could get away without the `TMViewerContext2` technique. But now that these are loader methods on the `PostgresEntity` subclass, we need this again (it's the same as Entity and ReadonlyEntity).

This type allows the typechecker to behave correctly when a subclass of ViewerContext is used.

# How

Add generic the same as ReadonlyEntity/Entity.

# Test Plan

`yarn tsc` in application that uses ViewerContext subclass and knexLoader.