### PR TITLE
chore: fix renovate updates

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
 node = "24.14.0"
-yarn = "4.12.0"
 
 [tasks.yarn]
 run = "yarn install --immutable"
@@ -35,3 +34,14 @@ run = "yarn integration --coverage"
 
 [tasks.ci]
 run = { task = "checks:*" }
+
+[settings]
+experimental = true # needed for postinstall hook
+
+[hooks]
+postinstall = [
+  # Enable yarn shim.  Version controlled by package.json#packageManager
+  # NOTE: mise can install yarn directly, but renovate does not use mise, so we
+  # control yarn versions using the packageManager field.
+  "corepack enable yarn"
+]

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
   },
   "resolutions": {
     "collect-v8-coverage": "^1.0.3"
-  }
+  },
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
 }


### PR DESCRIPTION
# Why

Renovate update PRs are now having trouble.

# How

Set yarn version via corepack and the packageManager field instead of in mise.toml, add a postinstall hook so that `mise install` will still install yarn, via corepack's shims.

# Test Plan

By using the branch name `renovate/reconfigure`, the renovate bot should comment on this to say it can successfully run on the branch.
