### PR TITLE
feat: Add SQLExpression class that supports fluent comparison method API

### DIFF
--- a/packages/entity-database-adapter-knex/src/SQLOperator.ts
+++ b/packages/entity-database-adapter-knex/src/SQLOperator.ts
@@ -278,6 +278,26 @@ export function unsafeRaw(sqlString: string): SQLUnsafeRaw {
 }
 
 /**
+ * Wraps a SQLFragment or entity field name into an SQLExpression for fluent comparison usage.
+ *
+ * @example
+ * ```ts
+ * expression<MyFields>('age').gte(18)
+ * expression<MyFields>('name').ilike('%john%')
+ * expression(sql`${entityField('status')}`).eq('active')
+ * ```
+ */
+export function expression<TFields extends Record<string, any>>(
+  fragmentOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLExpression<TFields> {
+  if (fragmentOrFieldName instanceof SQLFragment) {
+    return new SQLExpression(fragmentOrFieldName.sql, fragmentOrFieldName.bindings);
+  }
+  const fragment = sql`${entityField(fragmentOrFieldName)}`;
+  return new SQLExpression(fragment.sql, fragment.bindings);
+}
+
+/**
  * Tagged template literal function for SQL queries
  *
  * @example
@@ -320,7 +340,7 @@ export function sql<TFields extends Record<string, any>>(
       } else if (value instanceof SQLArrayValue) {
         // Handle array as a single bound parameter (for = ANY(?), etc.)
         sqlString += '?';
-        bindings.push({ type: 'value', value: value.values as SupportedSQLValue });
+        bindings.push({ type: 'value', value: value.values });
       } else if (value instanceof SQLUnsafeRaw) {
         // Handle raw SQL (WARNING: no parameterization)
         sqlString += value.rawSql;
@@ -357,6 +377,141 @@ type JsonSerializable =
   | { readonly [key: string]: JsonSerializable };
 
 /**
+ * An SQL expression that supports fluent comparison methods.
+ * Extends SQLFragment so it can be used anywhere a SQLFragment is accepted.
+ * The fluent methods return plain SQLFragment instances since they produce
+ * complete conditions, not further chainable expressions.
+ */
+export class SQLExpression<TFields extends Record<string, any>> extends SQLFragment<TFields> {
+  eq(value: SupportedSQLValue): SQLFragment<TFields> {
+    if (value === null || value === undefined) {
+      return this.isNull();
+    }
+    return sql`${this} = ${value}`;
+  }
+
+  neq(value: SupportedSQLValue): SQLFragment<TFields> {
+    if (value === null || value === undefined) {
+      return this.isNotNull();
+    }
+    return sql`${this} != ${value}`;
+  }
+
+  gt(value: SupportedSQLValue): SQLFragment<TFields> {
+    return sql`${this} > ${value}`;
+  }
+
+  gte(value: SupportedSQLValue): SQLFragment<TFields> {
+    return sql`${this} >= ${value}`;
+  }
+
+  lt(value: SupportedSQLValue): SQLFragment<TFields> {
+    return sql`${this} < ${value}`;
+  }
+
+  lte(value: SupportedSQLValue): SQLFragment<TFields> {
+    return sql`${this} <= ${value}`;
+  }
+
+  isNull(): SQLFragment<TFields> {
+    return sql`${this} IS NULL`;
+  }
+
+  isNotNull(): SQLFragment<TFields> {
+    return sql`${this} IS NOT NULL`;
+  }
+
+  like(pattern: string): SQLFragment<TFields> {
+    return sql`${this} LIKE ${pattern}`;
+  }
+
+  notLike(pattern: string): SQLFragment<TFields> {
+    return sql`${this} NOT LIKE ${pattern}`;
+  }
+
+  ilike(pattern: string): SQLFragment<TFields> {
+    return sql`${this} ILIKE ${pattern}`;
+  }
+
+  notIlike(pattern: string): SQLFragment<TFields> {
+    return sql`${this} NOT ILIKE ${pattern}`;
+  }
+
+  inArray(values: readonly SupportedSQLValue[]): SQLFragment<TFields> {
+    if (values.length === 0) {
+      return sql`FALSE`;
+    }
+    return sql`${this} IN ${values}`;
+  }
+
+  notInArray(values: readonly SupportedSQLValue[]): SQLFragment<TFields> {
+    if (values.length === 0) {
+      return sql`TRUE`;
+    }
+    return sql`${this} NOT IN ${values}`;
+  }
+
+  anyArray(values: readonly SupportedSQLValue[]): SQLFragment<TFields> {
+    if (values.length === 0) {
+      return sql`FALSE`;
+    }
+    return sql`${this} = ANY(${arrayValue(values)})`;
+  }
+
+  between(min: SupportedSQLValue, max: SupportedSQLValue): SQLFragment<TFields> {
+    return sql`${this} BETWEEN ${min} AND ${max}`;
+  }
+
+  notBetween(min: SupportedSQLValue, max: SupportedSQLValue): SQLFragment<TFields> {
+    return sql`${this} NOT BETWEEN ${min} AND ${max}`;
+  }
+}
+
+/**
+ * Allowed PostgreSQL type names for the cast() helper.
+ * Only these types can be used to prevent SQL injection through type name interpolation.
+ */
+const ALLOWED_CAST_TYPES = [
+  'int',
+  'integer',
+  'int2',
+  'int4',
+  'int8',
+  'smallint',
+  'bigint',
+  'numeric',
+  'decimal',
+  'real',
+  'double precision',
+  'float',
+  'float4',
+  'float8',
+  'text',
+  'varchar',
+  'char',
+  'character varying',
+  'boolean',
+  'bool',
+  'date',
+  'time',
+  'timestamp',
+  'timestamptz',
+  'interval',
+  'json',
+  'jsonb',
+  'uuid',
+  'bytea',
+] as const;
+
+/**
+ * Allowed PostgreSQL type names for the cast() helper.
+ * Only these types can be used to prevent SQL injection through type name interpolation.
+ */
+export type PostgresCastType = (typeof ALLOWED_CAST_TYPES)[number];
+
+const ALLOWED_CAST_TYPES_SET: ReadonlySet<string> = new Set<PostgresCastType>(ALLOWED_CAST_TYPES);
+
+/**
  * Common SQL helper functions for building queries
  */
 export const SQLFragmentHelpers = {
@@ -373,11 +528,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     values: readonly TFields[N][],
   ): SQLFragment<TFields> {
-    if (values.length === 0) {
-      // Handle empty array case - always false
-      return sql`1 = 0`;
-    }
-    return sql`${entityField(fieldName)} IN ${values}`;
+    return expression<TFields>(fieldName).inArray(values);
   },
 
   /**
@@ -395,11 +546,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     values: readonly TFields[N][],
   ): SQLFragment<TFields> {
-    if (values.length === 0) {
-      // Handle empty array case - always false
-      return sql`1 = 0`;
-    }
-    return sql`${entityField(fieldName)} = ANY(${arrayValue(values)})`;
+    return expression<TFields>(fieldName).anyArray(values);
   },
 
   /**
@@ -409,11 +556,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     values: readonly TFields[N][],
   ): SQLFragment<TFields> {
-    if (values.length === 0) {
-      // Handle empty array case - always true
-      return sql`1 = 1`;
-    }
-    return sql`${entityField(fieldName)} NOT IN ${values}`;
+    return expression<TFields>(fieldName).notInArray(values);
   },
 
   /**
@@ -430,7 +573,7 @@ export const SQLFragmentHelpers = {
     min: TFields[N],
     max: TFields[N],
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} BETWEEN ${min} AND ${max}`;
+    return expression<TFields>(fieldName).between(min, max);
   },
 
   /**
@@ -441,7 +584,7 @@ export const SQLFragmentHelpers = {
     min: TFields[N],
     max: TFields[N],
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} NOT BETWEEN ${min} AND ${max}`;
+    return expression<TFields>(fieldName).notBetween(min, max);
   },
 
   /**
@@ -457,7 +600,7 @@ export const SQLFragmentHelpers = {
     fieldName: PickStringValueKeys<TFields>,
     pattern: string,
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} LIKE ${pattern}`;
+    return expression<TFields>(fieldName).like(pattern);
   },
 
   /**
@@ -467,7 +610,7 @@ export const SQLFragmentHelpers = {
     fieldName: PickStringValueKeys<TFields>,
     pattern: string,
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} NOT LIKE ${pattern}`;
+    return expression<TFields>(fieldName).notLike(pattern);
   },
 
   /**
@@ -477,7 +620,7 @@ export const SQLFragmentHelpers = {
     fieldName: PickStringValueKeys<TFields>,
     pattern: string,
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} ILIKE ${pattern}`;
+    return expression<TFields>(fieldName).ilike(pattern);
   },
 
   /**
@@ -487,21 +630,21 @@ export const SQLFragmentHelpers = {
     fieldName: PickStringValueKeys<TFields>,
     pattern: string,
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} NOT ILIKE ${pattern}`;
+    return expression<TFields>(fieldName).notIlike(pattern);
   },
 
   /**
    * NULL check helper
    */
   isNull<TFields extends Record<string, any>>(fieldName: keyof TFields): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} IS NULL`;
+    return expression<TFields>(fieldName).isNull();
   },
 
   /**
    * NOT NULL check helper
    */
   isNotNull<TFields extends Record<string, any>>(fieldName: keyof TFields): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} IS NOT NULL`;
+    return expression<TFields>(fieldName).isNotNull();
   },
 
   /**
@@ -511,10 +654,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     value: TFields[N],
   ): SQLFragment<TFields> {
-    if (value === null || value === undefined) {
-      return SQLFragmentHelpers.isNull(fieldName);
-    }
-    return sql`${entityField(fieldName)} = ${value}`;
+    return expression<TFields>(fieldName).eq(value);
   },
 
   /**
@@ -524,10 +664,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     value: TFields[N],
   ): SQLFragment<TFields> {
-    if (value === null || value === undefined) {
-      return SQLFragmentHelpers.isNotNull(fieldName);
-    }
-    return sql`${entityField(fieldName)} != ${value}`;
+    return expression<TFields>(fieldName).neq(value);
   },
 
   /**
@@ -537,7 +674,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     value: TFields[N],
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} > ${value}`;
+    return expression<TFields>(fieldName).gt(value);
   },
 
   /**
@@ -547,7 +684,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     value: TFields[N],
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} >= ${value}`;
+    return expression<TFields>(fieldName).gte(value);
   },
 
   /**
@@ -557,7 +694,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     value: TFields[N],
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} < ${value}`;
+    return expression<TFields>(fieldName).lt(value);
   },
 
   /**
@@ -567,7 +704,7 @@ export const SQLFragmentHelpers = {
     fieldName: N,
     value: TFields[N],
   ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)} <= ${value}`;
+    return expression<TFields>(fieldName).lte(value);
   },
 
   /**
@@ -604,22 +741,138 @@ export const SQLFragmentHelpers = {
 
   /**
    * JSON path extraction helper (-\>)
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
    */
   jsonPath<TFields extends Record<string, any>>(
     fieldName: keyof TFields,
     path: string,
-  ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)}->${path}`;
+  ): SQLExpression<TFields> {
+    return expression(sql`${entityField(fieldName)}->${path}`);
   },
 
   /**
    * JSON path text extraction helper (-\>\>)
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
    */
   jsonPathText<TFields extends Record<string, any>>(
     fieldName: keyof TFields,
     path: string,
-  ): SQLFragment<TFields> {
-    return sql`${entityField(fieldName)}->>${path}`;
+  ): SQLExpression<TFields> {
+    return expression(sql`${entityField(fieldName)}->>${path}`);
+  },
+
+  /**
+   * JSON deep path extraction helper (#\>)
+   * Extracts a JSON sub-object at the specified key path, returning jsonb.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   *
+   * @param fieldName - The entity field containing JSON/JSONB data
+   * @param path - Array of keys forming the path (e.g., ['user', 'address', 'city'])
+   */
+  jsonDeepPath<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    path: readonly string[],
+  ): SQLExpression<TFields> {
+    const pathLiteral = `{${path.map(quotePostgresArrayElement).join(',')}}`;
+    return expression(sql`${entityField(fieldName)} #> ${pathLiteral}`);
+  },
+
+  /**
+   * JSON deep path text extraction helper (#\>\>)
+   * Extracts a JSON sub-object at the specified key path as text.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   *
+   * @param fieldName - The entity field containing JSON/JSONB data
+   * @param path - Array of keys forming the path (e.g., ['user', 'address', 'city'])
+   */
+  jsonDeepPathText<TFields extends Record<string, any>>(
+    fieldName: keyof TFields,
+    path: readonly string[],
+  ): SQLExpression<TFields> {
+    const pathLiteral = `{${path.map(quotePostgresArrayElement).join(',')}}`;
+    return expression(sql`${entityField(fieldName)} #>> ${pathLiteral}`);
+  },
+
+  /**
+   * SQL type cast helper (::type)
+   * Casts an expression to a PostgreSQL type.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   *
+   * @param fragment - An SQLFragment or SQLExpression to cast
+   * @param typeName - The PostgreSQL type name (e.g., 'int', 'text', 'timestamptz')
+   */
+  cast<TFields extends Record<string, any>>(
+    fragmentOrExpression: SQLFragment<TFields>,
+    typeName: PostgresCastType,
+  ): SQLExpression<TFields> {
+    assert(
+      ALLOWED_CAST_TYPES_SET.has(typeName),
+      `cast: unsupported type name "${typeName}". Allowed types: ${[...ALLOWED_CAST_TYPES_SET].join(', ')}`,
+    );
+    return expression(sql`(${fragmentOrExpression})::${unsafeRaw(typeName)}`);
+  },
+
+  /**
+   * COALESCE helper
+   * Returns the first non-null value from the given expressions/values.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   */
+  coalesce<TFields extends Record<string, any>>(
+    ...args: readonly (SQLFragment<TFields> | SupportedSQLValue)[]
+  ): SQLExpression<TFields> {
+    const fragments = args.map((arg) => {
+      if (arg instanceof SQLFragment) {
+        return arg;
+      }
+      return sql`${arg}`;
+    });
+    const inner = SQLFragment.joinWithCommaSeparator(...fragments);
+    return expression(sql`COALESCE(${inner})`);
+  },
+
+  /**
+   * LOWER helper
+   * Converts a string expression to lowercase.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   */
+  lower<TFields extends Record<string, any>>(
+    expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  ): SQLExpression<TFields> {
+    const inner =
+      expressionOrFieldName instanceof SQLFragment
+        ? expressionOrFieldName
+        : sql`${entityField(expressionOrFieldName)}`;
+    return expression(sql`LOWER(${inner})`);
+  },
+
+  /**
+   * UPPER helper
+   * Converts a string expression to uppercase.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   */
+  upper<TFields extends Record<string, any>>(
+    expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  ): SQLExpression<TFields> {
+    const inner =
+      expressionOrFieldName instanceof SQLFragment
+        ? expressionOrFieldName
+        : sql`${entityField(expressionOrFieldName)}`;
+    return expression(sql`UPPER(${inner})`);
+  },
+
+  /**
+   * TRIM helper
+   * Removes leading and trailing whitespace from a string expression.
+   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   */
+  trim<TFields extends Record<string, any>>(
+    expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  ): SQLExpression<TFields> {
+    const inner =
+      expressionOrFieldName instanceof SQLFragment
+        ? expressionOrFieldName
+        : sql`${entityField(expressionOrFieldName)}`;
+    return expression(sql`TRIM(${inner})`);
   },
 
   /**
@@ -629,7 +882,7 @@ export const SQLFragmentHelpers = {
     ...conditions: readonly SQLFragment<TFields>[]
   ): SQLFragment<TFields> {
     if (conditions.length === 0) {
-      return sql`1 = 1`;
+      return sql`TRUE`;
     }
     return joinSQLFragments(
       conditions.map((c) => SQLFragmentHelpers.group(c)),
@@ -644,7 +897,7 @@ export const SQLFragmentHelpers = {
     ...conditions: readonly SQLFragment<TFields>[]
   ): SQLFragment<TFields> {
     if (conditions.length === 0) {
-      return sql`1 = 0`;
+      return sql`FALSE`;
     }
     return joinSQLFragments(
       conditions.map((c) => SQLFragmentHelpers.group(c)),
@@ -656,7 +909,7 @@ export const SQLFragmentHelpers = {
    * Logical NOT of a fragment
    */
   not<TFields extends Record<string, any>>(condition: SQLFragment<TFields>): SQLFragment<TFields> {
-    return new SQLFragment('NOT (' + condition.sql + ')', condition.bindings);
+    return sql`NOT (${condition})`;
   },
 
   /**
@@ -665,7 +918,7 @@ export const SQLFragmentHelpers = {
   group<TFields extends Record<string, any>>(
     condition: SQLFragment<TFields>,
   ): SQLFragment<TFields> {
-    return new SQLFragment('(' + condition.sql + ')', condition.bindings);
+    return sql`(${condition})`;
   },
 };
 
@@ -678,4 +931,14 @@ function joinSQLFragments<TFields extends Record<string, any>>(
     fragments.map((f) => f.sql).join(separator),
     fragments.flatMap((f) => f.bindings),
   );
+}
+
+// Internal helper to properly quote elements for PostgreSQL array literals.
+// Elements containing special characters (commas, braces, quotes, backslashes, whitespace)
+// or empty strings must be double-quoted with internal escaping.
+function quotePostgresArrayElement(element: string): string {
+  if (element === '' || /[,{}"\\\s]/.test(element)) {
+    return `"${element.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  return element;
 }

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -521,6 +521,33 @@ describe('postgres entity integration', () => {
       expect(complexQuery[1]!.getField('name')).toBe('User3');
     });
 
+    it('handles empty-array and empty-condition edge cases with TRUE/FALSE', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+      const { and, or, inArray } = SQLFragmentHelpers;
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'TrueFalseUser')
+          .setField('hasACat', true)
+          .setField('hasADog', false)
+          .createAsync(),
+      );
+
+      // inArray([]) produces FALSE — should return no results
+      const emptyIn = await PostgresTestEntity.knexLoader(vc1)
+        .loadManyBySQL(inArray('name', []))
+        .executeAsync();
+      expect(emptyIn).toHaveLength(0);
+
+      // and() with no conditions produces TRUE — should return all results
+      const emptyAnd = await PostgresTestEntity.knexLoader(vc1).loadManyBySQL(and()).executeAsync();
+      expect(emptyAnd.length).toBeGreaterThanOrEqual(1);
+
+      // or() with no conditions produces FALSE — should return no results
+      const emptyOr = await PostgresTestEntity.knexLoader(vc1).loadManyBySQL(or()).executeAsync();
+      expect(emptyOr).toHaveLength(0);
+    });
+
     it('supports entityField for entity-to-DB field name translation', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 

--- a/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
@@ -8,9 +8,11 @@ import {
   unsafeRaw,
   sql,
   SQLEntityField,
+  SQLExpression,
   SQLFragment,
   SQLFragmentHelpers,
   SQLIdentifier,
+  expression,
 } from '../SQLOperator';
 import { TestFields, testEntityConfiguration } from './fixtures/TestEntity';
 
@@ -497,7 +499,7 @@ describe('SQLOperator', () => {
       it('handles empty array', () => {
         const fragment = SQLFragmentHelpers.inArray('stringField', []);
 
-        expect(fragment.sql).toBe('1 = 0'); // Always false
+        expect(fragment.sql).toBe('FALSE'); // Always false
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
@@ -517,7 +519,7 @@ describe('SQLOperator', () => {
       it('handles empty array', () => {
         const fragment = SQLFragmentHelpers.notInArray('stringField', []);
 
-        expect(fragment.sql).toBe('1 = 1'); // Always true
+        expect(fragment.sql).toBe('TRUE'); // Always true
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
@@ -536,7 +538,7 @@ describe('SQLOperator', () => {
       it('handles empty array', () => {
         const fragment = SQLFragmentHelpers.anyArray('stringField', []);
 
-        expect(fragment.sql).toBe('1 = 0'); // Always false
+        expect(fragment.sql).toBe('FALSE'); // Always false
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
@@ -829,7 +831,7 @@ describe('SQLOperator', () => {
       it('handles empty conditions in AND', () => {
         const fragment = SQLFragmentHelpers.and();
 
-        expect(fragment.sql).toBe('1 = 1');
+        expect(fragment.sql).toBe('TRUE');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
@@ -855,7 +857,7 @@ describe('SQLOperator', () => {
       it('handles empty conditions in OR', () => {
         const fragment = SQLFragmentHelpers.or();
 
-        expect(fragment.sql).toBe('1 = 0');
+        expect(fragment.sql).toBe('FALSE');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
@@ -905,6 +907,387 @@ describe('SQLOperator', () => {
           'premium',
           'admin',
           'test_index',
+        ]);
+      });
+    });
+
+    describe(expression, () => {
+      it('wraps a field name into an SQLExpression', () => {
+        const fragment = expression<TestFields>('stringField').eq('active');
+
+        expect(fragment.sql).toBe('?? = ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'active']);
+      });
+
+      it('wraps a SQLFragment into an SQLExpression', () => {
+        const raw = sql<TestFields>`LOWER(${entityField<TestFields>('stringField')})`;
+        const fragment = expression(raw).eq('test');
+
+        expect(fragment.sql).toBe('LOWER(??) = ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'test']);
+      });
+    });
+  });
+
+  describe(SQLExpression, () => {
+    // Use a simple expression for testing all fluent methods.
+    // Since fluent methods live on SQLExpression and behave identically regardless of
+    // how the expression was constructed, we only need to test them once.
+    const makeStringFieldExpr = (): SQLExpression<TestFields> =>
+      expression<TestFields>('stringField');
+
+    describe('comparison methods', () => {
+      it('eq(value)', () => {
+        const fragment = makeStringFieldExpr().eq('active');
+        expect(fragment.sql).toBe('?? = ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'active']);
+      });
+
+      it('eq(null) uses IS NULL', () => {
+        const fragment = makeStringFieldExpr().eq(null);
+        expect(fragment.sql).toBe('?? IS NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('eq(undefined) uses IS NULL', () => {
+        const fragment = makeStringFieldExpr().eq(undefined);
+        expect(fragment.sql).toBe('?? IS NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('neq(value)', () => {
+        const fragment = makeStringFieldExpr().neq('deleted');
+        expect(fragment.sql).toBe('?? != ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'deleted']);
+      });
+
+      it('neq(null) uses IS NOT NULL', () => {
+        const fragment = makeStringFieldExpr().neq(null);
+        expect(fragment.sql).toBe('?? IS NOT NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('neq(undefined) uses IS NOT NULL', () => {
+        const fragment = makeStringFieldExpr().neq(undefined);
+        expect(fragment.sql).toBe('?? IS NOT NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('gt(value)', () => {
+        const fragment = makeStringFieldExpr().gt(10);
+        expect(fragment.sql).toBe('?? > ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 10]);
+      });
+
+      it('gte(value)', () => {
+        const fragment = makeStringFieldExpr().gte(10);
+        expect(fragment.sql).toBe('?? >= ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 10]);
+      });
+
+      it('lt(value)', () => {
+        const fragment = makeStringFieldExpr().lt(100);
+        expect(fragment.sql).toBe('?? < ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 100]);
+      });
+
+      it('lte(value)', () => {
+        const fragment = makeStringFieldExpr().lte(100);
+        expect(fragment.sql).toBe('?? <= ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 100]);
+      });
+
+      it('isNull()', () => {
+        const fragment = makeStringFieldExpr().isNull();
+        expect(fragment.sql).toBe('?? IS NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('isNotNull()', () => {
+        const fragment = makeStringFieldExpr().isNotNull();
+        expect(fragment.sql).toBe('?? IS NOT NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+    });
+
+    describe('pattern matching methods', () => {
+      it('like(pattern)', () => {
+        const fragment = makeStringFieldExpr().like('%test%');
+        expect(fragment.sql).toBe('?? LIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
+      });
+
+      it('notLike(pattern)', () => {
+        const fragment = makeStringFieldExpr().notLike('%test%');
+        expect(fragment.sql).toBe('?? NOT LIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
+      });
+
+      it('ilike(pattern)', () => {
+        const fragment = makeStringFieldExpr().ilike('%test%');
+        expect(fragment.sql).toBe('?? ILIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
+      });
+
+      it('notIlike(pattern)', () => {
+        const fragment = makeStringFieldExpr().notIlike('%test%');
+        expect(fragment.sql).toBe('?? NOT ILIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
+      });
+    });
+
+    describe('collection methods', () => {
+      it('inArray(values)', () => {
+        const fragment = makeStringFieldExpr().inArray(['a', 'b']);
+        expect(fragment.sql).toBe('?? IN (?, ?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'a', 'b']);
+      });
+
+      it('inArray([]) returns always-false', () => {
+        const fragment = makeStringFieldExpr().inArray([]);
+        expect(fragment.sql).toBe('FALSE');
+      });
+
+      it('notInArray(values)', () => {
+        const fragment = makeStringFieldExpr().notInArray(['x']);
+        expect(fragment.sql).toBe('?? NOT IN (?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'x']);
+      });
+
+      it('notInArray([]) returns always-true', () => {
+        const fragment = makeStringFieldExpr().notInArray([]);
+        expect(fragment.sql).toBe('TRUE');
+      });
+
+      it('anyArray(values)', () => {
+        const fragment = makeStringFieldExpr().anyArray(['a', 'b']);
+        expect(fragment.sql).toBe('?? = ANY(?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', ['a', 'b']]);
+      });
+
+      it('anyArray([]) returns always-false', () => {
+        const fragment = makeStringFieldExpr().anyArray([]);
+        expect(fragment.sql).toBe('FALSE');
+      });
+    });
+
+    describe('range methods', () => {
+      it('between(min, max)', () => {
+        const fragment = makeStringFieldExpr().between(1, 100);
+        expect(fragment.sql).toBe('?? BETWEEN ? AND ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 1, 100]);
+      });
+
+      it('notBetween(min, max)', () => {
+        const fragment = makeStringFieldExpr().notBetween(1, 100);
+        expect(fragment.sql).toBe('?? NOT BETWEEN ? AND ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 1, 100]);
+      });
+    });
+
+    describe('helpers that return SQLExpression', () => {
+      it('jsonPath returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'key');
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('??->?');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', 'key']);
+      });
+
+      it('jsonPathText returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'email');
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('??->>?');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
+      });
+
+      it('jsonDeepPath returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', [
+          'user',
+          'address',
+          'city',
+        ]);
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('?? #> ?');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{user,address,city}',
+        ]);
+      });
+
+      it('jsonDeepPath properly quotes path elements with special characters', () => {
+        const fragment = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', [
+          'user',
+          'first,last',
+          'na}me',
+        ]);
+
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{user,"first,last","na}me"}',
+        ]);
+      });
+
+      it('jsonDeepPath properly quotes empty path elements', () => {
+        const fragment = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', ['user', '']);
+
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '{user,""}']);
+      });
+
+      it('jsonDeepPath properly escapes quotes and backslashes in path elements', () => {
+        const fragment = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', [
+          'key"with"quotes',
+          'back\\slash',
+        ]);
+
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{"key\\"with\\"quotes","back\\\\slash"}',
+        ]);
+      });
+
+      it('jsonDeepPathText returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.jsonDeepPathText<TestFields>('stringField', [
+          'user',
+          'address',
+          'city',
+        ]);
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('?? #>> ?');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{user,address,city}',
+        ]);
+      });
+
+      it('cast returns an SQLExpression with correct base SQL', () => {
+        const jsonExpr = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'count');
+        const expr = SQLFragmentHelpers.cast(jsonExpr, 'int');
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('(??->?)::int');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', 'count']);
+      });
+
+      it('cast rejects unsupported type names', () => {
+        const expr = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'count');
+        expect(() => SQLFragmentHelpers.cast(expr, 'int; DROP TABLE users' as any)).toThrow(
+          'cast: unsupported type name',
+        );
+      });
+
+      it('coalesce returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.coalesce<TestFields>(
+          sql`${entityField<TestFields>('nullableField')}`,
+          'default',
+        );
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('COALESCE(??, ?)');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['nullable_field', 'default']);
+      });
+
+      it('coalesce with multiple expressions', () => {
+        const fragment = SQLFragmentHelpers.coalesce<TestFields>(
+          sql`${entityField<TestFields>('nullableField')}`,
+          sql`${entityField<TestFields>('stringField')}`,
+          'fallback',
+        );
+        expect(fragment.sql).toBe('COALESCE(??, ??, ?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'nullable_field',
+          'string_field',
+          'fallback',
+        ]);
+      });
+
+      it('lower returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.lower<TestFields>('stringField');
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('LOWER(??)');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('lower accepts a SQLFragment', () => {
+        const fragment = SQLFragmentHelpers.lower(
+          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'email'),
+        );
+        expect(fragment.sql).toBe('LOWER(??->>?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
+      });
+
+      it('upper returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.upper<TestFields>('stringField');
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('UPPER(??)');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('upper accepts a SQLFragment', () => {
+        const fragment = SQLFragmentHelpers.upper(
+          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'email'),
+        );
+        expect(fragment.sql).toBe('UPPER(??->>?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
+      });
+
+      it('trim returns an SQLExpression with correct base SQL', () => {
+        const expr = SQLFragmentHelpers.trim<TestFields>('stringField');
+        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr.sql).toBe('TRIM(??)');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field']);
+      });
+
+      it('trim accepts a SQLFragment', () => {
+        const fragment = SQLFragmentHelpers.trim(
+          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'name'),
+        );
+        expect(fragment.sql).toBe('TRIM(??->>?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'name']);
+      });
+
+      it('SQLExpression still works as a SQLFragment in sql template', () => {
+        const path = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'key');
+        const fragment = sql`${path} IS NOT NULL`;
+
+        expect(fragment.sql).toBe('??->? IS NOT NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'key']);
+      });
+    });
+
+    describe('composing multiple expression helpers', () => {
+      it('lower(trim(field)).eq(value)', () => {
+        const fragment = SQLFragmentHelpers.lower(
+          SQLFragmentHelpers.trim<TestFields>('stringField'),
+        ).eq('hello');
+
+        expect(fragment.sql).toBe('LOWER(TRIM(??)) = ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'hello']);
+      });
+
+      it('cast(jsonDeepPath(...), type).gt(value)', () => {
+        const fragment = SQLFragmentHelpers.cast(
+          SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', ['stats', 'count']),
+          'int',
+        ).gt(10);
+
+        expect(fragment.sql).toBe('(?? #> ?)::int > ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{stats,count}',
+          10,
+        ]);
+      });
+
+      it('coalesce(jsonPathText(...), default).ilike(pattern)', () => {
+        const fragment = SQLFragmentHelpers.coalesce(
+          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'name'),
+          '',
+        ).ilike('%test%');
+
+        expect(fragment.sql).toBe('COALESCE(??->>?, ?) ILIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          'name',
+          '',
+          '%test%',
         ]);
       });
     });

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -487,7 +487,7 @@ export class EntityKnexDataManager<
   ): SQLFragment<TFields> {
     const conditions = [baseWhere, cursorCondition].filter((it) => !!it);
     if (conditions.length === 0) {
-      return sql`1 = 1`;
+      return sql`TRUE`;
     }
     if (conditions.length === 1) {
       return conditions[0]!;
@@ -775,7 +775,7 @@ export class EntityKnexDataManager<
         ];
 
         return {
-          searchWhere: conditions.length > 0 ? SQLFragmentHelpers.or(...conditions) : sql`1 = 0`,
+          searchWhere: conditions.length > 0 ? SQLFragmentHelpers.or(...conditions) : sql`FALSE`,
           searchOrderByClauses,
         };
       }


### PR DESCRIPTION
# Why

When converting the Expo server's `loadManyByRawWhereClause` to `loadManyBySQL` I found myself wanting the ability to do something like `jsonPath('fieldName', 'wat').isNull()` rather than having to use the template tag.

# How

Add SQLExpression with claude to support a better API for expressions, and add a few more common methods as well.

# Test Plan

Run all tests.
