### PR TITLE
chore: allow relative imports with ts file extension

### DIFF
--- a/packages/entity-example/tsconfig.json
+++ b/packages/entity-example/tsconfig.json
@@ -3,8 +3,6 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "noEmit": true,
-    // Support running in development with `node --experimental-transform-types`
-    "rewriteRelativeImportExtensions": true,
     "verbatimModuleSyntax": true
   },
   "references": [{ "path": "../entity" }, { "path": "../entity-testing-utils" }]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "${configDir}/build",
-    "sourceMap": true
+    "sourceMap": true,
+    "rewriteRelativeImportExtensions": true
   }
 }


### PR DESCRIPTION
# Why

[ESM requires relative imports to have file endings](https://nodejs.org/api/esm.html#mandatory-file-extensions).  New versions of typescript finally allow us to write source files with imports ending in `.ts`  and get built files with imports ending in `.js`.  If you run `node --experimental-transform-types` on a file, it will treat the import paths as they're written, so typescript source files need to be importing their typescript siblings.

With this enabled, we can run node with strip- or transform-types on the source files, _and_ run `tsc` to get correctly built output with `.js` imports.

# How

Just added the setting.  See other PRs in the stack for changes which depend on this.

# Test Plan

No changes to source.