### PR TITLE
fix: fix some security review suggestions

### DIFF
--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -95,8 +95,7 @@ export type EntityLoaderFieldNameConstructorFn<
 
 /**
  * Specification for a search field that is a manually constructed SQLFragment. Useful for complex search fields that require
- * transformations or combinations of multiple fields, such as `COALESCE(NULLIF(display_name, ''), split_part(full_name, '/', 2))`
- * to search by display name with fallback to full name.
+ * transformations to make nullable fields non-null or to make combinations of multiple fields.
  */
 export type EntityLoaderSearchFieldSQLFragmentFnSpecification<
   TFields extends Record<string, any>,

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -9,6 +9,7 @@ import { Knex } from 'knex';
 import {
   BasePostgresEntityDatabaseAdapter,
   NullsOrdering,
+  OrderByOrdering,
   TableFieldMultiValueEqualityCondition,
   TableFieldSingleValueEqualityCondition,
   TableQuerySelectionModifiers,
@@ -139,11 +140,13 @@ export class PostgresEntityDatabaseAdapter<
             orderBySpecification.nulls,
           );
         } else {
+          const orderDirection =
+            orderBySpecification.order === OrderByOrdering.ASCENDING ? 'ASC' : 'DESC';
           const nullsSuffix = orderBySpecification.nulls
             ? ` NULLS ${orderBySpecification.nulls === NullsOrdering.FIRST ? 'FIRST' : 'LAST'}`
             : '';
           ret = ret.orderByRaw(
-            `(${orderBySpecification.columnFragment.sql}) ${orderBySpecification.order}${nullsSuffix}`,
+            `(${orderBySpecification.columnFragment.sql}) ${orderDirection}${nullsSuffix}`,
             orderBySpecification.columnFragment.getKnexBindings((fieldName) =>
               getDatabaseFieldForEntityField(this.entityConfiguration, fieldName),
             ),

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -3668,9 +3668,9 @@ describe('postgres entity integration', () => {
         }
 
         const paginationSpec: PaginationSpecification<PostgresTestEntityFields> = {
-          strategy: PaginationStrategy.TRIGRAM_SEARCH as const,
+          strategy: PaginationStrategy.TRIGRAM_SEARCH,
           term: 'Johnson',
-          fields: ['label' as const],
+          fields: ['label'],
           threshold: 0.2,
           extraOrderByFields: [
             {

--- a/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
@@ -692,6 +692,26 @@ describe('SQLOperator', () => {
           '{"premium":true}',
         ]);
       });
+
+      it('generates JSON contains for null and undefined values', () => {
+        const fragmentNull = SQLFragmentHelpers.jsonContains('stringField', null);
+        const fragmentUndefined = SQLFragmentHelpers.jsonContains('stringField', undefined);
+
+        expect(fragmentNull.sql).toBe('?? @> ?::jsonb');
+        expect(fragmentNull.getKnexBindings(getColumnForField)).toEqual(['string_field', 'null']);
+
+        expect(fragmentUndefined.sql).toBe('?? @> ?::jsonb');
+        expect(fragmentUndefined.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          undefined,
+        ]);
+      });
+
+      it('throws when value is not JSON-serializable', () => {
+        expect(() => SQLFragmentHelpers.jsonContains('stringField', (() => {}) as any)).toThrow(
+          'jsonContains: value is not JSON-serializable',
+        );
+      });
     });
 
     describe(SQLFragmentHelpers.jsonContainedBy, () => {
@@ -706,6 +726,26 @@ describe('SQLOperator', () => {
           'string_field',
           '{"theme":"dark","lang":"en"}',
         ]);
+      });
+
+      it('generates JSON contained by for null and undefined values', () => {
+        const fragmentNull = SQLFragmentHelpers.jsonContainedBy('stringField', null);
+        const fragmentUndefined = SQLFragmentHelpers.jsonContainedBy('stringField', undefined);
+
+        expect(fragmentNull.sql).toBe('?? <@ ?::jsonb');
+        expect(fragmentNull.getKnexBindings(getColumnForField)).toEqual(['string_field', 'null']);
+
+        expect(fragmentUndefined.sql).toBe('?? <@ ?::jsonb');
+        expect(fragmentUndefined.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          undefined,
+        ]);
+      });
+
+      it('throws when value is not JSON-serializable', () => {
+        expect(() => SQLFragmentHelpers.jsonContainedBy('stringField', (() => {}) as any)).toThrow(
+          'jsonContainedBy: value is not JSON-serializable',
+        );
       });
     });
 


### PR DESCRIPTION
# Why

Had claude do a security review of entity-database-adapter-knex.

# How

The items it noticed were:
- `orderBySpecification.order` is type safe but could be overridden via an `any`-casted value, which could result in an injection since it was directly inserted into the knex `orderByRaw` method. The fix is to do a runtime check for value equal to the enum.
- Better type constraints for `like`/`iLike`/etc since they should only be usable for string-like fields.
- For `jsonContains`, need to constrain types and do a runtime validity check to ensure value is JSON-serializable.

# Test Plan

Run new tests.
