### PR TITLE
chore: use @expo/nullthrows in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   transform: { '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }] },
   // ESM modules that need to be transformed
-  transformIgnorePatterns: ['node_modules/(?!(uuid)/)'],
+  transformIgnorePatterns: ['node_modules/(?!(uuid|@expo)/)'],
   collectCoverageFrom: [
     'packages/*/src/**',
     '!packages/*/src/index.ts',

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -6,10 +6,10 @@ import {
   ViewerContext,
   zipToMap,
 } from '@expo/entity';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import invariant from 'invariant';
 import Redis from 'ioredis';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
@@ -1,7 +1,7 @@
 import { createWithUniqueConstraintRecoveryAsync, ViewerContext } from '@expo/entity';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import knex, { Knex } from 'knex';
-import nullthrows from 'nullthrows';
 
 import { PostgresUniqueTestEntity } from '../__testfixtures__/PostgresUniqueTestEntity';
 import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -4,16 +4,16 @@ import {
   ViewerContext,
 } from '@expo/entity';
 import { createUnitTestEntityCompanionProvider } from '@expo/entity-testing-utils';
+import nullthrows from '@expo/nullthrows';
 import { enforceAsyncResult } from '@expo/results';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, test } from '@jest/globals';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 import { setTimeout } from 'timers/promises';
 
 import { PaginationSpecification } from '../AuthorizationResultBasedKnexEntityLoader';
 import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
 import { PaginationStrategy } from '../PaginationStrategy';
-import { entityField, unsafeRaw, sql, SQLFragmentHelpers, SQLFragment } from '../SQLOperator';
+import { entityField, sql, SQLFragment, SQLFragmentHelpers, unsafeRaw } from '../SQLOperator';
 import {
   PostgresTestEntity,
   PostgresTestEntityFields,

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -1,7 +1,7 @@
 import { TransactionalDataLoaderMode, ViewerContext } from '@expo/entity';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, test } from '@jest/globals';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 
 import { PostgresEntityQueryContextProvider } from '../PostgresEntityQueryContextProvider';
 import { PostgresUniqueTestEntity } from '../__testfixtures__/PostgresUniqueTestEntity';

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -1,8 +1,8 @@
 import { ViewerContext } from '@expo/entity';
+import nullthrows from '@expo/nullthrows';
 import { enforceAsyncResult } from '@expo/results';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 
 import { InvalidTestEntity } from '../__testfixtures__/InvalidTestEntity';
 import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -8,9 +8,9 @@ import {
   EntityDatabaseAdapterUnknownError,
   ViewerContext,
 } from '@expo/entity';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 
 import { ErrorsTestEntity } from '../__testfixtures__/ErrorsTestEntity';
 import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -1,21 +1,21 @@
 import {
-  EntityPrivacyPolicy,
-  ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
+  EntityPrivacyPolicy,
   StringField,
   UUIDField,
+  ViewerContext,
 } from '@expo/entity';
 import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 
 import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -1,21 +1,21 @@
 import {
-  EntityPrivacyPolicy,
-  ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
+  EntityPrivacyPolicy,
   StringField,
   UUIDField,
+  ViewerContext,
 } from '@expo/entity';
 import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 
 import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -3,15 +3,15 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 
+import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
 import ChildEntity from './entities/ChildEntity';
 import ParentEntity from './entities/ParentEntity';
-import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
 
 async function createOrTruncatePostgresTablesAsync(knex: Knex): Promise<void> {
   await knex.schema.createTable('parents', (table) => {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -1,20 +1,20 @@
 import {
-  EntityPrivacyPolicy,
-  ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
+  EntityPrivacyPolicy,
   UUIDField,
+  ViewerContext,
 } from '@expo/entity';
 import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -1,21 +1,21 @@
 import {
-  EntityPrivacyPolicy,
-  ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   Entity,
   EntityCompanionDefinition,
   EntityConfiguration,
-  UUIDField,
   EntityEdgeDeletionBehavior,
+  EntityPrivacyPolicy,
+  UUIDField,
+  ViewerContext,
 } from '@expo/entity';
 import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
 import { knex, Knex } from 'knex';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -32,9 +32,9 @@
     "@expo/entity-cache-adapter-local-memory": "workspace:^"
   },
   "devDependencies": {
+    "@expo/nullthrows": "2.1.0",
     "@isaacs/ttlcache": "2.1.4",
     "@jest/globals": "30.2.0",
-    "nullthrows": "1.1.1",
     "typescript": "5.9.3"
   }
 }

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -21,9 +21,9 @@ import {
   LocalMemoryCacheValue,
 } from '@expo/entity-cache-adapter-local-memory';
 import { StubDatabaseAdapterProvider, StubQueryContextProvider } from '@expo/entity-testing-utils';
+import nullthrows from '@expo/nullthrows';
 import { TTLCache } from '@isaacs/ttlcache';
 import { describe, expect, it } from '@jest/globals';
-import nullthrows from 'nullthrows';
 
 import { LocalMemorySecondaryEntityCache } from '../LocalMemorySecondaryEntityCache';
 

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -31,9 +31,9 @@
     "@expo/entity-cache-adapter-redis": "workspace:^"
   },
   "devDependencies": {
+    "@expo/nullthrows": "2.1.0",
     "@jest/globals": "30.2.0",
     "ioredis": "5.10.0",
-    "nullthrows": "1.1.1",
     "typescript": "5.9.3"
   }
 }

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -9,9 +9,9 @@ import {
   GenericRedisCacheContext,
   RedisCacheInvalidationStrategy,
 } from '@expo/entity-cache-adapter-redis';
+import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import Redis from 'ioredis';
-import nullthrows from 'nullthrows';
 import { URL } from 'url';
 
 import { RedisSecondaryEntityCache } from '../RedisSecondaryEntityCache';

--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -1,6 +1,6 @@
+import nullthrows from '@expo/nullthrows';
 import { Result, result } from '@expo/results';
 import invariant from 'invariant';
-import nullthrows from 'nullthrows';
 
 import { IEntityClass } from './Entity';
 import {

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -1,4 +1,4 @@
-import nullthrows from 'nullthrows';
+import nullthrows from '@expo/nullthrows';
 
 import { IEntityCacheAdapter } from './IEntityCacheAdapter';
 import { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';

--- a/packages/entity/src/ComposedSecondaryEntityCache.ts
+++ b/packages/entity/src/ComposedSecondaryEntityCache.ts
@@ -1,4 +1,4 @@
-import nullthrows from 'nullthrows';
+import nullthrows from '@expo/nullthrows';
 
 import { ISecondaryEntityCache } from './EntitySecondaryCacheLoader';
 

--- a/packages/entity/src/EntityConstructionUtils.ts
+++ b/packages/entity/src/EntityConstructionUtils.ts
@@ -1,6 +1,6 @@
+import nullthrows from '@expo/nullthrows';
 import { Result, asyncResult, result } from '@expo/results';
 import invariant from 'invariant';
-import nullthrows from 'nullthrows';
 
 import { IEntityClass } from './Entity';
 import { EntityConfiguration } from './EntityConfiguration';

--- a/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
@@ -1,6 +1,6 @@
+import nullthrows from '@expo/nullthrows';
 import { describe, expect, it } from '@jest/globals';
 import invariant from 'invariant';
-import nullthrows from 'nullthrows';
 
 import { ComposedSecondaryEntityCache } from '../ComposedSecondaryEntityCache';
 import { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader';

--- a/packages/entity/src/__tests__/GenericSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/GenericSecondaryEntityCache-test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from '@jest/globals';
-import nullthrows from 'nullthrows';
+import nullthrows from '@expo/nullthrows';
+import { describe, expect, it } from '@jest/globals';
 
 import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
 import { EntityConstructionUtils } from '../EntityConstructionUtils';

--- a/packages/entity/src/internal/EntityFieldTransformationUtils.ts
+++ b/packages/entity/src/internal/EntityFieldTransformationUtils.ts
@@ -1,5 +1,5 @@
+import nullthrows from '@expo/nullthrows';
 import invariant from 'invariant';
-import nullthrows from 'nullthrows';
 
 import { EntityConfiguration } from '../EntityConfiguration';
 

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -1,5 +1,5 @@
+import nullthrows from '@expo/nullthrows';
 import { describe, expect, it } from '@jest/globals';
-import nullthrows from 'nullthrows';
 
 import { Entity } from '../../Entity';
 import { EntityCompanionDefinition } from '../../EntityCompanionProvider';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,9 +1828,9 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-cache-adapter-local-memory": "workspace:^"
+    "@expo/nullthrows": "npm:2.1.0"
     "@isaacs/ttlcache": "npm:2.1.4"
     "@jest/globals": "npm:30.2.0"
-    nullthrows: "npm:1.1.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -1841,9 +1841,9 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@expo/entity-cache-adapter-redis": "workspace:^"
+    "@expo/nullthrows": "npm:2.1.0"
     "@jest/globals": "npm:30.2.0"
     ioredis: "npm:5.10.0"
-    nullthrows: "npm:1.1.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -1881,6 +1881,13 @@ __metadata:
     uuid: "npm:13.0.0"
   languageName: unknown
   linkType: soft
+
+"@expo/nullthrows@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@expo/nullthrows@npm:2.1.0"
+  checksum: 10c0/9f0b7f8ebcf5932ecc9bd2c55a4892ad35e009d21448881455b3f491bb96751586041fb852577c6c43b89c5df74a14b0693e9f2156093ffa1073be5d0670054f
+  languageName: node
+  linkType: hard
 
 "@expo/results@npm:^1.0.0":
   version: 1.0.0
@@ -10461,13 +10468,6 @@ __metadata:
   dependencies:
     path-key: "npm:^3.0.0"
   checksum: 10c0/6f9353a95288f8455cf64cbeb707b28826a7f29690244c1e4bb61ec573256e021b6ad6651b394eb1ccfd00d6ec50147253aba2c5fe58a57ceb111fad62c519ac
-  languageName: node
-  linkType: hard
-
-"nullthrows@npm:1.1.1":
-  version: 1.1.1
-  resolution: "nullthrows@npm:1.1.1"
-  checksum: 10c0/56f34bd7c3dcb3bd23481a277fa22918120459d3e9d95ca72976c72e9cac33a97483f0b95fc420e2eb546b9fe6db398273aba9a938650cdb8c98ee8f159dcb30
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

This package is slightly newer and is usable with ESM.

# How

Drop-in replacement.

# Test Plan

We only use it in tests, so I ran those tests.
