### PR TITLE
chore: raw -> unsafeRaw

### DIFF
--- a/packages/entity-database-adapter-knex/src/SQLOperator.ts
+++ b/packages/entity-database-adapter-knex/src/SQLOperator.ts
@@ -180,7 +180,7 @@ export class SQLIdentifier {
  * Helper for raw SQL that should not be parameterized
  * WARNING: Only use this with trusted input to avoid SQL injection
  */
-export class SQLRaw {
+export class SQLUnsafeRaw {
   constructor(public readonly rawSql: string) {}
 }
 
@@ -207,14 +207,14 @@ export function identifier(name: string): SQLIdentifier {
  * ```ts
  * // Dynamic column names
  * const sortColumn = 'created_at';
- * const query = sql`ORDER BY ${raw(sortColumn)} DESC`;
+ * const query = sql`ORDER BY ${unsafeRaw(sortColumn)} DESC`;
  *
  * // Dynamic SQL expressions
- * const query = sql`WHERE ${raw('EXTRACT(year FROM created_at)')} = ${2024}`;
+ * const query = sql`WHERE ${unsafeRaw('EXTRACT(year FROM created_at)')} = ${2024}`;
  * ```
  */
-export function raw(sqlString: string): SQLRaw {
-  return new SQLRaw(sqlString);
+export function unsafeRaw(sqlString: string): SQLUnsafeRaw {
+  return new SQLUnsafeRaw(sqlString);
 }
 
 /**
@@ -228,7 +228,7 @@ export function raw(sqlString: string): SQLRaw {
  */
 export function sql(
   strings: TemplateStringsArray,
-  ...values: readonly (SupportedSQLValue | SQLFragment | SQLIdentifier | SQLRaw)[]
+  ...values: readonly (SupportedSQLValue | SQLFragment | SQLIdentifier | SQLUnsafeRaw)[]
 ): SQLFragment {
   let sqlString = '';
   const bindings: SQLBinding[] = [];
@@ -246,7 +246,7 @@ export function sql(
         // Handle identifiers (table/column names) with ?? placeholder
         sqlString += '??';
         bindings.push({ type: 'identifier', name: value.name });
-      } else if (value instanceof SQLRaw) {
+      } else if (value instanceof SQLUnsafeRaw) {
         // Handle raw SQL (WARNING: no parameterization)
         sqlString += value.rawSql;
       } else if (Array.isArray(value)) {

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -13,7 +13,7 @@ import { setTimeout } from 'timers/promises';
 import { PaginationSpecification } from '../AuthorizationResultBasedKnexEntityLoader';
 import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
 import { PaginationStrategy } from '../PaginationStrategy';
-import { raw, sql, SQLFragmentHelpers } from '../SQLOperator';
+import { unsafeRaw, sql, SQLFragmentHelpers } from '../SQLOperator';
 import {
   PostgresTestEntity,
   PostgresTestEntityFields,
@@ -631,8 +631,8 @@ describe('postgres entity integration', () => {
       // Test raw SQL for dynamic column names with orderBySQL
       const sortColumn = 'name';
       const rawResults = await PostgresTestEntity.knexLoader(vc1)
-        .loadManyBySQL(sql`${raw('name')} LIKE ${'RawTest%'}`)
-        .orderBySQL(sql`${raw(sortColumn)}`, OrderByOrdering.DESCENDING)
+        .loadManyBySQL(sql`${unsafeRaw('name')} LIKE ${'RawTest%'}`)
+        .orderBySQL(sql`${unsafeRaw(sortColumn)}`, OrderByOrdering.DESCENDING)
         .executeAsync();
 
       expect(rawResults).toHaveLength(3);
@@ -651,7 +651,7 @@ describe('postgres entity integration', () => {
           END`,
           OrderByOrdering.ASCENDING,
         )
-        .orderBySQL(sql`${raw('name')}`, OrderByOrdering.ASCENDING)
+        .orderBySQL(sql`${unsafeRaw('name')}`, OrderByOrdering.ASCENDING)
         .executeAsync();
 
       expect(priorityResults).toHaveLength(3);
@@ -662,7 +662,7 @@ describe('postgres entity integration', () => {
       // Test raw SQL with complex expressions - using CASE statement
       const complexExpression = await PostgresTestEntity.knexLoader(vc1)
         .loadManyBySQL(
-          sql`${raw('CASE WHEN has_a_cat THEN 1 ELSE 0 END')} + ${raw(
+          sql`${unsafeRaw('CASE WHEN has_a_cat THEN 1 ELSE 0 END')} + ${unsafeRaw(
             'CASE WHEN has_a_dog THEN 1 ELSE 0 END',
           )} >= 1 AND name LIKE ${'RawTest%'}`,
         )
@@ -766,7 +766,7 @@ describe('postgres entity integration', () => {
       // Test 1: Simple orderBySQL with raw column
       const simpleOrder = await PostgresTestEntity.knexLoader(vc1)
         .loadManyBySQL(sql`name LIKE ${'OrderTest%'}`)
-        .orderBySQL(sql`${raw('name')}`, OrderByOrdering.DESCENDING)
+        .orderBySQL(sql`${unsafeRaw('name')}`, OrderByOrdering.DESCENDING)
         .executeAsync();
 
       expect(simpleOrder).toHaveLength(4);
@@ -790,7 +790,7 @@ describe('postgres entity integration', () => {
             ELSE ${priority4}
           END`,
         )
-        .orderBySQL(sql`${raw('name')}`, OrderByOrdering.ASCENDING)
+        .orderBySQL(sql`${unsafeRaw('name')}`, OrderByOrdering.ASCENDING)
         .executeAsync();
 
       expect(caseOrder).toHaveLength(4);
@@ -803,7 +803,7 @@ describe('postgres entity integration', () => {
       const arrayLengthOrder = await PostgresTestEntity.knexLoader(vc1)
         .loadManyBySQL(sql`name LIKE ${'OrderTest%'}`)
         .orderBySQL(sql`COALESCE(array_length(string_array, 1), 0)`, OrderByOrdering.DESCENDING)
-        .orderBySQL(sql`${raw('name')}`, OrderByOrdering.ASCENDING)
+        .orderBySQL(sql`${unsafeRaw('name')}`, OrderByOrdering.ASCENDING)
         .executeAsync();
 
       expect(arrayLengthOrder).toHaveLength(4);
@@ -815,7 +815,7 @@ describe('postgres entity integration', () => {
       // Test 4: Combining orderBySQL with limit and offset
       const limitedOrder = await PostgresTestEntity.knexLoader(vc1)
         .loadManyBySQL(sql`name LIKE ${'OrderTest%'}`)
-        .orderBySQL(sql`${raw('name')}`, OrderByOrdering.ASCENDING)
+        .orderBySQL(sql`${unsafeRaw('name')}`, OrderByOrdering.ASCENDING)
         .limit(2)
         .offset(1)
         .executeAsync();
@@ -1017,7 +1017,7 @@ describe('postgres entity integration', () => {
         PostgresTestEntity.knexLoader(vc1).loadManyByFieldEqualityConjunctionAsync([], {
           orderBy: [
             {
-              fieldFragment: sql`${raw('name')} ASC`,
+              fieldFragment: sql`${unsafeRaw('name')} ASC`,
               order: OrderByOrdering.ASCENDING,
             },
           ],
@@ -1028,7 +1028,7 @@ describe('postgres entity integration', () => {
         PostgresTestEntity.knexLoader(vc1).loadManyByFieldEqualityConjunctionAsync([], {
           orderBy: [
             {
-              fieldFragment: sql`${raw('name')} desc`,
+              fieldFragment: sql`${unsafeRaw('name')} desc`,
               order: OrderByOrdering.DESCENDING,
             },
           ],

--- a/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   identifier,
-  raw,
+  unsafeRaw,
   sql,
   SQLFragment,
   SQLFragmentHelpers,
@@ -75,14 +75,14 @@ describe('SQLOperator', () => {
 
     it('handles raw SQL', () => {
       const columnName = 'created_at';
-      const fragment = sql`ORDER BY ${raw(columnName)} DESC`;
+      const fragment = sql`ORDER BY ${unsafeRaw(columnName)} DESC`;
 
       expect(fragment.sql).toBe('ORDER BY created_at DESC');
       expect(fragment.getKnexBindings()).toEqual([]);
     });
 
     it('handles complex raw SQL expressions', () => {
-      const fragment = sql`WHERE ${raw('EXTRACT(year FROM created_at)')} = ${2024}`;
+      const fragment = sql`WHERE ${unsafeRaw('EXTRACT(year FROM created_at)')} = ${2024}`;
 
       expect(fragment.sql).toBe('WHERE EXTRACT(year FROM created_at) = ?');
       expect(fragment.getKnexBindings()).toEqual([2024]);
@@ -90,7 +90,7 @@ describe('SQLOperator', () => {
 
     it('combines raw SQL with regular parameters', () => {
       const sortColumn = 'name';
-      const fragment = sql`SELECT * FROM users WHERE age > ${18} ORDER BY ${raw(sortColumn)} ${raw('DESC')}`;
+      const fragment = sql`SELECT * FROM users WHERE age > ${18} ORDER BY ${unsafeRaw(sortColumn)} ${unsafeRaw('DESC')}`;
 
       expect(fragment.sql).toBe('SELECT * FROM users WHERE age > ? ORDER BY name DESC');
       expect(fragment.getKnexBindings()).toEqual([18]);

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -18,7 +18,7 @@ import {
   PostgresQuerySelectionModifiers,
 } from '../BasePostgresEntityDatabaseAdapter';
 import { PaginationStrategy } from '../PaginationStrategy';
-import { SQLFragment, SQLFragmentHelpers, identifier, raw, sql } from '../SQLOperator';
+import { SQLFragment, SQLFragmentHelpers, identifier, unsafeRaw, sql } from '../SQLOperator';
 import { DistributiveOmit, NonNullableKeys } from './utilityTypes';
 
 interface DataManagerStandardSpecification<TFields extends Record<string, any>> {
@@ -586,14 +586,14 @@ export class EntityKnexDataManager<
       return field.fieldConstructor((fieldName) => {
         const dbField = getDatabaseFieldForEntityField(this.entityConfiguration, fieldName);
         return tableAlias
-          ? sql`${raw(tableAlias)}.${identifier(dbField)}`
+          ? sql`${unsafeRaw(tableAlias)}.${identifier(dbField)}`
           : sql`${identifier(dbField)}`;
       });
     }
 
     const dbField = getDatabaseFieldForEntityField(this.entityConfiguration, field);
     return tableAlias
-      ? sql`${raw(tableAlias)}.${identifier(dbField)}`
+      ? sql`${unsafeRaw(tableAlias)}.${identifier(dbField)}`
       : sql`${identifier(dbField)}`;
   }
 
@@ -636,10 +636,10 @@ export class EntityKnexDataManager<
     // Build SELECT fields for subquery
     const rightSideSubquery = sql`
       SELECT ${SQLFragment.joinWithCommaSeparator(...postgresCursorRowFieldIdentifiers)}
-      FROM ${identifier(tableName)} AS ${raw(CURSOR_ROW_TABLE_ALIAS)}
-      WHERE ${raw(CURSOR_ROW_TABLE_ALIAS)}.${identifier(idField)} = ${decodedExternalCursorEntityID}
+      FROM ${identifier(tableName)} AS ${unsafeRaw(CURSOR_ROW_TABLE_ALIAS)}
+      WHERE ${unsafeRaw(CURSOR_ROW_TABLE_ALIAS)}.${identifier(idField)} = ${decodedExternalCursorEntityID}
     `;
-    return sql`(${leftSide}) ${raw(operator)} (${rightSideSubquery})`;
+    return sql`(${leftSide}) ${unsafeRaw(operator)} (${rightSideSubquery})`;
   }
 
   private buildILikeConditions(
@@ -730,16 +730,16 @@ export class EntityKnexDataManager<
       cursorExactMatchExpr,
       cursorSimilarityExpr,
       ...cursorExtraFields,
-      sql`${raw(CURSOR_ROW_TABLE_ALIAS)}.${identifier(idField)}`,
+      sql`${unsafeRaw(CURSOR_ROW_TABLE_ALIAS)}.${identifier(idField)}`,
     ];
 
     const rightSideSubquery = sql`
       SELECT ${SQLFragment.joinWithCommaSeparator(...selectFields)}
-      FROM ${identifier(this.entityConfiguration.tableName)} AS ${raw(CURSOR_ROW_TABLE_ALIAS)}
-      WHERE ${raw(CURSOR_ROW_TABLE_ALIAS)}.${identifier(idField)} = ${decodedExternalCursorEntityID}
+      FROM ${identifier(this.entityConfiguration.tableName)} AS ${unsafeRaw(CURSOR_ROW_TABLE_ALIAS)}
+      WHERE ${unsafeRaw(CURSOR_ROW_TABLE_ALIAS)}.${identifier(idField)} = ${decodedExternalCursorEntityID}
     `;
 
-    return sql`(${leftSide}) ${raw(operator)} (${rightSideSubquery})`;
+    return sql`(${leftSide}) ${unsafeRaw(operator)} (${rightSideSubquery})`;
   }
 
   private buildSearchConditionAndOrderBy(search: DataManagerSearchSpecification<TFields>): {


### PR DESCRIPTION
# Why

Asked claude to do a security review of entity-database-adapter-knex and renaming `raw` to `unsafeRaw` was one suggestion.

# How

Rename.

# Test Plan

`yarn tsc`