### PR TITLE
fix: escape all matching portions of parts of cacher cache keys

### DIFF
--- a/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
+++ b/packages/entity-cache-adapter-local-memory/src/GenericLocalMemoryCacher.ts
@@ -122,7 +122,7 @@ export class GenericLocalMemoryCacher<
 
     const delimiter = ':';
     const escapedParts = parts.map((part) =>
-      part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+      part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
     );
     return escapedParts.join(delimiter);
   }

--- a/packages/entity-cache-adapter-redis/README.md
+++ b/packages/entity-cache-adapter-redis/README.md
@@ -16,7 +16,7 @@ const genericRedisCacherContext = {
   makeKeyFn(...parts: string[]): string {
     const delimiter = ':';
     const escapedParts = parts.map((part) =>
-      part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`)
+      part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`)
     );
     return escapedParts.join(delimiter);
   },

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -215,7 +215,7 @@ export class GenericRedisCacher<
       this.context.cacheKeyPrefix,
       cacheKeyType,
       this.entityConfiguration.tableName,
-      `v2.${cacheKeyVersion}`,
+      `v3.${cacheKeyVersion}`,
       ...parts,
     );
   }

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -80,7 +80,7 @@ describe(GenericRedisCacher, () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -31,7 +31,7 @@ describe(GenericRedisCacher, () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -26,7 +26,7 @@ describe(GenericRedisCacher, () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -23,7 +23,7 @@ describe(GenericRedisCacher, () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -212,7 +212,7 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
       expect(cacheKeys).toHaveLength(1);
-      expect(cacheKeys[0]).toBe('hello-:single:blah:v2.2:id:wat');
+      expect(cacheKeys[0]).toBe('hello-:single:blah:v3.2:id:wat');
 
       await genericCacher.invalidateManyAsync(cacheKeys);
       verify(mockRedisClient.del(...cacheKeys)).once();
@@ -240,9 +240,9 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
       expect(cacheKeys).toHaveLength(3);
-      expect(cacheKeys[0]).toBe('hello-:single:blah:v2.1:id:wat');
-      expect(cacheKeys[1]).toBe('hello-:single:blah:v2.2:id:wat');
-      expect(cacheKeys[2]).toBe('hello-:single:blah:v2.3:id:wat');
+      expect(cacheKeys[0]).toBe('hello-:single:blah:v3.1:id:wat');
+      expect(cacheKeys[1]).toBe('hello-:single:blah:v3.2:id:wat');
+      expect(cacheKeys[2]).toBe('hello-:single:blah:v3.3:id:wat');
 
       await genericCacher.invalidateManyAsync(cacheKeys);
       verify(mockRedisClient.del(...cacheKeys)).once();
@@ -278,10 +278,10 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
       expect(cacheKeys).toHaveLength(4);
-      expect(cacheKeys[0]).toBe('hello-:single:blah:v2.2:id:wat');
-      expect(cacheKeys[1]).toBe('hello-:single:blah:v2.3:id:wat');
-      expect(cacheKeys[2]).toBe('hello-:single:blah:v2.4:id:wat');
-      expect(cacheKeys[3]).toBe('hello-:single:blah:v2.5:id:wat');
+      expect(cacheKeys[0]).toBe('hello-:single:blah:v3.2:id:wat');
+      expect(cacheKeys[1]).toBe('hello-:single:blah:v3.3:id:wat');
+      expect(cacheKeys[2]).toBe('hello-:single:blah:v3.4:id:wat');
+      expect(cacheKeys[3]).toBe('hello-:single:blah:v3.5:id:wat');
 
       await genericCacher.invalidateManyAsync(cacheKeys);
       verify(mockRedisClient.del(...cacheKeys)).once();

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -118,7 +118,7 @@ describe('Entity cache inconsistency', () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -118,7 +118,7 @@ describe('Lack of entity cache push safety with RedisCacheInvalidationStrategy.C
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },
@@ -210,7 +210,7 @@ describe('Entity cache push safety with RedisCacheInvalidationStrategy.SURROUNDI
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -56,7 +56,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -107,7 +107,7 @@ describe('Entity integrity', () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -195,7 +195,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
       makeKeyFn(...parts: string[]): string {
         const delimiter = ':';
         const escapedParts = parts.map((part) =>
-          part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`),
+          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
         );
         return escapedParts.join(delimiter);
       },

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -115,7 +115,7 @@ class TestLocalCacheAdapter<
       cacheKeyType,
       `${this.entityConfiguration.cacheKeyVersion}`,
       ...parts,
-    ].map((part) => part.replace('\\', '\\\\').replace(delimiter, `\\${delimiter}`));
+    ].map((part) => part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`));
     return escapedParts.join(delimiter);
   }
 }


### PR DESCRIPTION
# Why

One more review suggestion from claude. This fixes an incorrect encoding of the cache keys where if a key portion included a `:` (delimiter) it could potentially conflict with another key (though admittedly very unlikely). This happened because we were erroneously suggesting use of `replace` instead of `replaceAll`.

Note that this lives in the application code where companion provider is created, so applications will need to fix independently of this upgrade. This just fixes the suggestions.

# How

The fix is to use `replaceAll`.

# Test Plan

Run new test.
