### PR TITLE
chore: remove @types/uuid package

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/package.json
+++ b/packages/entity-database-adapter-knex-testing-utils/package.json
@@ -39,7 +39,6 @@
     "@jest/globals": "30.2.0",
     "@types/invariant": "2.2.37",
     "@types/node": "24.11.0",
-    "@types/uuid": "10.0.0",
     "typescript": "5.9.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,7 +1753,6 @@ __metadata:
     "@jest/globals": "npm:30.2.0"
     "@types/invariant": "npm:2.2.37"
     "@types/node": "npm:24.11.0"
-    "@types/uuid": "npm:10.0.0"
     invariant: "npm:^2.2.4"
     typescript: "npm:5.9.3"
     uuid: "npm:^13.0.0"
@@ -3984,13 +3983,6 @@ __metadata:
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
   checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

I just noticed that renovate was trying to update this package, but the `uuid` package ships with its own types now.

# Test Plan

I ran `mise run ci`, and so will ci.
