### PR TITLE
feat: add entityField SQL helper

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -105,8 +105,8 @@ export class StubPostgresDatabaseAdapter<
     return results[0] ?? null;
   }
 
-  private static compareByOrderBys(
-    orderBys: TableOrderByClause[],
+  private static compareByOrderBys<TFields extends Record<string, any>>(
+    orderBys: TableOrderByClause<TFields>[],
     objectA: { [key: string]: any },
     objectB: { [key: string]: any },
   ): 0 | 1 | -1 {
@@ -160,7 +160,7 @@ export class StubPostgresDatabaseAdapter<
     tableName: string,
     tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
     tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
-    querySelectionModifiers: TableQuerySelectionModifiers,
+    querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
     let filteredObjects = this.getObjectCollectionForTable(tableName);
     for (const { tableField, tableValue } of tableFieldSingleValueEqualityOperands) {
@@ -196,7 +196,7 @@ export class StubPostgresDatabaseAdapter<
     _tableName: string,
     _rawWhereClause: string,
     _bindings: object | any[],
-    _querySelectionModifiers: TableQuerySelectionModifiers,
+    _querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
     throw new Error('Raw WHERE clauses not supported for StubDatabaseAdapter');
   }
@@ -204,8 +204,8 @@ export class StubPostgresDatabaseAdapter<
   protected fetchManyBySQLFragmentInternalAsync(
     _queryInterface: any,
     _tableName: string,
-    _sqlFragment: SQLFragment,
-    _querySelectionModifiers: TableQuerySelectionModifiers,
+    _sqlFragment: SQLFragment<TFields>,
+    _querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
     throw new Error('SQL fragments not supported for StubDatabaseAdapter');
   }

--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -43,12 +43,15 @@ export type EntityLoaderFieldNameOrderByClause<
   fieldName: TSelectedFields;
 };
 
-export type EntityLoaderFieldFragmentOrderByClause = EntityLoaderBaseOrderByClause & {
+export type EntityLoaderFieldFragmentOrderByClause<
+  TFields extends Record<string, any>,
+  TSelectedFields extends keyof TFields = keyof TFields,
+> = EntityLoaderBaseOrderByClause & {
   /**
    * The SQL fragment to order by, which can reference selected fields. Example: `COALESCE(NULLIF(display_name, ''), split_part(full_name, '/', 2))`.
    * May not contain ASC or DESC, as ordering direction is controlled by the `order` property.
    */
-  fieldFragment: SQLFragment;
+  fieldFragment: SQLFragment<Pick<TFields, TSelectedFields>>;
 };
 
 export type EntityLoaderOrderByClause<
@@ -56,7 +59,7 @@ export type EntityLoaderOrderByClause<
   TSelectedFields extends keyof TFields = keyof TFields,
 > =
   | EntityLoaderFieldNameOrderByClause<TFields, TSelectedFields>
-  | EntityLoaderFieldFragmentOrderByClause;
+  | EntityLoaderFieldFragmentOrderByClause<TFields, TSelectedFields>;
 
 /**
  * SQL modifiers that only affect the selection but not the projection.
@@ -88,7 +91,7 @@ export interface EntityLoaderQuerySelectionModifiers<
 export type EntityLoaderFieldNameConstructorFn<
   TFields extends Record<string, any>,
   TSelectedFields extends keyof TFields = keyof TFields,
-> = (fieldName: TSelectedFields) => SQLFragment;
+> = (fieldName: TSelectedFields) => SQLFragment<TFields>;
 
 /**
  * Specification for a search field that is a manually constructed SQLFragment. Useful for complex search fields that require
@@ -122,7 +125,7 @@ export type EntityLoaderSearchFieldSQLFragmentFnSpecification<
      * Helper function to get a SQLFragment for a given field name, which should be used to construct the final SQLFragment for the search field.
      */
     getFragmentForFieldName: EntityLoaderFieldNameConstructorFn<TFields, TSelectedFields>,
-  ) => SQLFragment;
+  ) => SQLFragment<Pick<TFields, TSelectedFields>>;
 };
 
 /**
@@ -240,7 +243,7 @@ interface EntityLoaderBaseUnifiedPaginationArgs<
   /**
    * SQLFragment representing the WHERE clause to filter the entities being paginated.
    */
-  where?: SQLFragment;
+  where?: SQLFragment<Pick<TFields, TSelectedFields>>;
 
   /**
    * Pagination specification determining how to order and paginate results.
@@ -421,7 +424,7 @@ export class AuthorizationResultBasedKnexEntityLoader<
    * @returns SQL query builder for building and executing SQL queries that when executed returns entity results where result error can be UnauthorizedError.
    */
   loadManyBySQL(
-    fragment: SQLFragment,
+    fragment: SQLFragment<Pick<TFields, TSelectedFields>>,
     modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): AuthorizationResultBasedSQLQueryBuilder<
     TFields,
@@ -515,7 +518,7 @@ export class AuthorizationResultBasedSQLQueryBuilder<
       TSelectedFields
     >,
     private readonly queryContext: EntityQueryContext,
-    sqlFragment: SQLFragment,
+    sqlFragment: SQLFragment<Pick<TFields, TSelectedFields>>,
     modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields>,
   ) {
     super(sqlFragment, modifiers);

--- a/packages/entity-database-adapter-knex/src/BaseSQLQueryBuilder.ts
+++ b/packages/entity-database-adapter-knex/src/BaseSQLQueryBuilder.ts
@@ -16,7 +16,7 @@ export abstract class BaseSQLQueryBuilder<
   private executed = false;
 
   constructor(
-    private readonly sqlFragment: SQLFragment,
+    private readonly sqlFragment: SQLFragment<Pick<TFields, TSelectedFields>>,
     private readonly modifiers: {
       limit?: number;
       offset?: number;
@@ -71,7 +71,7 @@ export abstract class BaseSQLQueryBuilder<
    * @param order - The ordering direction (ascending or descending). Defaults to ascending.
    */
   orderBySQL(
-    fragment: SQLFragment,
+    fragment: SQLFragment<Pick<TFields, TSelectedFields>>,
     order: OrderByOrdering = OrderByOrdering.ASCENDING,
     nulls: NullsOrdering | undefined = undefined,
   ): this {
@@ -92,7 +92,7 @@ export abstract class BaseSQLQueryBuilder<
   /**
    * Get the SQL fragment
    */
-  protected getSQLFragment(): SQLFragment {
+  protected getSQLFragment(): SQLFragment<Pick<TFields, TSelectedFields>> {
     return this.sqlFragment;
   }
 

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -168,7 +168,7 @@ export class EnforcingKnexEntityLoader<
    * ```
    */
   loadManyBySQL(
-    fragment: SQLFragment,
+    fragment: SQLFragment<Pick<TFields, TSelectedFields>>,
     modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields> = {},
   ): EnforcingSQLQueryBuilder<
     TFields,
@@ -251,7 +251,7 @@ export class EnforcingSQLQueryBuilder<
       TPrivacyPolicy,
       TSelectedFields
     >,
-    sqlFragment: SQLFragment,
+    sqlFragment: SQLFragment<Pick<TFields, TSelectedFields>>,
     modifiers: EntityLoaderQuerySelectionModifiers<TFields, TSelectedFields>,
   ) {
     super(sqlFragment, modifiers);

--- a/packages/entity-database-adapter-knex/src/SQLOperator.ts
+++ b/packages/entity-database-adapter-knex/src/SQLOperator.ts
@@ -17,29 +17,37 @@ export type SupportedSQLValue =
 /**
  * Types of bindings that can be used in SQL queries.
  */
-export type SQLBinding =
+export type SQLBinding<TFields extends Record<string, any>> =
   | { type: 'value'; value: SupportedSQLValue }
-  | { type: 'identifier'; name: string };
+  | { type: 'identifier'; name: string }
+  | { type: 'entityField'; fieldName: keyof TFields };
 
 /**
  * SQL Fragment class that safely handles parameterized queries.
  */
-export class SQLFragment {
+export class SQLFragment<TFields extends Record<string, any>> {
   constructor(
     public readonly sql: string,
-    public readonly bindings: readonly SQLBinding[],
+    public readonly bindings: readonly SQLBinding<TFields>[],
   ) {}
 
   /**
    * Get bindings in the format expected by Knex.
    * Knex expects a flat array where both identifiers and values are mixed in order.
+   *
+   * @param getColumnForField - function that resolves an entity field name to its database column name
    */
-  getKnexBindings(): readonly (string | SupportedSQLValue)[] {
+  getKnexBindings(
+    getColumnForField: (fieldName: keyof TFields) => string,
+  ): readonly (string | SupportedSQLValue)[] {
     return this.bindings.map((b) => {
-      if (b.type === 'identifier') {
-        return b.name;
-      } else {
-        return b.value;
+      switch (b.type) {
+        case 'entityField':
+          return getColumnForField(b.fieldName);
+        case 'identifier':
+          return b.name;
+        case 'value':
+          return b.value;
       }
     });
   }
@@ -47,7 +55,7 @@ export class SQLFragment {
   /**
    * Combine SQL fragments
    */
-  append(other: SQLFragment): SQLFragment {
+  append(other: SQLFragment<TFields>): SQLFragment<TFields> {
     return joinSQLFragments([this, other], ' ');
   }
 
@@ -58,7 +66,9 @@ export class SQLFragment {
    * @param fragments - Array of SQL fragments to join
    * @returns - A new SQLFragment with the fragments joined by a comma and space
    */
-  static joinWithCommaSeparator(...fragments: readonly SQLFragment[]): SQLFragment {
+  static joinWithCommaSeparator<TFields extends Record<string, any>>(
+    ...fragments: readonly SQLFragment<TFields>[]
+  ): SQLFragment<TFields> {
     return joinSQLFragments(fragments, ', ');
   }
 
@@ -74,7 +84,9 @@ export class SQLFragment {
    * // Generates: "SELECT * FROM users WHERE age > ? ORDER BY name"
    * ```
    */
-  static concat(...fragments: readonly SQLFragment[]): SQLFragment {
+  static concat<TFields extends Record<string, any>>(
+    ...fragments: readonly SQLFragment<TFields>[]
+  ): SQLFragment<TFields> {
     return joinSQLFragments(fragments, ' ');
   }
 
@@ -100,6 +112,9 @@ export class SQLFragment {
       if (match === '??' && binding.type === 'identifier') {
         // For identifiers, show them quoted as they would appear
         return `"${binding.name.replace(/"/g, '""')}"`;
+      } else if (match === '??' && binding.type === 'entityField') {
+        // For entity fields, show the entity field name as the identifier for debugging
+        return `"${binding.fieldName.toString()}"`;
       } else if (match === '?' && binding.type === 'value') {
         return SQLFragment.formatDebugValue(binding.value);
       } else {
@@ -177,6 +192,14 @@ export class SQLIdentifier {
 }
 
 /**
+ * Helper for referencing entity fields that can be used in SQL queries. This allows for type-safe references to fields of an entity
+ * and does automatic translation to DB field names.
+ */
+export class SQLEntityField<TFields extends Record<string, any>> {
+  constructor(public readonly fieldName: keyof TFields) {}
+}
+
+/**
  * Helper for raw SQL that should not be parameterized
  * WARNING: Only use this with trusted input to avoid SQL injection
  */
@@ -186,7 +209,6 @@ export class SQLUnsafeRaw {
 
 /**
  * Create a SQL identifier (table/column name) that will be escaped by Knex using ??.
- * The escaping is delegated to Knex which will handle it based on the database type.
  *
  * @example
  * ```ts
@@ -197,6 +219,18 @@ export class SQLUnsafeRaw {
  */
 export function identifier(name: string): SQLIdentifier {
   return new SQLIdentifier(name);
+}
+
+/**
+ * Create a reference to an entity field that can be used in SQL queries. This allows for type-safe references to fields of an entity
+ * and does automatic translation to DB field names and will be escaped by Knex using ??.
+ *
+ * @param fieldName - The entity field name to reference.
+ */
+export function entityField<TFields extends Record<string, any>>(
+  fieldName: keyof TFields,
+): SQLEntityField<TFields> {
+  return new SQLEntityField(fieldName);
 }
 
 /**
@@ -226,12 +260,18 @@ export function unsafeRaw(sqlString: string): SQLUnsafeRaw {
  * const query = sql`age >= ${age} AND status = ${'active'}`;
  * ```
  */
-export function sql(
+export function sql<TFields extends Record<string, any>>(
   strings: TemplateStringsArray,
-  ...values: readonly (SupportedSQLValue | SQLFragment | SQLIdentifier | SQLUnsafeRaw)[]
-): SQLFragment {
+  ...values: readonly (
+    | SupportedSQLValue
+    | SQLFragment<TFields>
+    | SQLIdentifier
+    | SQLUnsafeRaw
+    | SQLEntityField<TFields>
+  )[]
+): SQLFragment<TFields> {
   let sqlString = '';
-  const bindings: SQLBinding[] = [];
+  const bindings: SQLBinding<TFields>[] = [];
 
   strings.forEach((string, i) => {
     sqlString += string;
@@ -246,13 +286,17 @@ export function sql(
         // Handle identifiers (table/column names) with ?? placeholder
         sqlString += '??';
         bindings.push({ type: 'identifier', name: value.name });
+      } else if (value instanceof SQLEntityField) {
+        // Handle entity field references by treating them as identifiers
+        sqlString += '??';
+        bindings.push({ type: 'entityField', fieldName: value.fieldName });
       } else if (value instanceof SQLUnsafeRaw) {
         // Handle raw SQL (WARNING: no parameterization)
         sqlString += value.rawSql;
       } else if (Array.isArray(value)) {
         // Handle IN clauses
         sqlString += `(${value.map(() => '?').join(', ')})`;
-        bindings.push(...value.map((v) => ({ type: 'value' as const, value: v })));
+        bindings.push(...value.map((v): SQLBinding<TFields> => ({ type: 'value', value: v })));
       } else {
         // Regular value binding
         sqlString += '?';
@@ -264,6 +308,10 @@ export function sql(
   return new SQLFragment(sqlString, bindings);
 }
 
+type PickSupportedSQLValueKeys<T> = {
+  [K in keyof T]: T[K] extends SupportedSQLValue ? K : never;
+}[keyof T];
+
 /**
  * Common SQL helper functions for building queries
  */
@@ -273,28 +321,33 @@ export const SQLFragmentHelpers = {
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.inArray('status', ['active', 'pending']);
-   * // Generates: ?? IN (?, ?) with bindings ['status', 'active', 'pending']
+   * const query = SQLFragmentHelpers.inArray<MyFields, 'id'>('status', ['active', 'pending']);
+   * // Generates: ?? IN (?, ?) with entityField binding for 'status' and value bindings
    * ```
    */
-  inArray<T extends SupportedSQLValue>(column: string, values: readonly T[]): SQLFragment {
+  inArray<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    values: readonly TFields[N][],
+  ): SQLFragment<TFields> {
     if (values.length === 0) {
       // Handle empty array case - always false
       return sql`1 = 0`;
     }
-    // The array is already correctly typed, just needs to be seen as SupportedSQLValue for the template
-    return sql`${identifier(column)} IN ${values as readonly SupportedSQLValue[]}`;
+    return sql`${entityField(fieldName)} IN ${values}`;
   },
 
   /**
    * NOT IN clause helper
    */
-  notInArray<T extends SupportedSQLValue>(column: string, values: readonly T[]): SQLFragment {
+  notInArray<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    values: readonly TFields[N][],
+  ): SQLFragment<TFields> {
     if (values.length === 0) {
       // Handle empty array case - always true
       return sql`1 = 1`;
     }
-    return sql`${identifier(column)} NOT IN ${values as readonly SupportedSQLValue[]}`;
+    return sql`${entityField(fieldName)} NOT IN ${values}`;
   },
 
   /**
@@ -302,19 +355,27 @@ export const SQLFragmentHelpers = {
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.between('age', 18, 65);
-   * // Generates: "age" BETWEEN ? AND ? with values [18, 65]
+   * const query = SQLFragmentHelpers.between<MyFields, 'id'>('age', 18, 65);
+   * // Generates: ?? BETWEEN ? AND ? with entityField binding for 'age' and value bindings
    * ```
    */
-  between<T extends string | number | Date>(column: string, min: T, max: T): SQLFragment {
-    return sql`${identifier(column)} BETWEEN ${min} AND ${max}`;
+  between<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    min: TFields[N],
+    max: TFields[N],
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} BETWEEN ${min} AND ${max}`;
   },
 
   /**
    * NOT BETWEEN helper
    */
-  notBetween<T extends string | number | Date>(column: string, min: T, max: T): SQLFragment {
-    return sql`${identifier(column)} NOT BETWEEN ${min} AND ${max}`;
+  notBetween<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    min: TFields[N],
+    max: TFields[N],
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} NOT BETWEEN ${min} AND ${max}`;
   },
 
   /**
@@ -322,129 +383,173 @@ export const SQLFragmentHelpers = {
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.like('name', '%John%');
-   * // Generates: "name" LIKE ? with value '%John%'
+   * const query = SQLFragmentHelpers.like<MyFields, 'id'>('name', '%John%');
+   * // Generates: ?? LIKE ? with entityField binding for 'name' and value binding
    * ```
    */
-  like(column: string, pattern: string): SQLFragment {
-    return sql`${identifier(column)} LIKE ${pattern}`;
+  like<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    pattern: string,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} LIKE ${pattern}`;
   },
 
   /**
    * NOT LIKE helper
    */
-  notLike(column: string, pattern: string): SQLFragment {
-    return sql`${identifier(column)} NOT LIKE ${pattern}`;
+  notLike<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    pattern: string,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} NOT LIKE ${pattern}`;
   },
 
   /**
    * ILIKE helper for case-insensitive matching
    */
-  ilike(column: string, pattern: string): SQLFragment {
-    return sql`${identifier(column)} ILIKE ${pattern}`;
+  ilike<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    pattern: string,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} ILIKE ${pattern}`;
   },
 
   /**
    * NOT ILIKE helper for case-insensitive non-matching
    */
-  notIlike(column: string, pattern: string): SQLFragment {
-    return sql`${identifier(column)} NOT ILIKE ${pattern}`;
+  notIlike<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    pattern: string,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} NOT ILIKE ${pattern}`;
   },
 
   /**
    * NULL check helper
    */
-  isNull(column: string): SQLFragment {
-    return sql`${identifier(column)} IS NULL`;
+  isNull<TFields extends Record<string, any>>(fieldName: keyof TFields): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} IS NULL`;
   },
 
   /**
    * NOT NULL check helper
    */
-  isNotNull(column: string): SQLFragment {
-    return sql`${identifier(column)} IS NOT NULL`;
+  isNotNull<TFields extends Record<string, any>>(fieldName: keyof TFields): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} IS NOT NULL`;
   },
 
   /**
    * Single-equals-equality operator
    */
-  eq(column: string, value: SupportedSQLValue): SQLFragment {
+  eq<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    value: TFields[N],
+  ): SQLFragment<TFields> {
     if (value === null || value === undefined) {
-      return SQLFragmentHelpers.isNull(column);
+      return SQLFragmentHelpers.isNull(fieldName);
     }
-    return sql`${identifier(column)} = ${value}`;
+    return sql`${entityField(fieldName)} = ${value}`;
   },
 
   /**
    * Single-equals-inequality operator
    */
-  neq(column: string, value: SupportedSQLValue): SQLFragment {
+  neq<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    value: TFields[N],
+  ): SQLFragment<TFields> {
     if (value === null || value === undefined) {
-      return SQLFragmentHelpers.isNotNull(column);
+      return SQLFragmentHelpers.isNotNull(fieldName);
     }
-    return sql`${identifier(column)} != ${value}`;
+    return sql`${entityField(fieldName)} != ${value}`;
   },
 
   /**
    * Greater-than comparison operator
    */
-  gt(column: string, value: SupportedSQLValue): SQLFragment {
-    return sql`${identifier(column)} > ${value}`;
+  gt<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    value: TFields[N],
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} > ${value}`;
   },
 
   /**
    * Greater-than-or-equal-to comparison operator
    */
-  gte(column: string, value: SupportedSQLValue): SQLFragment {
-    return sql`${identifier(column)} >= ${value}`;
+  gte<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    value: TFields[N],
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} >= ${value}`;
   },
 
   /**
    * Less-than comparison operator
    */
-  lt(column: string, value: SupportedSQLValue): SQLFragment {
-    return sql`${identifier(column)} < ${value}`;
+  lt<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    value: TFields[N],
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} < ${value}`;
   },
 
   /**
    * Less-than-or-equal-to comparison operator
    */
-  lte(column: string, value: SupportedSQLValue): SQLFragment {
-    return sql`${identifier(column)} <= ${value}`;
+  lte<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
+    fieldName: N,
+    value: TFields[N],
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} <= ${value}`;
   },
 
   /**
    * JSON contains operator (\@\>)
    */
-  jsonContains(column: string, value: unknown): SQLFragment {
-    return sql`${identifier(column)} @> ${JSON.stringify(value)}::jsonb`;
+  jsonContains<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    value: unknown,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} @> ${JSON.stringify(value)}::jsonb`;
   },
 
   /**
    * JSON contained by operator (\<\@\)
    */
-  jsonContainedBy(column: string, value: unknown): SQLFragment {
-    return sql`${identifier(column)} <@ ${JSON.stringify(value)}::jsonb`;
+  jsonContainedBy<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    value: unknown,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)} <@ ${JSON.stringify(value)}::jsonb`;
   },
 
   /**
    * JSON path extraction helper (-\>)
    */
-  jsonPath(column: string, path: string): SQLFragment {
-    return sql`${identifier(column)}->${path}`;
+  jsonPath<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    path: string,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)}->${path}`;
   },
 
   /**
    * JSON path text extraction helper (-\>\>)
    */
-  jsonPathText(column: string, path: string): SQLFragment {
-    return sql`${identifier(column)}->>${path}`;
+  jsonPathText<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    path: string,
+  ): SQLFragment<TFields> {
+    return sql`${entityField(fieldName)}->>${path}`;
   },
 
   /**
    * Logical AND of multiple fragments
    */
-  and(...conditions: readonly SQLFragment[]): SQLFragment {
+  and<TFields extends Record<string, any>>(
+    ...conditions: readonly SQLFragment<TFields>[]
+  ): SQLFragment<TFields> {
     if (conditions.length === 0) {
       return sql`1 = 1`;
     }
@@ -457,7 +562,9 @@ export const SQLFragmentHelpers = {
   /**
    * Logical OR of multiple fragments
    */
-  or(...conditions: readonly SQLFragment[]): SQLFragment {
+  or<TFields extends Record<string, any>>(
+    ...conditions: readonly SQLFragment<TFields>[]
+  ): SQLFragment<TFields> {
     if (conditions.length === 0) {
       return sql`1 = 0`;
     }
@@ -470,20 +577,25 @@ export const SQLFragmentHelpers = {
   /**
    * Logical NOT of a fragment
    */
-  not(condition: SQLFragment): SQLFragment {
+  not<TFields extends Record<string, any>>(condition: SQLFragment<TFields>): SQLFragment<TFields> {
     return new SQLFragment('NOT (' + condition.sql + ')', condition.bindings);
   },
 
   /**
    * Parentheses helper for grouping conditions
    */
-  group(condition: SQLFragment): SQLFragment {
+  group<TFields extends Record<string, any>>(
+    condition: SQLFragment<TFields>,
+  ): SQLFragment<TFields> {
     return new SQLFragment('(' + condition.sql + ')', condition.bindings);
   },
 };
 
 // Internal helper function to join SQL fragments with a specified separator
-function joinSQLFragments(fragments: readonly SQLFragment[], separator: string): SQLFragment {
+function joinSQLFragments<TFields extends Record<string, any>>(
+  fragments: readonly SQLFragment<TFields>[],
+  separator: string,
+): SQLFragment<TFields> {
   return new SQLFragment(
     fragments.map((f) => f.sql).join(separator),
     fragments.flatMap((f) => f.bindings),

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -13,7 +13,7 @@ import { setTimeout } from 'timers/promises';
 import { PaginationSpecification } from '../AuthorizationResultBasedKnexEntityLoader';
 import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
 import { PaginationStrategy } from '../PaginationStrategy';
-import { unsafeRaw, sql, SQLFragmentHelpers } from '../SQLOperator';
+import { entityField, unsafeRaw, sql, SQLFragmentHelpers, SQLFragment } from '../SQLOperator';
 import {
   PostgresTestEntity,
   PostgresTestEntityFields,
@@ -484,7 +484,7 @@ describe('postgres entity integration', () => {
 
       // Test AND condition
       const bothPets = await PostgresTestEntity.knexLoader(vc1)
-        .loadManyBySQL(and(eq('has_a_cat', true), eq('has_a_dog', true)))
+        .loadManyBySQL(and(eq('hasACat', true), eq('hasADog', true)))
         .executeAsync();
 
       expect(bothPets).toHaveLength(1);
@@ -492,7 +492,7 @@ describe('postgres entity integration', () => {
 
       // Test OR condition
       const eitherPet = await PostgresTestEntity.knexLoader(vc1)
-        .loadManyBySQL(or(eq('has_a_cat', false), eq('has_a_dog', false)))
+        .loadManyBySQL(or(eq('hasACat', false), eq('hasADog', false)))
         .orderBy('name', OrderByOrdering.ASCENDING)
         .executeAsync();
 
@@ -512,13 +512,61 @@ describe('postgres entity integration', () => {
 
       // Test complex condition
       const complexQuery = await PostgresTestEntity.knexLoader(vc1)
-        .loadManyBySQL(and(or(eq('has_a_cat', true), eq('has_a_dog', true)), neq('name', 'User2')))
+        .loadManyBySQL(and(or(eq('hasACat', true), eq('hasADog', true)), neq('name', 'User2')))
         .orderBy('name', OrderByOrdering.ASCENDING)
         .executeAsync();
 
       expect(complexQuery).toHaveLength(2);
       expect(complexQuery[0]!.getField('name')).toBe('User1');
       expect(complexQuery[1]!.getField('name')).toBe('User3');
+    });
+
+    it('supports entityField for entity-to-DB field name translation', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'EntityFieldUser1')
+          .setField('hasACat', true)
+          .setField('hasADog', false)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'EntityFieldUser2')
+          .setField('hasACat', false)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'EntityFieldUser3')
+          .setField('hasACat', true)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      // Use entityField to reference fields by entity name instead of DB column name
+      const catOwners = await PostgresTestEntity.knexLoader(vc1)
+        .loadManyBySQL(sql`${entityField('hasACat')} = ${true}`)
+        .orderBy('name', OrderByOrdering.ASCENDING)
+        .executeAsync();
+
+      expect(catOwners).toHaveLength(2);
+      expect(catOwners[0]!.getField('name')).toBe('EntityFieldUser1');
+      expect(catOwners[1]!.getField('name')).toBe('EntityFieldUser3');
+
+      // Combine entityField with other SQL constructs
+      const bothPets = await PostgresTestEntity.knexLoader(vc1)
+        .loadManyBySQL(
+          sql`${entityField('hasACat')} = ${true} AND ${entityField('hasADog')} = ${true}`,
+        )
+        .executeAsync();
+
+      expect(bothPets).toHaveLength(1);
+      expect(bothPets[0]!.getField('name')).toBe('EntityFieldUser3');
     });
 
     it('supports executeFirstAsync', async () => {
@@ -690,12 +738,12 @@ describe('postgres entity integration', () => {
       );
 
       // Test join with OR conditions
-      const conditions = [
+      const conditions: SQLFragment<PostgresTestEntityFields>[] = [
         sql`name = ${'JoinTest1'}`,
         sql`(has_a_cat = ${true} AND has_a_dog = ${true})`,
       ];
       const joinedResults = await PostgresTestEntity.knexLoader(vc1)
-        .loadManyBySQL(SQLFragmentHelpers.or(...conditions))
+        .loadManyBySQL(SQLFragmentHelpers.or<PostgresTestEntityFields>(...conditions))
         .orderBy('name', OrderByOrdering.ASCENDING)
         .executeAsync();
 
@@ -1191,11 +1239,11 @@ describe('postgres entity integration', () => {
       ).loadManyByRawWhereClauseAsync('has_a_dog = ?', [true], {
         orderBy: [
           {
-            fieldFragment: sql`has_a_dog`,
+            fieldFragment: sql`${entityField('hasADog')}`,
             order: OrderByOrdering.ASCENDING,
           },
           {
-            fieldFragment: sql`name`,
+            fieldFragment: sql`${entityField('name')}`,
             order: OrderByOrdering.DESCENDING,
           },
         ],

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -106,8 +106,8 @@ export class StubPostgresDatabaseAdapter<
     return results[0] ?? null;
   }
 
-  private static compareByOrderBys(
-    orderBys: TableOrderByClause[],
+  private static compareByOrderBys<TFields extends Record<string, any>>(
+    orderBys: TableOrderByClause<TFields>[],
     objectA: { [key: string]: any },
     objectB: { [key: string]: any },
   ): 0 | 1 | -1 {
@@ -161,7 +161,7 @@ export class StubPostgresDatabaseAdapter<
     tableName: string,
     tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
     tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
-    querySelectionModifiers: TableQuerySelectionModifiers,
+    querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
     let filteredObjects = this.getObjectCollectionForTable(tableName);
     for (const { tableField, tableValue } of tableFieldSingleValueEqualityOperands) {
@@ -197,7 +197,7 @@ export class StubPostgresDatabaseAdapter<
     _tableName: string,
     _rawWhereClause: string,
     _bindings: object | any[],
-    _querySelectionModifiers: TableQuerySelectionModifiers,
+    _querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
     throw new Error('Raw WHERE clauses not supported for StubDatabaseAdapter');
   }
@@ -205,8 +205,8 @@ export class StubPostgresDatabaseAdapter<
   protected fetchManyBySQLFragmentInternalAsync(
     _queryInterface: any,
     _tableName: string,
-    _sqlFragment: SQLFragment,
-    _querySelectionModifiers: TableQuerySelectionModifiers,
+    _sqlFragment: SQLFragment<TFields>,
+    _querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
     throw new Error('SQL fragments not supported for StubDatabaseAdapter');
   }


### PR DESCRIPTION
# Why

Asked claude to do an API usability review and it noted that forcing the user to context-switch between entity fields and database fields for SQLFragments was an unfortunate pattern.

# How

This PR provides a SQLFragment helper, `entityField<TFields>('fieldName')` which does the conversion for the user so they don't need to look up the underlying database field.

Secondarily, this provides type safety to ensure SQLFragments for one entity aren't used for SQLFragments of another entity (unless types overlap via shared config).

# Test Plan

Add feature and tests and examples.