### PR TITLE
feat: update the SQLExpression and SQLFragmentHelpers APIs

### DIFF
--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -159,7 +159,7 @@ export class EnforcingKnexEntityLoader<
    *   .limit(10)
    *   .executeAsync();
    *
-   * const { between, inArray } = SQLFragmentHelpers;
+   * const { between, inArray } = SQLExpression;
    * const filtered = await ExampleEntity.loader(vc)
    *   .loadManyBySQL(
    *     sql`${between('age', 18, 65)} AND ${inArray('role', ['admin', 'moderator'])}`

--- a/packages/entity-database-adapter-knex/src/SQLOperator.ts
+++ b/packages/entity-database-adapter-knex/src/SQLOperator.ts
@@ -197,8 +197,8 @@ export class SQLIdentifier {
  * Helper for referencing entity fields that can be used in SQL queries. This allows for type-safe references to fields of an entity
  * and does automatic translation to DB field names.
  */
-export class SQLEntityField<TFields extends Record<string, any>> {
-  constructor(public readonly fieldName: keyof TFields) {}
+export class SQLEntityField<TFields extends Record<string, any>, N extends keyof TFields> {
+  constructor(public readonly fieldName: N) {}
 }
 
 /**
@@ -238,9 +238,9 @@ export function identifier(name: string): SQLIdentifier {
  *
  * @param fieldName - The entity field name to reference.
  */
-export function entityField<TFields extends Record<string, any>>(
-  fieldName: keyof TFields,
-): SQLEntityField<TFields> {
+export function entityField<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+): SQLEntityField<TFields, N> {
   return new SQLEntityField(fieldName);
 }
 
@@ -278,26 +278,6 @@ export function unsafeRaw(sqlString: string): SQLUnsafeRaw {
 }
 
 /**
- * Wraps a SQLFragment or entity field name into an SQLExpression for fluent comparison usage.
- *
- * @example
- * ```ts
- * expression<MyFields>('age').gte(18)
- * expression<MyFields>('name').ilike('%john%')
- * expression(sql`${entityField('status')}`).eq('active')
- * ```
- */
-export function expression<TFields extends Record<string, any>>(
-  fragmentOrFieldName: SQLFragment<TFields> | keyof TFields,
-): SQLExpression<TFields> {
-  if (fragmentOrFieldName instanceof SQLFragment) {
-    return new SQLExpression(fragmentOrFieldName.sql, fragmentOrFieldName.bindings);
-  }
-  const fragment = sql`${entityField(fragmentOrFieldName)}`;
-  return new SQLExpression(fragment.sql, fragment.bindings);
-}
-
-/**
  * Tagged template literal function for SQL queries
  *
  * @example
@@ -313,7 +293,7 @@ export function sql<TFields extends Record<string, any>>(
     | SQLFragment<TFields>
     | SQLIdentifier
     | SQLUnsafeRaw
-    | SQLEntityField<TFields>
+    | SQLEntityField<TFields, keyof TFields>
     | SQLArrayValue
   )[]
 ): SQLFragment<TFields> {
@@ -382,87 +362,200 @@ type JsonSerializable =
  * The fluent methods return plain SQLFragment instances since they produce
  * complete conditions, not further chainable expressions.
  */
-export class SQLExpression<TFields extends Record<string, any>> extends SQLFragment<TFields> {
-  eq(value: SupportedSQLValue): SQLFragment<TFields> {
+export class SQLChainableFragment<
+  TFields extends Record<string, any>,
+  TValue extends SupportedSQLValue,
+> extends SQLFragment<TFields> {
+  /**
+   * Generates an equality condition (`= value`).
+   * Automatically converts `null`/`undefined` to `IS NULL`.
+   *
+   * @param value - The value to compare against
+   * @returns A {@link SQLFragment} representing the equality condition
+   */
+  eq(value: TValue | null | undefined): SQLFragment<TFields> {
     if (value === null || value === undefined) {
       return this.isNull();
     }
     return sql`${this} = ${value}`;
   }
 
-  neq(value: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates an inequality condition (`!= value`).
+   * Automatically converts `null`/`undefined` to `IS NOT NULL`.
+   *
+   * @param value - The value to compare against
+   * @returns A {@link SQLFragment} representing the inequality condition
+   */
+  neq(value: TValue | null | undefined): SQLFragment<TFields> {
     if (value === null || value === undefined) {
       return this.isNotNull();
     }
     return sql`${this} != ${value}`;
   }
 
-  gt(value: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates a greater-than condition (`> value`).
+   *
+   * @param value - The value to compare against
+   * @returns A {@link SQLFragment} representing the condition
+   */
+  gt(value: TValue): SQLFragment<TFields> {
     return sql`${this} > ${value}`;
   }
 
-  gte(value: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates a greater-than-or-equal-to condition (`>= value`).
+   *
+   * @param value - The value to compare against
+   * @returns A {@link SQLFragment} representing the condition
+   */
+  gte(value: TValue): SQLFragment<TFields> {
     return sql`${this} >= ${value}`;
   }
 
-  lt(value: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates a less-than condition (`< value`).
+   *
+   * @param value - The value to compare against
+   * @returns A {@link SQLFragment} representing the condition
+   */
+  lt(value: TValue): SQLFragment<TFields> {
     return sql`${this} < ${value}`;
   }
 
-  lte(value: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates a less-than-or-equal-to condition (`<= value`).
+   *
+   * @param value - The value to compare against
+   * @returns A {@link SQLFragment} representing the condition
+   */
+  lte(value: TValue): SQLFragment<TFields> {
     return sql`${this} <= ${value}`;
   }
 
+  /**
+   * Generates an `IS NULL` condition.
+   *
+   * @returns A {@link SQLFragment} representing the IS NULL check
+   */
   isNull(): SQLFragment<TFields> {
     return sql`${this} IS NULL`;
   }
 
+  /**
+   * Generates an `IS NOT NULL` condition.
+   *
+   * @returns A {@link SQLFragment} representing the IS NOT NULL check
+   */
   isNotNull(): SQLFragment<TFields> {
     return sql`${this} IS NOT NULL`;
   }
 
+  /**
+   * Generates a case-sensitive `LIKE` condition for pattern matching.
+   *
+   * @param pattern - The LIKE pattern (use `%` for wildcards, `_` for single character)
+   * @returns A {@link SQLFragment} representing the LIKE condition
+   */
   like(pattern: string): SQLFragment<TFields> {
     return sql`${this} LIKE ${pattern}`;
   }
 
+  /**
+   * Generates a case-sensitive `NOT LIKE` condition.
+   *
+   * @param pattern - The LIKE pattern (use `%` for wildcards, `_` for single character)
+   * @returns A {@link SQLFragment} representing the NOT LIKE condition
+   */
   notLike(pattern: string): SQLFragment<TFields> {
     return sql`${this} NOT LIKE ${pattern}`;
   }
 
+  /**
+   * Generates a case-insensitive `ILIKE` condition (PostgreSQL-specific).
+   *
+   * @param pattern - The LIKE pattern (use `%` for wildcards, `_` for single character)
+   * @returns A {@link SQLFragment} representing the ILIKE condition
+   */
   ilike(pattern: string): SQLFragment<TFields> {
     return sql`${this} ILIKE ${pattern}`;
   }
 
+  /**
+   * Generates a case-insensitive `NOT ILIKE` condition (PostgreSQL-specific).
+   *
+   * @param pattern - The LIKE pattern (use `%` for wildcards, `_` for single character)
+   * @returns A {@link SQLFragment} representing the NOT ILIKE condition
+   */
   notIlike(pattern: string): SQLFragment<TFields> {
     return sql`${this} NOT ILIKE ${pattern}`;
   }
 
-  inArray(values: readonly SupportedSQLValue[]): SQLFragment<TFields> {
+  /**
+   * Generates an `IN (...)` condition. Each array element becomes a separate
+   * bound parameter (`IN (?, ?, ?)`).
+   * Returns `FALSE` when the values array is empty.
+   *
+   * @param values - The values to check membership against
+   * @returns A {@link SQLFragment} representing the IN condition
+   */
+  inArray(values: readonly TValue[]): SQLFragment<TFields> {
     if (values.length === 0) {
       return sql`FALSE`;
     }
     return sql`${this} IN ${values}`;
   }
 
-  notInArray(values: readonly SupportedSQLValue[]): SQLFragment<TFields> {
+  /**
+   * Generates a `NOT IN (...)` condition. Each array element becomes a separate
+   * bound parameter.
+   * Returns `TRUE` when the values array is empty.
+   *
+   * @param values - The values to check non-membership against
+   * @returns A {@link SQLFragment} representing the NOT IN condition
+   */
+  notInArray(values: readonly TValue[]): SQLFragment<TFields> {
     if (values.length === 0) {
       return sql`TRUE`;
     }
     return sql`${this} NOT IN ${values}`;
   }
 
-  anyArray(values: readonly SupportedSQLValue[]): SQLFragment<TFields> {
+  /**
+   * Generates an `= ANY(?)` condition. Unlike {@link inArray}, the array is bound
+   * as a single parameter, producing a consistent query shape for query metrics.
+   * Returns `FALSE` when the values array is empty.
+   *
+   * @param values - The values to check membership against
+   * @returns A {@link SQLFragment} representing the = ANY condition
+   */
+  anyArray(values: readonly TValue[]): SQLFragment<TFields> {
     if (values.length === 0) {
       return sql`FALSE`;
     }
     return sql`${this} = ANY(${arrayValue(values)})`;
   }
 
-  between(min: SupportedSQLValue, max: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates a `BETWEEN min AND max` condition (inclusive on both ends).
+   *
+   * @param min - The lower bound
+   * @param max - The upper bound
+   * @returns A {@link SQLFragment} representing the BETWEEN condition
+   */
+  between(min: TValue, max: TValue): SQLFragment<TFields> {
     return sql`${this} BETWEEN ${min} AND ${max}`;
   }
 
-  notBetween(min: SupportedSQLValue, max: SupportedSQLValue): SQLFragment<TFields> {
+  /**
+   * Generates a `NOT BETWEEN min AND max` condition.
+   *
+   * @param min - The lower bound
+   * @param max - The upper bound
+   * @returns A {@link SQLFragment} representing the NOT BETWEEN condition
+   */
+  notBetween(min: TValue, max: TValue): SQLFragment<TFields> {
     return sql`${this} NOT BETWEEN ${min} AND ${max}`;
   }
 }
@@ -511,25 +604,505 @@ export type PostgresCastType = (typeof ALLOWED_CAST_TYPES)[number];
 
 const ALLOWED_CAST_TYPES_SET: ReadonlySet<string> = new Set<PostgresCastType>(ALLOWED_CAST_TYPES);
 
+// Helper to resolve expressionOrFieldName to a SQLFragment
+function resolveInner<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLFragment<TFields> {
+  return expressionOrFieldName instanceof SQLFragment
+    ? expressionOrFieldName
+    : sql`${entityField<TFields, keyof TFields>(expressionOrFieldName)}`;
+}
+
+// Helper to resolve expressionOrFieldName to a SQLChainableFragment for fluent chaining
+function resolveInnerExpr<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  if (expressionOrFieldName instanceof SQLChainableFragment) {
+    return expressionOrFieldName;
+  }
+  const inner = resolveInner(expressionOrFieldName);
+  return new SQLChainableFragment(inner.sql, inner.bindings);
+}
+
+// --- Standalone overloaded helper functions ---
+// For methods with value params, the expression overload uses a conditional type to preserve
+// TValue from SQLChainableFragment (for type-safe value checking) while falling back to
+// SupportedSQLValue for plain SQLFragment inputs.
+
+// Extract TFields from a SQLFragment type
+type ExtractFields<T> = T extends SQLFragment<infer F> ? F : never;
+
+// Conditional value types for expression overloads.
+// Uses SQLChainableFragment<any, ...> so that TExpr alone drives inference (single type param).
+type ExprValueNullable<TExpr> =
+  TExpr extends SQLChainableFragment<any, infer TValue>
+    ? TValue | null | undefined
+    : SupportedSQLValue;
+
+type ExprValue<TExpr> =
+  TExpr extends SQLChainableFragment<any, infer TValue> ? TValue : SupportedSQLValue;
+
+type ExprValueArray<TExpr> =
+  TExpr extends SQLChainableFragment<any, infer TValue>
+    ? readonly TValue[]
+    : readonly SupportedSQLValue[];
+
+function inArrayHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  values: ExprValueArray<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function inArrayHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, values: readonly TFields[N][]): SQLFragment<TFields>;
+function inArrayHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  values: readonly SupportedSQLValue[],
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).inArray(values);
+}
+
+function anyArrayHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  values: ExprValueArray<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function anyArrayHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, values: readonly TFields[N][]): SQLFragment<TFields>;
+function anyArrayHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  values: readonly SupportedSQLValue[],
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).anyArray(values);
+}
+
+function notInArrayHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  values: ExprValueArray<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function notInArrayHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, values: readonly TFields[N][]): SQLFragment<TFields>;
+function notInArrayHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  values: readonly SupportedSQLValue[],
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).notInArray(values);
+}
+
+function betweenHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  min: ExprValue<TExpr>,
+  max: ExprValue<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function betweenHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, min: TFields[N], max: TFields[N]): SQLFragment<TFields>;
+function betweenHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  min: SupportedSQLValue,
+  max: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).between(min, max);
+}
+
+function notBetweenHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  min: ExprValue<TExpr>,
+  max: ExprValue<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function notBetweenHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, min: TFields[N], max: TFields[N]): SQLFragment<TFields>;
+function notBetweenHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  min: SupportedSQLValue,
+  max: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).notBetween(min, max);
+}
+
+function likeHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  pattern: string,
+): SQLFragment<ExtractFields<TExpr>>;
+function likeHelper<TFields extends Record<string, any>, N extends PickStringValueKeys<TFields>>(
+  fieldName: N,
+  pattern: string,
+): SQLFragment<TFields>;
+function likeHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  pattern: string,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).like(pattern);
+}
+
+function notLikeHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  pattern: string,
+): SQLFragment<ExtractFields<TExpr>>;
+function notLikeHelper<TFields extends Record<string, any>, N extends PickStringValueKeys<TFields>>(
+  fieldName: N,
+  pattern: string,
+): SQLFragment<TFields>;
+function notLikeHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  pattern: string,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).notLike(pattern);
+}
+
+function ilikeHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  pattern: string,
+): SQLFragment<ExtractFields<TExpr>>;
+function ilikeHelper<TFields extends Record<string, any>, N extends PickStringValueKeys<TFields>>(
+  fieldName: N,
+  pattern: string,
+): SQLFragment<TFields>;
+function ilikeHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  pattern: string,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).ilike(pattern);
+}
+
+function notIlikeHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  pattern: string,
+): SQLFragment<ExtractFields<TExpr>>;
+function notIlikeHelper<
+  TFields extends Record<string, any>,
+  N extends PickStringValueKeys<TFields>,
+>(fieldName: N, pattern: string): SQLFragment<TFields>;
+function notIlikeHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  pattern: string,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).notIlike(pattern);
+}
+
+function isNullHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+): SQLFragment<ExtractFields<TExpr>>;
+function isNullHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+): SQLFragment<TFields>;
+function isNullHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).isNull();
+}
+
+function isNotNullHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+): SQLFragment<ExtractFields<TExpr>>;
+function isNotNullHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+): SQLFragment<TFields>;
+function isNotNullHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).isNotNull();
+}
+
+function eqHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: ExprValueNullable<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function eqHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, value: TFields[N]): SQLFragment<TFields>;
+function eqHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).eq(value);
+}
+
+function neqHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: ExprValueNullable<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function neqHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, value: TFields[N]): SQLFragment<TFields>;
+function neqHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).neq(value);
+}
+
+function gtHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: ExprValue<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function gtHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, value: TFields[N]): SQLFragment<TFields>;
+function gtHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).gt(value);
+}
+
+function gteHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: ExprValue<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function gteHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, value: TFields[N]): SQLFragment<TFields>;
+function gteHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).gte(value);
+}
+
+function ltHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: ExprValue<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function ltHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, value: TFields[N]): SQLFragment<TFields>;
+function ltHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).lt(value);
+}
+
+function lteHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: ExprValue<TExpr>,
+): SQLFragment<ExtractFields<TExpr>>;
+function lteHelper<
+  TFields extends Record<string, any>,
+  N extends PickSupportedSQLValueKeys<TFields>,
+>(fieldName: N, value: TFields[N]): SQLFragment<TFields>;
+function lteHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: SupportedSQLValue,
+): SQLFragment<TFields> {
+  return resolveInnerExpr(expressionOrFieldName).lte(value);
+}
+
+function jsonContainsHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: JsonSerializable,
+): SQLFragment<ExtractFields<TExpr>>;
+function jsonContainsHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  value: JsonSerializable,
+): SQLFragment<TFields>;
+function jsonContainsHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: JsonSerializable,
+): SQLFragment<TFields> {
+  const serialized = JSON.stringify(value);
+  assert(
+    serialized !== undefined || value === undefined,
+    'jsonContains: value is not JSON-serializable',
+  );
+  const inner = resolveInner(expressionOrFieldName);
+  return sql`${inner} @> ${serialized}::jsonb`;
+}
+
+function jsonContainedByHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  value: JsonSerializable,
+): SQLFragment<ExtractFields<TExpr>>;
+function jsonContainedByHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  value: JsonSerializable,
+): SQLFragment<TFields>;
+function jsonContainedByHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  value: JsonSerializable,
+): SQLFragment<TFields> {
+  const serialized = JSON.stringify(value);
+  assert(
+    serialized !== undefined || value === undefined,
+    'jsonContainedBy: value is not JSON-serializable',
+  );
+  const inner = resolveInner(expressionOrFieldName);
+  return sql`${inner} <@ ${serialized}::jsonb`;
+}
+
+function jsonPathHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  path: string,
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function jsonPathHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  path: string,
+): SQLChainableFragment<TFields, SupportedSQLValue>;
+function jsonPathHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  path: string,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`${inner}->${path}`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function jsonPathTextHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  path: string,
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function jsonPathTextHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  path: string,
+): SQLChainableFragment<TFields, SupportedSQLValue>;
+function jsonPathTextHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  path: string,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`${inner}->>${path}`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function jsonDeepPathHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  path: readonly string[],
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function jsonDeepPathHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  path: readonly string[],
+): SQLChainableFragment<TFields, SupportedSQLValue>;
+function jsonDeepPathHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  path: readonly string[],
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const pathLiteral = `{${path.map(quotePostgresArrayElement).join(',')}}`;
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`${inner} #> ${pathLiteral}`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function jsonDeepPathTextHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  path: readonly string[],
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function jsonDeepPathTextHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  path: readonly string[],
+): SQLChainableFragment<TFields, SupportedSQLValue>;
+function jsonDeepPathTextHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  path: readonly string[],
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const pathLiteral = `{${path.map(quotePostgresArrayElement).join(',')}}`;
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`${inner} #>> ${pathLiteral}`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function castHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+  typeName: PostgresCastType,
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function castHelper<TFields extends Record<string, any>, N extends keyof TFields>(
+  fieldName: N,
+  typeName: PostgresCastType,
+): SQLChainableFragment<TFields, SupportedSQLValue>;
+function castHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+  typeName: PostgresCastType,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  assert(
+    ALLOWED_CAST_TYPES_SET.has(typeName),
+    `cast: unsupported type name "${typeName}". Allowed types: ${[...ALLOWED_CAST_TYPES_SET].join(', ')}`,
+  );
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`(${inner})::${unsafeRaw(typeName)}`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function lowerHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function lowerHelper<TFields extends Record<string, any>, N extends PickStringValueKeys<TFields>>(
+  fieldName: N,
+): SQLChainableFragment<TFields, TFields[N]>;
+function lowerHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`LOWER(${inner})`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function upperHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function upperHelper<TFields extends Record<string, any>, N extends PickStringValueKeys<TFields>>(
+  fieldName: N,
+): SQLChainableFragment<TFields, TFields[N]>;
+function upperHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`UPPER(${inner})`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
+function trimHelper<TExpr extends SQLFragment<any>>(
+  expression: TExpr,
+): SQLChainableFragment<ExtractFields<TExpr>, SupportedSQLValue>;
+function trimHelper<TFields extends Record<string, any>, N extends PickStringValueKeys<TFields>>(
+  fieldName: N,
+): SQLChainableFragment<TFields, TFields[N]>;
+function trimHelper<TFields extends Record<string, any>>(
+  expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
+): SQLChainableFragment<TFields, SupportedSQLValue> {
+  const inner = resolveInner(expressionOrFieldName);
+  const wrapped = sql`TRIM(${inner})`;
+  return new SQLChainableFragment(wrapped.sql, wrapped.bindings);
+}
+
 /**
- * Common SQL helper functions for building queries
+ * Common SQL helper functions for building queries.
+ *
+ * All methods accept either a field name (string) or a SQLFragment/SQLChainableFragment as the
+ * first argument. When a SQLChainableFragment with a known TValue is passed (e.g. from trim, lower),
+ * value parameters are type-checked against that TValue.
+ *
+ * @example
+ * ```ts
+ * // Field name usage
+ * SQLExpression.eq('status', 'active')
+ *
+ * // SQLFragment/SQLChainableFragment usage
+ * SQLExpression.eq(sql`${entityField('status')}`, 'active')
+ * SQLExpression.eq(SQLExpression.trim('name'), 'hello') // value constrained to string
+ * ```
  */
-export const SQLFragmentHelpers = {
+export const SQLExpression = {
   /**
-   * IN clause helper
+   * IN clause helper.
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.inArray<MyFields, 'id'>('status', ['active', 'pending']);
-   * // Generates: ?? IN (?, ?) with entityField binding for 'status' and value bindings
+   * SQLExpression.inArray('status', ['active', 'pending'])
+   * SQLExpression.inArray(SQLExpression.lower('status'), ['active', 'pending'])
    * ```
    */
-  inArray<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    values: readonly TFields[N][],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).inArray(values);
-  },
+  inArray: inArrayHelper,
 
   /**
    * = ANY() clause helper. Binds the array as a single parameter instead of expanding it.
@@ -538,342 +1111,187 @@ export const SQLFragmentHelpers = {
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.anyArray('status', ['active', 'pending']);
-   * // Generates: ?? = ANY(?) with entityField binding for 'status' and a single array value binding
+   * SQLExpression.anyArray('status', ['active', 'pending'])
    * ```
    */
-  anyArray<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    values: readonly TFields[N][],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).anyArray(values);
-  },
+  anyArray: anyArrayHelper,
 
   /**
-   * NOT IN clause helper
+   * NOT IN clause helper.
    */
-  notInArray<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    values: readonly TFields[N][],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).notInArray(values);
-  },
+  notInArray: notInArrayHelper,
 
   /**
-   * BETWEEN helper
+   * BETWEEN helper.
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.between<MyFields, 'id'>('age', 18, 65);
-   * // Generates: ?? BETWEEN ? AND ? with entityField binding for 'age' and value bindings
+   * SQLExpression.between('age', 18, 65)
+   * SQLExpression.between(SQLExpression.cast('age', 'int'), 18, 65)
    * ```
    */
-  between<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    min: TFields[N],
-    max: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).between(min, max);
-  },
+  between: betweenHelper,
 
   /**
-   * NOT BETWEEN helper
+   * NOT BETWEEN helper.
    */
-  notBetween<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    min: TFields[N],
-    max: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).notBetween(min, max);
-  },
+  notBetween: notBetweenHelper,
 
   /**
-   * LIKE helper with automatic escaping
+   * LIKE helper for case-sensitive pattern matching.
    *
    * @example
    * ```ts
-   * const query = SQLFragmentHelpers.like<MyFields, 'id'>('name', '%John%');
-   * // Generates: ?? LIKE ? with entityField binding for 'name' and value binding
+   * SQLExpression.like('name', '%John%')
    * ```
    */
-  like<TFields extends Record<string, any>>(
-    fieldName: PickStringValueKeys<TFields>,
-    pattern: string,
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).like(pattern);
-  },
+  like: likeHelper,
 
   /**
-   * NOT LIKE helper
+   * NOT LIKE helper.
    */
-  notLike<TFields extends Record<string, any>>(
-    fieldName: PickStringValueKeys<TFields>,
-    pattern: string,
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).notLike(pattern);
-  },
+  notLike: notLikeHelper,
 
   /**
-   * ILIKE helper for case-insensitive matching
+   * ILIKE helper for case-insensitive matching (PostgreSQL-specific).
    */
-  ilike<TFields extends Record<string, any>>(
-    fieldName: PickStringValueKeys<TFields>,
-    pattern: string,
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).ilike(pattern);
-  },
+  ilike: ilikeHelper,
 
   /**
-   * NOT ILIKE helper for case-insensitive non-matching
+   * NOT ILIKE helper for case-insensitive non-matching (PostgreSQL-specific).
    */
-  notIlike<TFields extends Record<string, any>>(
-    fieldName: PickStringValueKeys<TFields>,
-    pattern: string,
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).notIlike(pattern);
-  },
+  notIlike: notIlikeHelper,
 
   /**
-   * NULL check helper
+   * IS NULL check helper.
    */
-  isNull<TFields extends Record<string, any>>(fieldName: keyof TFields): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).isNull();
-  },
+  isNull: isNullHelper,
 
   /**
-   * NOT NULL check helper
+   * IS NOT NULL check helper.
    */
-  isNotNull<TFields extends Record<string, any>>(fieldName: keyof TFields): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).isNotNull();
-  },
+  isNotNull: isNotNullHelper,
 
   /**
-   * Single-equals-equality operator
+   * Equality operator. Automatically converts null/undefined to IS NULL.
    */
-  eq<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    value: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).eq(value);
-  },
+  eq: eqHelper,
 
   /**
-   * Single-equals-inequality operator
+   * Inequality operator. Automatically converts null/undefined to IS NOT NULL.
    */
-  neq<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    value: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).neq(value);
-  },
+  neq: neqHelper,
 
   /**
-   * Greater-than comparison operator
+   * Greater-than comparison operator.
    */
-  gt<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    value: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).gt(value);
-  },
+  gt: gtHelper,
 
   /**
-   * Greater-than-or-equal-to comparison operator
+   * Greater-than-or-equal-to comparison operator.
    */
-  gte<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    value: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).gte(value);
-  },
+  gte: gteHelper,
 
   /**
-   * Less-than comparison operator
+   * Less-than comparison operator.
    */
-  lt<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    value: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).lt(value);
-  },
+  lt: ltHelper,
 
   /**
-   * Less-than-or-equal-to comparison operator
+   * Less-than-or-equal-to comparison operator.
    */
-  lte<TFields extends Record<string, any>, N extends PickSupportedSQLValueKeys<TFields>>(
-    fieldName: N,
-    value: TFields[N],
-  ): SQLFragment<TFields> {
-    return expression<TFields>(fieldName).lte(value);
-  },
+  lte: lteHelper,
 
   /**
-   * JSON contains operator (\@\>)
+   * JSON contains operator (\@\>).
    */
-  jsonContains<TFields extends Record<string, any>>(
-    fieldName: keyof TFields,
-    value: JsonSerializable,
-  ): SQLFragment<TFields> {
-    const serialized = JSON.stringify(value);
-    // JSON.stringify returns undefined for unsupported types, but we also want to allow undefined as a value
-    assert(
-      serialized !== undefined || value === undefined,
-      'jsonContains: value is not JSON-serializable',
-    );
-    return sql`${entityField(fieldName)} @> ${serialized}::jsonb`;
-  },
+  jsonContains: jsonContainsHelper,
 
   /**
-   * JSON contained by operator (\<\@\)
+   * JSON contained by operator (\<\@\).
    */
-  jsonContainedBy<TFields extends Record<string, any>>(
-    fieldName: keyof TFields,
-    value: JsonSerializable,
-  ): SQLFragment<TFields> {
-    const serialized = JSON.stringify(value);
-    // JSON.stringify returns undefined for unsupported types, but we also want to allow undefined as a value
-    assert(
-      serialized !== undefined || value === undefined,
-      'jsonContainedBy: value is not JSON-serializable',
-    );
-    return sql`${entityField(fieldName)} <@ ${serialized}::jsonb`;
-  },
+  jsonContainedBy: jsonContainedByHelper,
 
   /**
-   * JSON path extraction helper (-\>)
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * JSON path extraction helper (-\>).
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    */
-  jsonPath<TFields extends Record<string, any>>(
-    fieldName: keyof TFields,
-    path: string,
-  ): SQLExpression<TFields> {
-    return expression(sql`${entityField(fieldName)}->${path}`);
-  },
+  jsonPath: jsonPathHelper,
 
   /**
-   * JSON path text extraction helper (-\>\>)
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * JSON path text extraction helper (-\>\>).
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    */
-  jsonPathText<TFields extends Record<string, any>>(
-    fieldName: keyof TFields,
-    path: string,
-  ): SQLExpression<TFields> {
-    return expression(sql`${entityField(fieldName)}->>${path}`);
-  },
+  jsonPathText: jsonPathTextHelper,
 
   /**
-   * JSON deep path extraction helper (#\>)
+   * JSON deep path extraction helper (#\>).
    * Extracts a JSON sub-object at the specified key path, returning jsonb.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    *
-   * @param fieldName - The entity field containing JSON/JSONB data
+   * @param expressionOrFieldName - A SQLFragment/SQLChainableFragment or entity field name
    * @param path - Array of keys forming the path (e.g., ['user', 'address', 'city'])
    */
-  jsonDeepPath<TFields extends Record<string, any>>(
-    fieldName: keyof TFields,
-    path: readonly string[],
-  ): SQLExpression<TFields> {
-    const pathLiteral = `{${path.map(quotePostgresArrayElement).join(',')}}`;
-    return expression(sql`${entityField(fieldName)} #> ${pathLiteral}`);
-  },
+  jsonDeepPath: jsonDeepPathHelper,
 
   /**
-   * JSON deep path text extraction helper (#\>\>)
+   * JSON deep path text extraction helper (#\>\>).
    * Extracts a JSON sub-object at the specified key path as text.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    *
-   * @param fieldName - The entity field containing JSON/JSONB data
+   * @param expressionOrFieldName - A SQLFragment/SQLChainableFragment or entity field name
    * @param path - Array of keys forming the path (e.g., ['user', 'address', 'city'])
    */
-  jsonDeepPathText<TFields extends Record<string, any>>(
-    fieldName: keyof TFields,
-    path: readonly string[],
-  ): SQLExpression<TFields> {
-    const pathLiteral = `{${path.map(quotePostgresArrayElement).join(',')}}`;
-    return expression(sql`${entityField(fieldName)} #>> ${pathLiteral}`);
-  },
+  jsonDeepPathText: jsonDeepPathTextHelper,
 
   /**
-   * SQL type cast helper (::type)
-   * Casts an expression to a PostgreSQL type.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * SQL type cast helper (::type).
+   * Casts an expression or field to a PostgreSQL type.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    *
-   * @param fragment - An SQLFragment or SQLExpression to cast
+   * @param expressionOrFieldName - A SQLFragment/SQLChainableFragment or entity field name to cast
    * @param typeName - The PostgreSQL type name (e.g., 'int', 'text', 'timestamptz')
    */
-  cast<TFields extends Record<string, any>>(
-    fragmentOrExpression: SQLFragment<TFields>,
-    typeName: PostgresCastType,
-  ): SQLExpression<TFields> {
-    assert(
-      ALLOWED_CAST_TYPES_SET.has(typeName),
-      `cast: unsupported type name "${typeName}". Allowed types: ${[...ALLOWED_CAST_TYPES_SET].join(', ')}`,
-    );
-    return expression(sql`(${fragmentOrExpression})::${unsafeRaw(typeName)}`);
-  },
+  cast: castHelper,
 
   /**
-   * COALESCE helper
+   * COALESCE helper.
    * Returns the first non-null value from the given expressions/values.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    */
   coalesce<TFields extends Record<string, any>>(
     ...args: readonly (SQLFragment<TFields> | SupportedSQLValue)[]
-  ): SQLExpression<TFields> {
+  ): SQLChainableFragment<TFields, SupportedSQLValue> {
     const fragments = args.map((arg) => {
       if (arg instanceof SQLFragment) {
         return arg;
       }
       return sql`${arg}`;
     });
-    const inner = SQLFragment.joinWithCommaSeparator(...fragments);
-    return expression(sql`COALESCE(${inner})`);
+    const inner = sql`COALESCE(${SQLFragment.joinWithCommaSeparator(...fragments)})`;
+    return new SQLChainableFragment(inner.sql, inner.bindings);
   },
 
   /**
    * LOWER helper
    * Converts a string expression to lowercase.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    */
-  lower<TFields extends Record<string, any>>(
-    expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
-  ): SQLExpression<TFields> {
-    const inner =
-      expressionOrFieldName instanceof SQLFragment
-        ? expressionOrFieldName
-        : sql`${entityField(expressionOrFieldName)}`;
-    return expression(sql`LOWER(${inner})`);
-  },
+  lower: lowerHelper,
 
   /**
    * UPPER helper
    * Converts a string expression to uppercase.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    */
-  upper<TFields extends Record<string, any>>(
-    expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
-  ): SQLExpression<TFields> {
-    const inner =
-      expressionOrFieldName instanceof SQLFragment
-        ? expressionOrFieldName
-        : sql`${entityField(expressionOrFieldName)}`;
-    return expression(sql`UPPER(${inner})`);
-  },
+  upper: upperHelper,
 
   /**
    * TRIM helper
    * Removes leading and trailing whitespace from a string expression.
-   * Returns an SQLExpression so that fluent comparison methods can be chained.
+   * Returns an SQLChainableFragment so that fluent comparison methods can be chained.
    */
-  trim<TFields extends Record<string, any>>(
-    expressionOrFieldName: SQLFragment<TFields> | keyof TFields,
-  ): SQLExpression<TFields> {
-    const inner =
-      expressionOrFieldName instanceof SQLFragment
-        ? expressionOrFieldName
-        : sql`${entityField(expressionOrFieldName)}`;
-    return expression(sql`TRIM(${inner})`);
-  },
+  trim: trimHelper,
 
   /**
    * Logical AND of multiple fragments
@@ -885,7 +1303,7 @@ export const SQLFragmentHelpers = {
       return sql`TRUE`;
     }
     return joinSQLFragments(
-      conditions.map((c) => SQLFragmentHelpers.group(c)),
+      conditions.map((c) => SQLExpression.group(c)),
       ' AND ',
     );
   },
@@ -900,7 +1318,7 @@ export const SQLFragmentHelpers = {
       return sql`FALSE`;
     }
     return joinSQLFragments(
-      conditions.map((c) => SQLFragmentHelpers.group(c)),
+      conditions.map((c) => SQLExpression.group(c)),
       ' OR ',
     );
   },

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -15,7 +15,7 @@ import type { PaginationSpecification } from '../AuthorizationResultBasedKnexEnt
 import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter.ts';
 import { PaginationStrategy } from '../PaginationStrategy.ts';
 import type { SQLFragment } from '../SQLOperator.ts';
-import { entityField, sql, SQLFragmentHelpers, unsafeRaw } from '../SQLOperator.ts';
+import { entityField, sql, SQLExpression, unsafeRaw } from '../SQLOperator.ts';
 import type { PostgresTestEntityFields } from '../__testfixtures__/PostgresTestEntity.ts';
 import { PostgresTestEntity } from '../__testfixtures__/PostgresTestEntity.ts';
 import { PostgresTriggerTestEntity } from '../__testfixtures__/PostgresTriggerTestEntity.ts';
@@ -456,7 +456,7 @@ describe('postgres entity integration', () => {
 
     it('supports SQL helper functions', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
-      const { and, or, eq, neq, inArray } = SQLFragmentHelpers;
+      const { and, or, eq, neq, inArray } = SQLExpression;
 
       await enforceAsyncResult(
         PostgresTestEntity.creatorWithAuthorizationResults(vc1)
@@ -523,7 +523,7 @@ describe('postgres entity integration', () => {
 
     it('handles empty-array and empty-condition edge cases with TRUE/FALSE', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
-      const { and, or, inArray } = SQLFragmentHelpers;
+      const { and, or, inArray } = SQLExpression;
 
       await enforceAsyncResult(
         PostgresTestEntity.creatorWithAuthorizationResults(vc1)
@@ -770,7 +770,7 @@ describe('postgres entity integration', () => {
         sql`(has_a_cat = ${true} AND has_a_dog = ${true})`,
       ];
       const joinedResults = await PostgresTestEntity.knexLoader(vc1)
-        .loadManyBySQL(SQLFragmentHelpers.or<PostgresTestEntityFields>(...conditions))
+        .loadManyBySQL(SQLExpression.or<PostgresTestEntityFields>(...conditions))
         .orderBy('name', OrderByOrdering.ASCENDING)
         .executeAsync();
 

--- a/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
@@ -4,15 +4,15 @@ import { describe, expect, it } from '@jest/globals';
 import {
   arrayValue,
   entityField,
-  expression,
   identifier,
   sql,
   SQLEntityField,
-  SQLExpression,
+  SQLChainableFragment,
   SQLFragment,
-  SQLFragmentHelpers,
+  SQLExpression,
   SQLIdentifier,
   unsafeRaw,
+  type SupportedSQLValue,
 } from '../SQLOperator.ts';
 import type { TestFields } from './fixtures/TestEntity.ts';
 import { testEntityConfiguration } from './fixtures/TestEntity.ts';
@@ -72,7 +72,7 @@ describe('SQLOperator', () => {
 
     it('handles arrayValue with entity field for = ANY()', () => {
       const values = ['active', 'pending'];
-      const fragment = sql`${entityField<TestFields>('stringField')} = ANY(${arrayValue(values)})`;
+      const fragment = sql`${entityField('stringField')} = ANY(${arrayValue(values)})`;
 
       expect(fragment.sql).toBe('?? = ANY(?)');
       expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -207,7 +207,7 @@ describe('SQLOperator', () => {
         filters.push(sql`category = ${'electronics'}`);
 
         if (filters.length > 0) {
-          fragments.push(sql`WHERE ${SQLFragmentHelpers.and(...filters)}`);
+          fragments.push(sql`WHERE ${SQLExpression.and(...filters)}`);
         }
 
         // Add ORDER BY
@@ -427,33 +427,33 @@ describe('SQLOperator', () => {
 
   describe(SQLEntityField, () => {
     it('stores the entity field name', () => {
-      const field = entityField<TestFields>('stringField');
+      const field = entityField('stringField');
       expect(field.fieldName).toBe('stringField');
     });
 
     it('uses ?? placeholder in SQL fragments', () => {
-      const fragment = sql`SELECT ${entityField<TestFields>('stringField')} FROM users`;
+      const fragment = sql`SELECT ${entityField('stringField')} FROM users`;
 
       expect(fragment.sql).toBe('SELECT ?? FROM users');
       expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
     });
 
     it('translates entity field name to database column name via getKnexBindings', () => {
-      const fragment = sql`WHERE ${entityField<TestFields>('intField')} = ${42}`;
+      const fragment = sql`WHERE ${entityField('intField')} = ${42}`;
 
       expect(fragment.sql).toBe('WHERE ?? = ?');
       expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 42]);
     });
 
     it('translates the id field correctly', () => {
-      const fragment = sql`WHERE ${entityField<TestFields>('customIdField')} = ${'some-id'}`;
+      const fragment = sql`WHERE ${entityField('customIdField')} = ${'some-id'}`;
 
       expect(fragment.sql).toBe('WHERE ?? = ?');
       expect(fragment.getKnexBindings(getColumnForField)).toEqual(['custom_id', 'some-id']);
     });
 
     it('works alongside identifiers and values', () => {
-      const fragment = sql`SELECT ${identifier('table_name')}.${entityField<TestFields>('stringField')} WHERE ${entityField<TestFields>('intField')} > ${10}`;
+      const fragment = sql`SELECT ${identifier('table_name')}.${entityField('stringField')} WHERE ${entityField('intField')} > ${10}`;
 
       expect(fragment.sql).toBe('SELECT ??.?? WHERE ?? > ?');
       expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -465,7 +465,7 @@ describe('SQLOperator', () => {
     });
 
     it('works with multiple entity fields', () => {
-      const fragment = sql`SELECT ${entityField<TestFields>('stringField')}, ${entityField<TestFields>('intField')}, ${entityField<TestFields>('dateField')} FROM test`;
+      const fragment = sql`SELECT ${entityField('stringField')}, ${entityField('intField')}, ${entityField('dateField')} FROM test`;
 
       expect(fragment.sql).toBe('SELECT ??, ??, ?? FROM test');
       expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -476,7 +476,7 @@ describe('SQLOperator', () => {
     });
 
     it('works in nested SQL fragments', () => {
-      const inner = sql`${entityField<TestFields>('stringField')} = ${'hello'}`;
+      const inner = sql`${entityField('stringField')} = ${'hello'}`;
       const outer = sql`SELECT * FROM test WHERE ${inner}`;
 
       expect(outer.sql).toBe('SELECT * FROM test WHERE ?? = ?');
@@ -484,10 +484,10 @@ describe('SQLOperator', () => {
     });
   });
 
-  describe('SQLFragmentHelpers', () => {
-    describe(SQLFragmentHelpers.inArray, () => {
+  describe('SQLExpression', () => {
+    describe(SQLExpression.inArray, () => {
       it('generates IN clause with values', () => {
-        const fragment = SQLFragmentHelpers.inArray('stringField', ['active', 'pending']);
+        const fragment = SQLExpression.inArray('stringField', ['active', 'pending']);
 
         expect(fragment.sql).toBe('?? IN (?, ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -498,16 +498,34 @@ describe('SQLOperator', () => {
       });
 
       it('handles empty array', () => {
-        const fragment = SQLFragmentHelpers.inArray('stringField', []);
+        const fragment = SQLExpression.inArray('stringField', []);
 
         expect(fragment.sql).toBe('FALSE'); // Always false
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.inArray(sql<TestFields>`${entityField('stringField')}`, [
+          'a',
+          'b',
+        ]);
+        expect(fragment.sql).toBe('?? IN (?, ?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'a', 'b']);
+      });
+
+      it('accepts a SQLChainableFragment and constrains value type', () => {
+        const fragment = SQLExpression.inArray(
+          SQLExpression.trim<TestFields, 'stringField'>('stringField'),
+          ['a', 'b'],
+        );
+        expect(fragment.sql).toBe('TRIM(??) IN (?, ?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'a', 'b']);
+      });
     });
 
-    describe(SQLFragmentHelpers.notInArray, () => {
+    describe(SQLExpression.notInArray, () => {
       it('generates NOT IN clause with values', () => {
-        const fragment = SQLFragmentHelpers.notInArray('stringField', ['deleted', 'archived']);
+        const fragment = SQLExpression.notInArray('stringField', ['deleted', 'archived']);
 
         expect(fragment.sql).toBe('?? NOT IN (?, ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -518,16 +536,24 @@ describe('SQLOperator', () => {
       });
 
       it('handles empty array', () => {
-        const fragment = SQLFragmentHelpers.notInArray('stringField', []);
+        const fragment = SQLExpression.notInArray('stringField', []);
 
         expect(fragment.sql).toBe('TRUE'); // Always true
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.notInArray(sql<TestFields>`${entityField('stringField')}`, [
+          'x',
+        ]);
+        expect(fragment.sql).toBe('?? NOT IN (?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'x']);
+      });
     });
 
-    describe(SQLFragmentHelpers.anyArray, () => {
+    describe(SQLExpression.anyArray, () => {
       it('generates = ANY() clause with values', () => {
-        const fragment = SQLFragmentHelpers.anyArray('stringField', ['active', 'pending']);
+        const fragment = SQLExpression.anyArray('stringField', ['active', 'pending']);
 
         expect(fragment.sql).toBe('?? = ANY(?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -537,16 +563,25 @@ describe('SQLOperator', () => {
       });
 
       it('handles empty array', () => {
-        const fragment = SQLFragmentHelpers.anyArray('stringField', []);
+        const fragment = SQLExpression.anyArray('stringField', []);
 
         expect(fragment.sql).toBe('FALSE'); // Always false
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.anyArray(sql<TestFields>`${entityField('stringField')}`, [
+          'a',
+          'b',
+        ]);
+        expect(fragment.sql).toBe('?? = ANY(?)');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', ['a', 'b']]);
+      });
     });
 
-    describe(SQLFragmentHelpers.between, () => {
+    describe(SQLExpression.between, () => {
       it('generates BETWEEN clause with numbers', () => {
-        const fragment = SQLFragmentHelpers.between('intField', 18, 65);
+        const fragment = SQLExpression.between('intField', 18, 65);
 
         expect(fragment.sql).toBe('?? BETWEEN ? AND ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 18, 65]);
@@ -555,23 +590,29 @@ describe('SQLOperator', () => {
       it('generates BETWEEN clause with dates', () => {
         const date1 = new Date('2024-01-01');
         const date2 = new Date('2024-12-31');
-        const fragment = SQLFragmentHelpers.between('dateField', date1, date2);
+        const fragment = SQLExpression.between('dateField', date1, date2);
 
         expect(fragment.sql).toBe('?? BETWEEN ? AND ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['date_field', date1, date2]);
       });
 
       it('generates BETWEEN clause with strings', () => {
-        const fragment = SQLFragmentHelpers.between('stringField', 'A', 'Z');
+        const fragment = SQLExpression.between('stringField', 'A', 'Z');
 
         expect(fragment.sql).toBe('?? BETWEEN ? AND ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'A', 'Z']);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.between(sql<TestFields>`${entityField('intField')}`, 1, 100);
+        expect(fragment.sql).toBe('?? BETWEEN ? AND ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 1, 100]);
+      });
     });
 
-    describe(SQLFragmentHelpers.notBetween, () => {
+    describe(SQLExpression.notBetween, () => {
       it('generates NOT BETWEEN clause with numbers', () => {
-        const fragment = SQLFragmentHelpers.notBetween('intField', 18, 65);
+        const fragment = SQLExpression.notBetween('intField', 18, 65);
 
         expect(fragment.sql).toBe('?? NOT BETWEEN ? AND ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 18, 65]);
@@ -580,35 +621,75 @@ describe('SQLOperator', () => {
       it('generates NOT BETWEEN clause with dates', () => {
         const date1 = new Date('2024-01-01');
         const date2 = new Date('2024-12-31');
-        const fragment = SQLFragmentHelpers.notBetween('dateField', date1, date2);
+        const fragment = SQLExpression.notBetween('dateField', date1, date2);
 
         expect(fragment.sql).toBe('?? NOT BETWEEN ? AND ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['date_field', date1, date2]);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.notBetween(
+          sql<TestFields>`${entityField('intField')}`,
+          1,
+          100,
+        );
+        expect(fragment.sql).toBe('?? NOT BETWEEN ? AND ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 1, 100]);
+      });
     });
 
-    describe(SQLFragmentHelpers.like, () => {
+    describe(SQLExpression.like, () => {
       it('generates LIKE clause', () => {
-        const fragment = SQLFragmentHelpers.like('stringField', '%John%');
+        const fragment = SQLExpression.like('stringField', '%John%');
 
+        expect(fragment.sql).toBe('?? LIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%John%']);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.like(
+          sql<TestFields>`${entityField('stringField')}`,
+          '%John%',
+        );
         expect(fragment.sql).toBe('?? LIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%John%']);
       });
     });
 
-    describe(SQLFragmentHelpers.notLike, () => {
+    describe(SQLExpression.notLike, () => {
       it('generates NOT LIKE clause', () => {
-        const fragment = SQLFragmentHelpers.notLike('stringField', '%test%');
+        const fragment = SQLExpression.notLike('stringField', '%test%');
 
+        expect(fragment.sql).toBe('?? NOT LIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.notLike(
+          sql<TestFields>`${entityField('stringField')}`,
+          '%test%',
+        );
         expect(fragment.sql).toBe('?? NOT LIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
       });
     });
 
-    describe(SQLFragmentHelpers.ilike, () => {
+    describe(SQLExpression.ilike, () => {
       it('generates ILIKE clause for case-insensitive matching', () => {
-        const fragment = SQLFragmentHelpers.ilike('testIndexedField', '%@example.com');
+        const fragment = SQLExpression.ilike('testIndexedField', '%@example.com');
 
+        expect(fragment.sql).toBe('?? ILIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'test_index',
+          '%@example.com',
+        ]);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.ilike(
+          sql<TestFields>`${entityField('testIndexedField')}`,
+          '%@example.com',
+        );
         expect(fragment.sql).toBe('?? ILIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([
           'test_index',
@@ -617,118 +698,189 @@ describe('SQLOperator', () => {
       });
     });
 
-    describe(SQLFragmentHelpers.notIlike, () => {
+    describe(SQLExpression.notIlike, () => {
       it('generates NOT ILIKE clause for case-insensitive non-matching', () => {
-        const fragment = SQLFragmentHelpers.notIlike('testIndexedField', '%@spam.com');
+        const fragment = SQLExpression.notIlike('testIndexedField', '%@spam.com');
 
+        expect(fragment.sql).toBe('?? NOT ILIKE ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['test_index', '%@spam.com']);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.notIlike(
+          sql<TestFields>`${entityField('testIndexedField')}`,
+          '%@spam.com',
+        );
         expect(fragment.sql).toBe('?? NOT ILIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['test_index', '%@spam.com']);
       });
     });
 
-    describe(SQLFragmentHelpers.isNull, () => {
+    describe(SQLExpression.isNull, () => {
       it('generates IS NULL', () => {
-        const fragment = SQLFragmentHelpers.isNull('nullableField');
+        const fragment = SQLExpression.isNull('nullableField');
 
+        expect(fragment.sql).toBe('?? IS NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['nullable_field']);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.isNull(sql<TestFields>`${entityField('nullableField')}`);
         expect(fragment.sql).toBe('?? IS NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['nullable_field']);
       });
     });
 
-    describe(SQLFragmentHelpers.isNotNull, () => {
+    describe(SQLExpression.isNotNull, () => {
       it('generates IS NOT NULL', () => {
-        const fragment = SQLFragmentHelpers.isNotNull('testIndexedField');
+        const fragment = SQLExpression.isNotNull('testIndexedField');
 
+        expect(fragment.sql).toBe('?? IS NOT NULL');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['test_index']);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.isNotNull(
+          sql<TestFields>`${entityField('testIndexedField')}`,
+        );
         expect(fragment.sql).toBe('?? IS NOT NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['test_index']);
       });
     });
 
-    describe(SQLFragmentHelpers.eq, () => {
+    describe(SQLExpression.eq, () => {
       it('generates equality check', () => {
-        const fragment = SQLFragmentHelpers.eq('stringField', 'active');
+        const fragment = SQLExpression.eq('stringField', 'active');
 
         expect(fragment.sql).toBe('?? = ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'active']);
       });
 
       it('handles null in equality check', () => {
-        const fragment = SQLFragmentHelpers.eq('nullableField', null);
+        const fragment = SQLExpression.eq('nullableField', null);
 
         expect(fragment.sql).toBe('?? IS NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['nullable_field']);
       });
 
       it('handles undefined in equality check', () => {
-        const fragment = SQLFragmentHelpers.eq('nullableField', undefined);
+        const fragment = SQLExpression.eq('nullableField', undefined);
 
         expect(fragment.sql).toBe('?? IS NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['nullable_field']);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.eq(sql<TestFields>`${entityField('stringField')}`, 'active');
+        expect(fragment.sql).toBe('?? = ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'active']);
+      });
+
+      it('accepts a SQLChainableFragment and constrains value type', () => {
+        const fragment = SQLExpression.eq(
+          SQLExpression.trim<TestFields, 'stringField'>('stringField'),
+          'trimmed',
+        );
+        expect(fragment.sql).toBe('TRIM(??) = ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'trimmed']);
+      });
     });
 
-    describe(SQLFragmentHelpers.neq, () => {
+    describe(SQLExpression.neq, () => {
       it('generates inequality check', () => {
-        const fragment = SQLFragmentHelpers.neq('stringField', 'deleted');
+        const fragment = SQLExpression.neq('stringField', 'deleted');
 
         expect(fragment.sql).toBe('?? != ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'deleted']);
       });
 
       it('handles null in inequality check', () => {
-        const fragment = SQLFragmentHelpers.neq('nullableField', null);
+        const fragment = SQLExpression.neq('nullableField', null);
 
         expect(fragment.sql).toBe('?? IS NOT NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['nullable_field']);
       });
 
       it('handles undefined in inequality check', () => {
-        const fragment = SQLFragmentHelpers.neq('nullableField', undefined);
+        const fragment = SQLExpression.neq('nullableField', undefined);
 
         expect(fragment.sql).toBe('?? IS NOT NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['nullable_field']);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.neq(
+          sql<TestFields>`${entityField('stringField')}`,
+          'deleted',
+        );
+        expect(fragment.sql).toBe('?? != ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'deleted']);
+      });
     });
 
-    describe(SQLFragmentHelpers.gt, () => {
+    describe(SQLExpression.gt, () => {
       it('generates greater than', () => {
-        const fragment = SQLFragmentHelpers.gt('intField', 18);
+        const fragment = SQLExpression.gt('intField', 18);
 
+        expect(fragment.sql).toBe('?? > ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 18]);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.gt(sql<TestFields>`${entityField('intField')}`, 18);
         expect(fragment.sql).toBe('?? > ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 18]);
       });
     });
 
-    describe(SQLFragmentHelpers.gte, () => {
+    describe(SQLExpression.gte, () => {
       it('generates greater than or equal', () => {
-        const fragment = SQLFragmentHelpers.gte('intField', 18);
+        const fragment = SQLExpression.gte('intField', 18);
 
+        expect(fragment.sql).toBe('?? >= ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 18]);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.gte(sql<TestFields>`${entityField('intField')}`, 18);
         expect(fragment.sql).toBe('?? >= ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 18]);
       });
     });
 
-    describe(SQLFragmentHelpers.lt, () => {
+    describe(SQLExpression.lt, () => {
       it('generates less than', () => {
-        const fragment = SQLFragmentHelpers.lt('intField', 65);
+        const fragment = SQLExpression.lt('intField', 65);
 
+        expect(fragment.sql).toBe('?? < ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 65]);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.lt(sql<TestFields>`${entityField('intField')}`, 65);
         expect(fragment.sql).toBe('?? < ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 65]);
       });
     });
 
-    describe(SQLFragmentHelpers.lte, () => {
+    describe(SQLExpression.lte, () => {
       it('generates less than or equal', () => {
-        const fragment = SQLFragmentHelpers.lte('intField', 65);
+        const fragment = SQLExpression.lte('intField', 65);
 
+        expect(fragment.sql).toBe('?? <= ?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 65]);
+      });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.lte(sql<TestFields>`${entityField('intField')}`, 65);
         expect(fragment.sql).toBe('?? <= ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 65]);
       });
     });
 
-    describe(SQLFragmentHelpers.jsonContains, () => {
+    describe(SQLExpression.jsonContains, () => {
       it('generates JSON contains', () => {
-        const fragment = SQLFragmentHelpers.jsonContains('stringField', { premium: true });
+        const fragment = SQLExpression.jsonContains('stringField', { premium: true });
 
         expect(fragment.sql).toBe('?? @> ?::jsonb');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([
@@ -738,8 +890,8 @@ describe('SQLOperator', () => {
       });
 
       it('generates JSON contains for null and undefined values', () => {
-        const fragmentNull = SQLFragmentHelpers.jsonContains('stringField', null);
-        const fragmentUndefined = SQLFragmentHelpers.jsonContains('stringField', undefined);
+        const fragmentNull = SQLExpression.jsonContains('stringField', null);
+        const fragmentUndefined = SQLExpression.jsonContains('stringField', undefined);
 
         expect(fragmentNull.sql).toBe('?? @> ?::jsonb');
         expect(fragmentNull.getKnexBindings(getColumnForField)).toEqual(['string_field', 'null']);
@@ -752,15 +904,27 @@ describe('SQLOperator', () => {
       });
 
       it('throws when value is not JSON-serializable', () => {
-        expect(() => SQLFragmentHelpers.jsonContains('stringField', (() => {}) as any)).toThrow(
+        expect(() => SQLExpression.jsonContains('stringField', (() => {}) as any)).toThrow(
           'jsonContains: value is not JSON-serializable',
         );
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.jsonContains(
+          sql<TestFields>`${entityField('stringField')}`,
+          { premium: true },
+        );
+        expect(fragment.sql).toBe('?? @> ?::jsonb');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{"premium":true}',
+        ]);
+      });
     });
 
-    describe(SQLFragmentHelpers.jsonContainedBy, () => {
+    describe(SQLExpression.jsonContainedBy, () => {
       it('generates JSON contained by', () => {
-        const fragment = SQLFragmentHelpers.jsonContainedBy('stringField', {
+        const fragment = SQLExpression.jsonContainedBy('stringField', {
           theme: 'dark',
           lang: 'en',
         });
@@ -773,8 +937,8 @@ describe('SQLOperator', () => {
       });
 
       it('generates JSON contained by for null and undefined values', () => {
-        const fragmentNull = SQLFragmentHelpers.jsonContainedBy('stringField', null);
-        const fragmentUndefined = SQLFragmentHelpers.jsonContainedBy('stringField', undefined);
+        const fragmentNull = SQLExpression.jsonContainedBy('stringField', null);
+        const fragmentUndefined = SQLExpression.jsonContainedBy('stringField', undefined);
 
         expect(fragmentNull.sql).toBe('?? <@ ?::jsonb');
         expect(fragmentNull.getKnexBindings(getColumnForField)).toEqual(['string_field', 'null']);
@@ -787,35 +951,65 @@ describe('SQLOperator', () => {
       });
 
       it('throws when value is not JSON-serializable', () => {
-        expect(() => SQLFragmentHelpers.jsonContainedBy('stringField', (() => {}) as any)).toThrow(
+        expect(() => SQLExpression.jsonContainedBy('stringField', (() => {}) as any)).toThrow(
           'jsonContainedBy: value is not JSON-serializable',
         );
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.jsonContainedBy(
+          sql<TestFields>`${entityField('stringField')}`,
+          { theme: 'dark' },
+        );
+        expect(fragment.sql).toBe('?? <@ ?::jsonb');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual([
+          'string_field',
+          '{"theme":"dark"}',
+        ]);
+      });
     });
 
-    describe(SQLFragmentHelpers.jsonPath, () => {
+    describe(SQLExpression.jsonPath, () => {
       it('generates JSON path access', () => {
-        const fragment = SQLFragmentHelpers.jsonPath('stringField', 'user');
+        const fragment = SQLExpression.jsonPath('stringField', 'user');
 
         expect(fragment.sql).toBe(`??->?`);
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'user']);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.jsonPath(
+          sql<TestFields>`${entityField('stringField')}`,
+          'user',
+        );
+        expect(fragment.sql).toBe('??->?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'user']);
+      });
     });
 
-    describe(SQLFragmentHelpers.jsonPathText, () => {
+    describe(SQLExpression.jsonPathText, () => {
       it('generates JSON path text access', () => {
-        const fragment = SQLFragmentHelpers.jsonPathText('stringField', 'email');
+        const fragment = SQLExpression.jsonPathText('stringField', 'email');
 
         expect(fragment.sql).toBe(`??->>?`);
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
       });
+
+      it('accepts a SQLFragment expression', () => {
+        const fragment = SQLExpression.jsonPathText(
+          sql<TestFields>`${entityField('stringField')}`,
+          'email',
+        );
+        expect(fragment.sql).toBe('??->>?');
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
+      });
     });
 
-    describe(SQLFragmentHelpers.and, () => {
+    describe(SQLExpression.and, () => {
       it('combines conditions with AND', () => {
         const cond1 = sql`age >= ${18}`;
         const cond2 = sql`status = ${'active'}`;
-        const fragment = SQLFragmentHelpers.and(cond1, cond2);
+        const fragment = SQLExpression.and(cond1, cond2);
 
         expect(fragment.sql).toBe('(age >= ?) AND (status = ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([18, 'active']);
@@ -823,25 +1017,25 @@ describe('SQLOperator', () => {
 
       it('handles single condition in AND', () => {
         const cond = sql`age >= ${18}`;
-        const fragment = SQLFragmentHelpers.and(cond);
+        const fragment = SQLExpression.and(cond);
 
         expect(fragment.sql).toBe('(age >= ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([18]);
       });
 
       it('handles empty conditions in AND', () => {
-        const fragment = SQLFragmentHelpers.and();
+        const fragment = SQLExpression.and();
 
         expect(fragment.sql).toBe('TRUE');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
 
-    describe(SQLFragmentHelpers.or, () => {
+    describe(SQLExpression.or, () => {
       it('combines conditions with OR', () => {
         const cond1 = sql`status = ${'active'}`;
         const cond2 = sql`status = ${'pending'}`;
-        const fragment = SQLFragmentHelpers.or(cond1, cond2);
+        const fragment = SQLExpression.or(cond1, cond2);
 
         expect(fragment.sql).toBe('(status = ?) OR (status = ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['active', 'pending']);
@@ -849,34 +1043,34 @@ describe('SQLOperator', () => {
 
       it('handles single condition in OR', () => {
         const cond = sql`status = ${'active'}`;
-        const fragment = SQLFragmentHelpers.or(cond);
+        const fragment = SQLExpression.or(cond);
 
         expect(fragment.sql).toBe('(status = ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['active']);
       });
 
       it('handles empty conditions in OR', () => {
-        const fragment = SQLFragmentHelpers.or();
+        const fragment = SQLExpression.or();
 
         expect(fragment.sql).toBe('FALSE');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([]);
       });
     });
 
-    describe(SQLFragmentHelpers.not, () => {
+    describe(SQLExpression.not, () => {
       it('negates conditions with NOT', () => {
         const cond = sql`status = ${'deleted'}`;
-        const fragment = SQLFragmentHelpers.not(cond);
+        const fragment = SQLExpression.not(cond);
 
         expect(fragment.sql).toBe('NOT (status = ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['deleted']);
       });
     });
 
-    describe(SQLFragmentHelpers.group, () => {
+    describe(SQLExpression.group, () => {
       it('groups conditions with parentheses', () => {
         const cond = sql`age >= ${18} AND age <= ${65}`;
-        const fragment = SQLFragmentHelpers.group(cond);
+        const fragment = SQLExpression.group(cond);
 
         expect(fragment.sql).toBe('(age >= ? AND age <= ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([18, 65]);
@@ -885,15 +1079,15 @@ describe('SQLOperator', () => {
 
     describe('complex combinations', () => {
       it('builds complex queries with multiple helpers', () => {
-        const fragment = SQLFragmentHelpers.and(
-          SQLFragmentHelpers.between('intField', 18, 65),
-          SQLFragmentHelpers.group(
-            SQLFragmentHelpers.or(
-              SQLFragmentHelpers.inArray('stringField', ['active', 'premium']),
+        const fragment = SQLExpression.and<TestFields>(
+          SQLExpression.between('intField', 18, 65),
+          SQLExpression.group(
+            SQLExpression.or(
+              SQLExpression.inArray('stringField', ['active', 'premium']),
               sql`role = ${'admin'}`,
             ),
           ),
-          SQLFragmentHelpers.isNotNull('testIndexedField'),
+          SQLExpression.isNotNull('testIndexedField'),
         );
 
         expect(fragment.sql).toBe(
@@ -911,101 +1105,88 @@ describe('SQLOperator', () => {
         ]);
       });
     });
-
-    describe(expression, () => {
-      it('wraps a field name into an SQLExpression', () => {
-        const fragment = expression<TestFields>('stringField').eq('active');
-
-        expect(fragment.sql).toBe('?? = ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'active']);
-      });
-
-      it('wraps a SQLFragment into an SQLExpression', () => {
-        const raw = sql<TestFields>`LOWER(${entityField<TestFields>('stringField')})`;
-        const fragment = expression(raw).eq('test');
-
-        expect(fragment.sql).toBe('LOWER(??) = ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'test']);
-      });
-    });
   });
 
-  describe(SQLExpression, () => {
-    // Use a simple expression for testing all fluent methods.
-    // Since fluent methods live on SQLExpression and behave identically regardless of
-    // how the expression was constructed, we only need to test them once.
-    const makeStringFieldExpr = (): SQLExpression<TestFields> =>
-      expression<TestFields>('stringField');
+  describe(SQLChainableFragment, () => {
+    // Use direct SQLChainableFragment construction to test fluent methods in isolation,
+    // without going through helpers like trim() or cast().
+    const makeExpr = <TValue extends SupportedSQLValue>(
+      fragment: SQLFragment<TestFields>,
+    ): SQLChainableFragment<TestFields, TValue> =>
+      new SQLChainableFragment(fragment.sql, fragment.bindings);
+
+    const stringFieldFragment = (): SQLFragment<TestFields> => sql`${entityField('stringField')}`;
+    const intFieldFragment = (): SQLFragment<TestFields> => sql`${entityField('intField')}`;
 
     describe('comparison methods', () => {
       it('eq(value)', () => {
-        const fragment = makeStringFieldExpr().eq('active');
+        const fragment = makeExpr<string>(stringFieldFragment()).eq('active');
         expect(fragment.sql).toBe('?? = ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'active']);
       });
 
       it('eq(null) uses IS NULL', () => {
-        const fragment = makeStringFieldExpr().eq(null);
+        const fragment = makeExpr<string>(stringFieldFragment()).eq(null);
         expect(fragment.sql).toBe('?? IS NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('eq(undefined) uses IS NULL', () => {
-        const fragment = makeStringFieldExpr().eq(undefined);
+        const fragment = makeExpr<string>(stringFieldFragment()).eq(undefined);
         expect(fragment.sql).toBe('?? IS NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('neq(value)', () => {
-        const fragment = makeStringFieldExpr().neq('deleted');
+        const fragment = makeExpr<string>(stringFieldFragment()).neq('deleted');
         expect(fragment.sql).toBe('?? != ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'deleted']);
       });
 
       it('neq(null) uses IS NOT NULL', () => {
-        const fragment = makeStringFieldExpr().neq(null);
+        const fragment = makeExpr<string>(stringFieldFragment()).neq(null);
         expect(fragment.sql).toBe('?? IS NOT NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('neq(undefined) uses IS NOT NULL', () => {
-        const fragment = makeStringFieldExpr().neq(undefined);
+        const fragment = makeExpr<string>(stringFieldFragment()).neq(undefined);
         expect(fragment.sql).toBe('?? IS NOT NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('gt(value)', () => {
-        const fragment = makeStringFieldExpr().gt(10);
+        const fragment = makeExpr<number>(intFieldFragment()).gt(10);
         expect(fragment.sql).toBe('?? > ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 10]);
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 10]);
       });
 
       it('gte(value)', () => {
-        const fragment = makeStringFieldExpr().gte(10);
+        const fragment = makeExpr<number>(intFieldFragment()).gte(10);
         expect(fragment.sql).toBe('?? >= ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 10]);
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 10]);
       });
 
       it('lt(value)', () => {
-        const fragment = makeStringFieldExpr().lt(100);
+        const fragment = makeExpr<number>(intFieldFragment()).lt(100);
         expect(fragment.sql).toBe('?? < ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 100]);
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 100]);
       });
 
       it('lte(value)', () => {
-        const fragment = makeStringFieldExpr().lte(100);
+        const fragment = makeExpr<number>(intFieldFragment()).lte(100);
         expect(fragment.sql).toBe('?? <= ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 100]);
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 100]);
       });
 
       it('isNull()', () => {
-        const fragment = makeStringFieldExpr().isNull();
+        const fragment = makeExpr<string>(stringFieldFragment()).isNull();
         expect(fragment.sql).toBe('?? IS NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('isNotNull()', () => {
-        const fragment = makeStringFieldExpr().isNotNull();
+        const fragment = makeExpr<string>(stringFieldFragment()).isNotNull();
         expect(fragment.sql).toBe('?? IS NOT NULL');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
@@ -1013,25 +1194,25 @@ describe('SQLOperator', () => {
 
     describe('pattern matching methods', () => {
       it('like(pattern)', () => {
-        const fragment = makeStringFieldExpr().like('%test%');
+        const fragment = makeExpr<string>(stringFieldFragment()).like('%test%');
         expect(fragment.sql).toBe('?? LIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
       });
 
       it('notLike(pattern)', () => {
-        const fragment = makeStringFieldExpr().notLike('%test%');
+        const fragment = makeExpr<string>(stringFieldFragment()).notLike('%test%');
         expect(fragment.sql).toBe('?? NOT LIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
       });
 
       it('ilike(pattern)', () => {
-        const fragment = makeStringFieldExpr().ilike('%test%');
+        const fragment = makeExpr<string>(stringFieldFragment()).ilike('%test%');
         expect(fragment.sql).toBe('?? ILIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
       });
 
       it('notIlike(pattern)', () => {
-        const fragment = makeStringFieldExpr().notIlike('%test%');
+        const fragment = makeExpr<string>(stringFieldFragment()).notIlike('%test%');
         expect(fragment.sql).toBe('?? NOT ILIKE ?');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '%test%']);
       });
@@ -1039,75 +1220,71 @@ describe('SQLOperator', () => {
 
     describe('collection methods', () => {
       it('inArray(values)', () => {
-        const fragment = makeStringFieldExpr().inArray(['a', 'b']);
+        const fragment = makeExpr<string>(stringFieldFragment()).inArray(['a', 'b']);
         expect(fragment.sql).toBe('?? IN (?, ?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'a', 'b']);
       });
 
       it('inArray([]) returns always-false', () => {
-        const fragment = makeStringFieldExpr().inArray([]);
+        const fragment = makeExpr<string>(stringFieldFragment()).inArray([]);
         expect(fragment.sql).toBe('FALSE');
       });
 
       it('notInArray(values)', () => {
-        const fragment = makeStringFieldExpr().notInArray(['x']);
+        const fragment = makeExpr<string>(stringFieldFragment()).notInArray(['x']);
         expect(fragment.sql).toBe('?? NOT IN (?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'x']);
       });
 
       it('notInArray([]) returns always-true', () => {
-        const fragment = makeStringFieldExpr().notInArray([]);
+        const fragment = makeExpr<string>(stringFieldFragment()).notInArray([]);
         expect(fragment.sql).toBe('TRUE');
       });
 
       it('anyArray(values)', () => {
-        const fragment = makeStringFieldExpr().anyArray(['a', 'b']);
+        const fragment = makeExpr<string>(stringFieldFragment()).anyArray(['a', 'b']);
         expect(fragment.sql).toBe('?? = ANY(?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', ['a', 'b']]);
       });
 
       it('anyArray([]) returns always-false', () => {
-        const fragment = makeStringFieldExpr().anyArray([]);
+        const fragment = makeExpr<string>(stringFieldFragment()).anyArray([]);
         expect(fragment.sql).toBe('FALSE');
       });
     });
 
     describe('range methods', () => {
       it('between(min, max)', () => {
-        const fragment = makeStringFieldExpr().between(1, 100);
+        const fragment = makeExpr<number>(intFieldFragment()).between(1, 100);
         expect(fragment.sql).toBe('?? BETWEEN ? AND ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 1, 100]);
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 1, 100]);
       });
 
       it('notBetween(min, max)', () => {
-        const fragment = makeStringFieldExpr().notBetween(1, 100);
+        const fragment = makeExpr<number>(intFieldFragment()).notBetween(1, 100);
         expect(fragment.sql).toBe('?? NOT BETWEEN ? AND ?');
-        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 1, 100]);
+        expect(fragment.getKnexBindings(getColumnForField)).toEqual(['number_field', 1, 100]);
       });
     });
 
-    describe('helpers that return SQLExpression', () => {
-      it('jsonPath returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'key');
-        expect(expr).toBeInstanceOf(SQLExpression);
+    describe('helpers that return SQLChainableFragment', () => {
+      it('jsonPath returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.jsonPath('stringField', 'key');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('??->?');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', 'key']);
       });
 
-      it('jsonPathText returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'email');
-        expect(expr).toBeInstanceOf(SQLExpression);
+      it('jsonPathText returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.jsonPathText('stringField', 'email');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('??->>?');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
       });
 
-      it('jsonDeepPath returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', [
-          'user',
-          'address',
-          'city',
-        ]);
-        expect(expr).toBeInstanceOf(SQLExpression);
+      it('jsonDeepPath returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.jsonDeepPath('stringField', ['user', 'address', 'city']);
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('?? #> ?');
         expect(expr.getKnexBindings(getColumnForField)).toEqual([
           'string_field',
@@ -1116,11 +1293,7 @@ describe('SQLOperator', () => {
       });
 
       it('jsonDeepPath properly quotes path elements with special characters', () => {
-        const fragment = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', [
-          'user',
-          'first,last',
-          'na}me',
-        ]);
+        const fragment = SQLExpression.jsonDeepPath('stringField', ['user', 'first,last', 'na}me']);
 
         expect(fragment.getKnexBindings(getColumnForField)).toEqual([
           'string_field',
@@ -1129,13 +1302,13 @@ describe('SQLOperator', () => {
       });
 
       it('jsonDeepPath properly quotes empty path elements', () => {
-        const fragment = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', ['user', '']);
+        const fragment = SQLExpression.jsonDeepPath('stringField', ['user', '']);
 
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', '{user,""}']);
       });
 
       it('jsonDeepPath properly escapes quotes and backslashes in path elements', () => {
-        const fragment = SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', [
+        const fragment = SQLExpression.jsonDeepPath('stringField', [
           'key"with"quotes',
           'back\\slash',
         ]);
@@ -1146,13 +1319,19 @@ describe('SQLOperator', () => {
         ]);
       });
 
-      it('jsonDeepPathText returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.jsonDeepPathText<TestFields>('stringField', [
+      it('jsonDeepPath accepts a SQLFragment expression', () => {
+        const expr = SQLExpression.jsonDeepPath(sql<TestFields>`${entityField('stringField')}`, [
           'user',
-          'address',
           'city',
         ]);
-        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
+        expect(expr.sql).toBe('?? #> ?');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', '{user,city}']);
+      });
+
+      it('jsonDeepPathText returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.jsonDeepPathText('stringField', ['user', 'address', 'city']);
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('?? #>> ?');
         expect(expr.getKnexBindings(getColumnForField)).toEqual([
           'string_field',
@@ -1160,35 +1339,52 @@ describe('SQLOperator', () => {
         ]);
       });
 
-      it('cast returns an SQLExpression with correct base SQL', () => {
-        const jsonExpr = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'count');
-        const expr = SQLFragmentHelpers.cast(jsonExpr, 'int');
-        expect(expr).toBeInstanceOf(SQLExpression);
+      it('jsonDeepPathText accepts a SQLFragment expression', () => {
+        const expr = SQLExpression.jsonDeepPathText(
+          sql<TestFields>`${entityField('stringField')}`,
+          ['user', 'city'],
+        );
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
+        expect(expr.sql).toBe('?? #>> ?');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', '{user,city}']);
+      });
+
+      it('cast returns an SQLChainableFragment with correct base SQL', () => {
+        const jsonExpr = SQLExpression.jsonPath('stringField', 'count');
+        const expr = SQLExpression.cast(jsonExpr, 'int');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('(??->?)::int');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field', 'count']);
       });
 
+      it('cast accepts a field name', () => {
+        const expr = SQLExpression.cast('intField', 'text');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
+        expect(expr.sql).toBe('(??)::text');
+        expect(expr.getKnexBindings(getColumnForField)).toEqual(['number_field']);
+      });
+
       it('cast rejects unsupported type names', () => {
-        const expr = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'count');
-        expect(() => SQLFragmentHelpers.cast(expr, 'int; DROP TABLE users' as any)).toThrow(
+        const expr = SQLExpression.jsonPath('stringField', 'count');
+        expect(() => SQLExpression.cast(expr, 'int; DROP TABLE users' as any)).toThrow(
           'cast: unsupported type name',
         );
       });
 
-      it('coalesce returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.coalesce<TestFields>(
-          sql`${entityField<TestFields>('nullableField')}`,
+      it('coalesce returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.coalesce<TestFields>(
+          sql`${entityField('nullableField')}`,
           'default',
         );
-        expect(expr).toBeInstanceOf(SQLExpression);
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('COALESCE(??, ?)');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['nullable_field', 'default']);
       });
 
       it('coalesce with multiple expressions', () => {
-        const fragment = SQLFragmentHelpers.coalesce<TestFields>(
-          sql`${entityField<TestFields>('nullableField')}`,
-          sql`${entityField<TestFields>('stringField')}`,
+        const fragment = SQLExpression.coalesce<TestFields>(
+          sql`${entityField('nullableField')}`,
+          sql`${entityField('stringField')}`,
           'fallback',
         );
         expect(fragment.sql).toBe('COALESCE(??, ??, ?)');
@@ -1199,53 +1395,53 @@ describe('SQLOperator', () => {
         ]);
       });
 
-      it('lower returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.lower<TestFields>('stringField');
-        expect(expr).toBeInstanceOf(SQLExpression);
+      it('lower returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.lower('stringField');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('LOWER(??)');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('lower accepts a SQLFragment', () => {
-        const fragment = SQLFragmentHelpers.lower(
-          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'email'),
+        const fragment = SQLExpression.lower(
+          SQLExpression.jsonPathText<TestFields, 'stringField'>('stringField', 'email'),
         );
         expect(fragment.sql).toBe('LOWER(??->>?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
       });
 
-      it('upper returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.upper<TestFields>('stringField');
-        expect(expr).toBeInstanceOf(SQLExpression);
+      it('upper returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.upper('stringField');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('UPPER(??)');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('upper accepts a SQLFragment', () => {
-        const fragment = SQLFragmentHelpers.upper(
-          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'email'),
+        const fragment = SQLExpression.upper(
+          SQLExpression.jsonPathText<TestFields, 'stringField'>('stringField', 'email'),
         );
         expect(fragment.sql).toBe('UPPER(??->>?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'email']);
       });
 
-      it('trim returns an SQLExpression with correct base SQL', () => {
-        const expr = SQLFragmentHelpers.trim<TestFields>('stringField');
-        expect(expr).toBeInstanceOf(SQLExpression);
+      it('trim returns an SQLChainableFragment with correct base SQL', () => {
+        const expr = SQLExpression.trim('stringField');
+        expect(expr).toBeInstanceOf(SQLChainableFragment);
         expect(expr.sql).toBe('TRIM(??)');
         expect(expr.getKnexBindings(getColumnForField)).toEqual(['string_field']);
       });
 
       it('trim accepts a SQLFragment', () => {
-        const fragment = SQLFragmentHelpers.trim(
-          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'name'),
+        const fragment = SQLExpression.trim(
+          SQLExpression.jsonPathText<TestFields, 'stringField'>('stringField', 'name'),
         );
         expect(fragment.sql).toBe('TRIM(??->>?)');
         expect(fragment.getKnexBindings(getColumnForField)).toEqual(['string_field', 'name']);
       });
 
-      it('SQLExpression still works as a SQLFragment in sql template', () => {
-        const path = SQLFragmentHelpers.jsonPath<TestFields>('stringField', 'key');
+      it('SQLChainableFragment still works as a SQLFragment in sql template', () => {
+        const path = SQLExpression.jsonPath('stringField', 'key');
         const fragment = sql`${path} IS NOT NULL`;
 
         expect(fragment.sql).toBe('??->? IS NOT NULL');
@@ -1255,8 +1451,8 @@ describe('SQLOperator', () => {
 
     describe('composing multiple expression helpers', () => {
       it('lower(trim(field)).eq(value)', () => {
-        const fragment = SQLFragmentHelpers.lower(
-          SQLFragmentHelpers.trim<TestFields>('stringField'),
+        const fragment = SQLExpression.lower(
+          SQLExpression.trim(sql<TestFields>`${entityField('stringField')}`),
         ).eq('hello');
 
         expect(fragment.sql).toBe('LOWER(TRIM(??)) = ?');
@@ -1264,8 +1460,8 @@ describe('SQLOperator', () => {
       });
 
       it('cast(jsonDeepPath(...), type).gt(value)', () => {
-        const fragment = SQLFragmentHelpers.cast(
-          SQLFragmentHelpers.jsonDeepPath<TestFields>('stringField', ['stats', 'count']),
+        const fragment = SQLExpression.cast(
+          SQLExpression.jsonDeepPath<TestFields, 'stringField'>('stringField', ['stats', 'count']),
           'int',
         ).gt(10);
 
@@ -1278,8 +1474,8 @@ describe('SQLOperator', () => {
       });
 
       it('coalesce(jsonPathText(...), default).ilike(pattern)', () => {
-        const fragment = SQLFragmentHelpers.coalesce(
-          SQLFragmentHelpers.jsonPathText<TestFields>('stringField', 'name'),
+        const fragment = SQLExpression.coalesce(
+          SQLExpression.jsonPathText<TestFields, 'stringField'>('stringField', 'name'),
           '',
         ).ilike('%test%');
 

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -15,7 +15,7 @@ import type {
 } from '../BasePostgresEntityDatabaseAdapter.ts';
 import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter.ts';
 import { PaginationStrategy } from '../PaginationStrategy.ts';
-import { SQLFragment, SQLFragmentHelpers, identifier, sql, unsafeRaw } from '../SQLOperator.ts';
+import { SQLFragment, SQLExpression, identifier, sql, unsafeRaw } from '../SQLOperator.ts';
 import type { DistributiveOmit, NonNullableKeys } from './utilityTypes.ts';
 
 interface DataManagerStandardSpecification<TFields extends Record<string, any>> {
@@ -329,7 +329,7 @@ export class EntityKnexDataManager<
 
       // Combine WHERE conditions: base where + search where
       const whereClause =
-        where && searchWhere ? SQLFragmentHelpers.and(where, searchWhere) : (where ?? searchWhere);
+        where && searchWhere ? SQLExpression.and(where, searchWhere) : (where ?? searchWhere);
 
       const fieldsToUseInPostgresTupleCursor =
         search.strategy === PaginationStrategy.TRIGRAM_SEARCH
@@ -674,7 +674,7 @@ export class EntityKnexDataManager<
     tableAlias?: typeof CURSOR_ROW_TABLE_ALIAS,
   ): SQLFragment<TFields> {
     const ilikeConditions = this.buildILikeConditions(search, tableAlias);
-    return sql`CASE WHEN ${SQLFragmentHelpers.or(...ilikeConditions)} THEN 1 ELSE 0 END`;
+    return sql`CASE WHEN ${SQLExpression.or(...ilikeConditions)} THEN 1 ELSE 0 END`;
   }
 
   private buildTrigramSimilarityGreatestExpression(
@@ -772,7 +772,7 @@ export class EntityKnexDataManager<
         ];
 
         return {
-          searchWhere: conditions.length > 0 ? SQLFragmentHelpers.or(...conditions) : sql`FALSE`,
+          searchWhere: conditions.length > 0 ? SQLExpression.or(...conditions) : sql`FALSE`,
           searchOrderByClauses,
         };
       }
@@ -816,7 +816,7 @@ export class EntityKnexDataManager<
         ];
 
         return {
-          searchWhere: SQLFragmentHelpers.or(...allConditions),
+          searchWhere: SQLExpression.or(...allConditions),
           searchOrderByClauses,
         };
       }


### PR DESCRIPTION
# Why

The `expression` API added in #506 was somewhat poisonous. When doing something like `jsonPath('fieldName', 'wat').eq(10)`, the type information was lost due to typescript not carrying it through chains. So I could do something like:
```
BlahEntity.knexLoader()..loadManyBySQL(sql`${entityField('hadsACat')} = ${true}`)
```
and it would correctly tell me that the field name is invalid (type info carries into single arg).

But the following wouldn't:
```
BlahEntity.knexLoader().loadBySQL(expression('hadsACat').eq(true))
```

# How

It's better to just get rid of `expression` though keep the fluent API on SQLFragmentHelper methods that can carry the type information through the chain.

This PR does a few things:
- adds the required code to carry that type information through
- updates SQLFragmentHelper methods to take either an expression/fragment or entity field name for better usability.
- renames SQLExpression to SQLChainableFragment to better describe what it does
- renames SQLFragmentHelper to SQLExpression to better describe the class of things it contains.

# Test Plan

Run new tests.
