### PR TITLE
chore!: ESM

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,7 +80,6 @@ module.exports = defineConfig([
           allowAsStatement: true,
         },
       ],
-      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/explicit-function-return-type': [
         'warn',
         {

--- a/packages/entity-cache-adapter-local-memory/package.json
+++ b/packages/entity-cache-adapter-local-memory/package.json
@@ -20,13 +20,14 @@
     "integration": "yarn integration:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^"
   },

--- a/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/LocalMemoryCacheAdapterProvider.ts
@@ -5,8 +5,8 @@ import type {
 } from '@expo/entity';
 import { computeIfAbsent, GenericEntityCacheAdapter } from '@expo/entity';
 
-import type { ILocalMemoryCache } from './GenericLocalMemoryCacher';
-import { GenericLocalMemoryCacher } from './GenericLocalMemoryCacher';
+import type { ILocalMemoryCache } from './GenericLocalMemoryCacher.ts';
+import { GenericLocalMemoryCacher } from './GenericLocalMemoryCacher.ts';
 
 export type LocalMemoryCacheCreator = <
   TFields extends Record<string, any>,

--- a/packages/entity-cache-adapter-local-memory/src/__testfixtures__/createLocalMemoryTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__testfixtures__/createLocalMemoryTestEntityCompanionProvider.ts
@@ -3,8 +3,8 @@ import { EntityCompanionProvider, NoOpEntityMetricsAdapter } from '@expo/entity'
 import { StubDatabaseAdapterProvider, StubQueryContextProvider } from '@expo/entity-testing-utils';
 import { TTLCache } from '@isaacs/ttlcache';
 
-import type { ILocalMemoryCache, LocalMemoryCacheValue } from '../GenericLocalMemoryCacher';
-import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
+import type { ILocalMemoryCache, LocalMemoryCacheValue } from '../GenericLocalMemoryCacher.ts';
+import { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider.ts';
 
 const queryContextProvider = new StubQueryContextProvider();
 

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-full-test.ts
@@ -8,14 +8,14 @@ import {
 import { describe, expect, it } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
-import { GenericLocalMemoryCacher } from '../GenericLocalMemoryCacher';
-import type { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider';
-import type { LocalMemoryTestEntityFields } from '../__testfixtures__/LocalMemoryTestEntity';
-import { LocalMemoryTestEntity } from '../__testfixtures__/LocalMemoryTestEntity';
+import { GenericLocalMemoryCacher } from '../GenericLocalMemoryCacher.ts';
+import type { LocalMemoryCacheAdapterProvider } from '../LocalMemoryCacheAdapterProvider.ts';
+import type { LocalMemoryTestEntityFields } from '../__testfixtures__/LocalMemoryTestEntity.ts';
+import { LocalMemoryTestEntity } from '../__testfixtures__/LocalMemoryTestEntity.ts';
 import {
   createLocalMemoryTestEntityCompanionProvider,
   createNoOpLocalMemoryIntegrationTestEntityCompanionProvider,
-} from '../__testfixtures__/createLocalMemoryTestEntityCompanionProvider';
+} from '../__testfixtures__/createLocalMemoryTestEntityCompanionProvider.ts';
 
 describe(GenericLocalMemoryCacher, () => {
   it('has correct caching behavior', async () => {

--- a/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
+++ b/packages/entity-cache-adapter-local-memory/src/__tests__/GenericLocalMemoryCacher-test.ts
@@ -10,11 +10,11 @@ import {
 import { TTLCache } from '@isaacs/ttlcache';
 import { describe, expect, it } from '@jest/globals';
 
-import type { ILocalMemoryCache, LocalMemoryCacheValue } from '../GenericLocalMemoryCacher';
+import type { ILocalMemoryCache, LocalMemoryCacheValue } from '../GenericLocalMemoryCacher.ts';
 import {
   DOES_NOT_EXIST_LOCAL_MEMORY_CACHE,
   GenericLocalMemoryCacher,
-} from '../GenericLocalMemoryCacher';
+} from '../GenericLocalMemoryCacher.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity-cache-adapter-redis/package.json
+++ b/packages/entity-cache-adapter-redis/package.json
@@ -20,13 +20,14 @@
     "integration": "yarn integration:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^"
   },

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -11,9 +11,9 @@ import {
   transformFieldsToCacheObject,
 } from '@expo/entity';
 
-import { redisTransformerMap } from './RedisCommon';
-import { wrapNativeRedisCallAsync } from './errors/wrapNativeRedisCallAsync';
-import { getSurroundingCacheKeyVersionsForInvalidation } from './utils/getSurroundingCacheKeyVersionsForInvalidation';
+import { redisTransformerMap } from './RedisCommon.ts';
+import { wrapNativeRedisCallAsync } from './errors/wrapNativeRedisCallAsync.ts';
+import { getSurroundingCacheKeyVersionsForInvalidation } from './utils/getSurroundingCacheKeyVersionsForInvalidation.ts';
 
 // Sentinel value we store in Redis to negatively cache a database miss.
 // The sentinel value is distinct from any (positively) cached value.

--- a/packages/entity-cache-adapter-redis/src/RedisCacheAdapterProvider.ts
+++ b/packages/entity-cache-adapter-redis/src/RedisCacheAdapterProvider.ts
@@ -5,8 +5,8 @@ import type {
 } from '@expo/entity';
 import { GenericEntityCacheAdapter } from '@expo/entity';
 
-import type { GenericRedisCacheContext } from './GenericRedisCacher';
-import { GenericRedisCacher } from './GenericRedisCacher';
+import type { GenericRedisCacheContext } from './GenericRedisCacher.ts';
+import { GenericRedisCacher } from './GenericRedisCacher.ts';
 
 export class RedisCacheAdapterProvider implements IEntityCacheAdapterProvider {
   constructor(private readonly context: GenericRedisCacheContext) {}

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -4,15 +4,15 @@ import { SingleFieldHolder, SingleFieldValueHolder, ViewerContext, zipToMap } fr
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import invariant from 'invariant';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { GenericRedisCacheContext, IRedis, IRedisTransaction } from '../GenericRedisCacher';
-import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher';
-import type { RedisTestEntityFields } from '../__testfixtures__/RedisTestEntity';
-import { RedisTestEntity } from '../__testfixtures__/RedisTestEntity';
-import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider';
+import type { GenericRedisCacheContext, IRedis, IRedisTransaction } from '../GenericRedisCacher.ts';
+import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher.ts';
+import type { RedisTestEntityFields } from '../__testfixtures__/RedisTestEntity.ts';
+import { RedisTestEntity } from '../__testfixtures__/RedisTestEntity.ts';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts';
 
 class BatchedRedis implements IRedis {
   private readonly mgetBatcher = new Batcher<string[], (string | null)[]>(

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -8,15 +8,15 @@ import {
 } from '@expo/entity';
 import { enforceAsyncResult } from '@expo/results';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { GenericRedisCacheContext } from '../GenericRedisCacher';
-import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher';
-import type { RedisTestEntityFields } from '../__testfixtures__/RedisTestEntity';
-import { RedisTestEntity } from '../__testfixtures__/RedisTestEntity';
-import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider';
+import type { GenericRedisCacheContext } from '../GenericRedisCacher.ts';
+import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher.ts';
+import type { RedisTestEntityFields } from '../__testfixtures__/RedisTestEntity.ts';
+import { RedisTestEntity } from '../__testfixtures__/RedisTestEntity.ts';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts';
 
 class TestViewerContext extends ViewerContext {}
 

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -1,13 +1,16 @@
 import { CacheStatus, ViewerContext } from '@expo/entity';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { URL } from 'url';
 
-import type { GenericRedisCacheContext } from '../GenericRedisCacher';
-import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher';
-import type { RedisTestEntityFields } from '../__testfixtures__/RedisTestEntity';
-import { RedisTestEntity, redisTestEntityConfiguration } from '../__testfixtures__/RedisTestEntity';
-import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider';
+import type { GenericRedisCacheContext } from '../GenericRedisCacher.ts';
+import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher.ts';
+import type { RedisTestEntityFields } from '../__testfixtures__/RedisTestEntity.ts';
+import {
+  RedisTestEntity,
+  redisTestEntityConfiguration,
+} from '../__testfixtures__/RedisTestEntity.ts';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts';
 
 class TestViewerContext extends ViewerContext {}
 

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -1,12 +1,12 @@
 import { EntityCacheAdapterTransientError, ViewerContext } from '@expo/entity';
 import { beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { URL } from 'url';
 
-import type { GenericRedisCacheContext } from '../GenericRedisCacher';
-import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher';
-import { RedisTestEntity } from '../__testfixtures__/RedisTestEntity';
-import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider';
+import type { GenericRedisCacheContext } from '../GenericRedisCacher.ts';
+import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher.ts';
+import { RedisTestEntity } from '../__testfixtures__/RedisTestEntity.ts';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts';
 
 class TestViewerContext extends ViewerContext {}
 

--- a/packages/entity-cache-adapter-redis/src/__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-cache-adapter-redis/src/__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts
@@ -2,8 +2,8 @@ import type { IEntityMetricsAdapter } from '@expo/entity';
 import { EntityCompanionProvider, NoOpEntityMetricsAdapter } from '@expo/entity';
 import { StubDatabaseAdapterProvider, StubQueryContextProvider } from '@expo/entity-testing-utils';
 
-import type { GenericRedisCacheContext } from '../GenericRedisCacher';
-import { RedisCacheAdapterProvider } from '../RedisCacheAdapterProvider';
+import type { GenericRedisCacheContext } from '../GenericRedisCacher.ts';
+import { RedisCacheAdapterProvider } from '../RedisCacheAdapterProvider.ts';
 
 // share across all in calls in test to simulate postgres
 const adapterProvider = new StubDatabaseAdapterProvider();

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from '@jest/globals';
 import type { Pipeline, Redis } from 'ioredis';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
-import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher';
+import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRedisCacher.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity-cache-adapter-redis/src/errors/__tests__/wrapNativeRedisCallAsync-test.ts
+++ b/packages/entity-cache-adapter-redis/src/errors/__tests__/wrapNativeRedisCallAsync-test.ts
@@ -1,7 +1,7 @@
 import { EntityCacheAdapterTransientError } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 
-import { wrapNativeRedisCallAsync } from '../wrapNativeRedisCallAsync';
+import { wrapNativeRedisCallAsync } from '../wrapNativeRedisCallAsync.ts';
 
 describe(wrapNativeRedisCallAsync, () => {
   it('rethrows literals', async () => {

--- a/packages/entity-cache-adapter-redis/src/utils/__tests__/getSurroundingCacheKeyVersionsForInvalidation-test.ts
+++ b/packages/entity-cache-adapter-redis/src/utils/__tests__/getSurroundingCacheKeyVersionsForInvalidation-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { getSurroundingCacheKeyVersionsForInvalidation } from '../getSurroundingCacheKeyVersionsForInvalidation';
+import { getSurroundingCacheKeyVersionsForInvalidation } from '../getSurroundingCacheKeyVersionsForInvalidation.ts';
 
 describe(getSurroundingCacheKeyVersionsForInvalidation, () => {
   it('returns the correct cache key versions to invalidate', () => {

--- a/packages/entity-codemod/package.json
+++ b/packages/entity-codemod/package.json
@@ -19,13 +19,14 @@
     "test": "yarn test:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "devDependencies": {
     "@jest/globals": "30.2.0",
     "@types/jscodeshift": "17.3.0",

--- a/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test1.input.ts
+++ b/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test1.input.ts
@@ -1,6 +1,6 @@
 import { ViewerContext } from '@expo/entity';
-import { UserEntity } from './entities/UserEntity';
-import { PostEntity } from './entities/PostEntity';
+import { PostEntity } from './entities/PostEntity.ts';
+import { UserEntity } from './entities/UserEntity.ts';
 
 async function loadUser(viewerContext: ViewerContext) {
   // Basic loader calls - only transformed when using knex-specific methods

--- a/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test1.output.ts
+++ b/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test1.output.ts
@@ -1,6 +1,6 @@
 import { ViewerContext } from '@expo/entity';
-import { UserEntity } from './entities/UserEntity';
-import { PostEntity } from './entities/PostEntity';
+import { PostEntity } from './entities/PostEntity.ts';
+import { UserEntity } from './entities/UserEntity.ts';
 
 async function loadUser(viewerContext: ViewerContext) {
   // Basic loader calls - only transformed when using knex-specific methods

--- a/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test2.input.ts
+++ b/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test2.input.ts
@@ -1,5 +1,5 @@
 import { ViewerContext } from '@expo/entity';
-import { CommentEntity } from './entities/CommentEntity';
+import { CommentEntity } from './entities/CommentEntity.ts';
 
 // Chained calls
 const loadComments = async (viewerContext: ViewerContext) => {

--- a/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test2.output.ts
+++ b/packages/entity-codemod/src/transforms/__testfixtures__/v0.55.0-v0.56.0/test2.output.ts
@@ -1,5 +1,5 @@
 import { ViewerContext } from '@expo/entity';
-import { CommentEntity } from './entities/CommentEntity';
+import { CommentEntity } from './entities/CommentEntity.ts';
 
 // Chained calls
 const loadComments = async (viewerContext: ViewerContext) => {

--- a/packages/entity-database-adapter-knex-testing-utils/package.json
+++ b/packages/entity-database-adapter-knex-testing-utils/package.json
@@ -19,13 +19,14 @@
     "test": "yarn test:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "@expo/entity-database-adapter-knex": "workspace:^",

--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapterProvider.ts
@@ -4,7 +4,7 @@ import type {
   IEntityDatabaseAdapterProvider,
 } from '@expo/entity';
 
-import { StubPostgresDatabaseAdapter } from './StubPostgresDatabaseAdapter';
+import { StubPostgresDatabaseAdapter } from './StubPostgresDatabaseAdapter.ts';
 
 export class StubPostgresDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
   private readonly objectCollection = new Map();

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -10,15 +10,15 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 import { validate, version } from 'uuid';
 
-import { StubPostgresDatabaseAdapter } from '../StubPostgresDatabaseAdapter';
-import type { DateIDTestFields } from '../__testfixtures__/DateIDTestEntity';
-import { dateIDTestEntityConfiguration } from '../__testfixtures__/DateIDTestEntity';
-import type { SimpleTestFields } from '../__testfixtures__/SimpleTestEntity';
-import { simpleTestEntityConfiguration } from '../__testfixtures__/SimpleTestEntity';
-import type { TestFields } from '../__testfixtures__/TestEntity';
-import { testEntityConfiguration } from '../__testfixtures__/TestEntity';
-import type { NumberKeyFields } from '../__testfixtures__/TestEntityNumberKey';
-import { numberKeyEntityConfiguration } from '../__testfixtures__/TestEntityNumberKey';
+import { StubPostgresDatabaseAdapter } from '../StubPostgresDatabaseAdapter.ts';
+import type { DateIDTestFields } from '../__testfixtures__/DateIDTestEntity.ts';
+import { dateIDTestEntityConfiguration } from '../__testfixtures__/DateIDTestEntity.ts';
+import type { SimpleTestFields } from '../__testfixtures__/SimpleTestEntity.ts';
+import { simpleTestEntityConfiguration } from '../__testfixtures__/SimpleTestEntity.ts';
+import type { TestFields } from '../__testfixtures__/TestEntity.ts';
+import { testEntityConfiguration } from '../__testfixtures__/TestEntity.ts';
+import type { NumberKeyFields } from '../__testfixtures__/TestEntityNumberKey.ts';
+import { numberKeyEntityConfiguration } from '../__testfixtures__/TestEntityNumberKey.ts';
 
 // uuid keeps state internally for v7 generation, so we fix the time for all tests for consistent test results
 const expectedTime = new Date('2024-06-03T20:16:33.761Z');

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/createUnitTestPostgresEntityCompanionProvider-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/createUnitTestPostgresEntityCompanionProvider-test.ts
@@ -1,8 +1,8 @@
 import { EntityCompanionProvider, ViewerContext } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 
-import { TestEntity } from '../__testfixtures__/TestEntity';
-import { createUnitTestPostgresEntityCompanionProvider } from '../createUnitTestPostgresEntityCompanionProvider';
+import { TestEntity } from '../__testfixtures__/TestEntity.ts';
+import { createUnitTestPostgresEntityCompanionProvider } from '../createUnitTestPostgresEntityCompanionProvider.ts';
 
 describe(createUnitTestPostgresEntityCompanionProvider, () => {
   it('creates a new EntityCompanionProvider', async () => {

--- a/packages/entity-database-adapter-knex-testing-utils/src/createUnitTestPostgresEntityCompanionProvider.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/createUnitTestPostgresEntityCompanionProvider.ts
@@ -5,7 +5,7 @@ import {
   StubQueryContextProvider,
 } from '@expo/entity-testing-utils';
 
-import { StubPostgresDatabaseAdapterProvider } from './StubPostgresDatabaseAdapterProvider';
+import { StubPostgresDatabaseAdapterProvider } from './StubPostgresDatabaseAdapterProvider.ts';
 
 const queryContextProvider = new StubQueryContextProvider();
 

--- a/packages/entity-database-adapter-knex/package.json
+++ b/packages/entity-database-adapter-knex/package.json
@@ -20,13 +20,14 @@
     "integration": "yarn integration:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "knex": "^3.1.0"

--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -2,9 +2,9 @@ import type {
   EntityConstructionUtils,
   EntityPrivacyPolicy,
   EntityQueryContext,
+  IEntityMetricsAdapter,
   ReadonlyEntity,
   ViewerContext,
-  IEntityMetricsAdapter,
 } from '@expo/entity';
 import type { Result } from '@expo/results';
 
@@ -12,13 +12,17 @@ import type {
   FieldEqualityCondition,
   NullsOrdering,
   OrderByOrdering,
-} from './BasePostgresEntityDatabaseAdapter';
-import { isSingleValueFieldEqualityCondition } from './BasePostgresEntityDatabaseAdapter';
-import { BaseSQLQueryBuilder } from './BaseSQLQueryBuilder';
-import type { PaginationStrategy } from './PaginationStrategy';
-import type { SQLFragment } from './SQLOperator';
-import type { Connection, PageInfo, EntityKnexDataManager } from './internal/EntityKnexDataManager';
-import type { NonNullableKeys } from './internal/utilityTypes';
+} from './BasePostgresEntityDatabaseAdapter.ts';
+import { isSingleValueFieldEqualityCondition } from './BasePostgresEntityDatabaseAdapter.ts';
+import { BaseSQLQueryBuilder } from './BaseSQLQueryBuilder.ts';
+import type { PaginationStrategy } from './PaginationStrategy.ts';
+import type { SQLFragment } from './SQLOperator.ts';
+import type {
+  Connection,
+  EntityKnexDataManager,
+  PageInfo,
+} from './internal/EntityKnexDataManager.ts';
+import type { NonNullableKeys } from './internal/utilityTypes.ts';
 
 export type EntityLoaderBaseOrderByClause = {
   /**

--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -6,7 +6,7 @@ import {
 } from '@expo/entity';
 import type { Knex } from 'knex';
 
-import type { SQLFragment } from './SQLOperator';
+import type { SQLFragment } from './SQLOperator.ts';
 
 /**
  * Equality operand that is used for selecting entities with a field with a single value.

--- a/packages/entity-database-adapter-knex/src/BaseSQLQueryBuilder.ts
+++ b/packages/entity-database-adapter-knex/src/BaseSQLQueryBuilder.ts
@@ -1,10 +1,10 @@
 import type {
   EntityLoaderOrderByClause,
   EntityLoaderQuerySelectionModifiers,
-} from './AuthorizationResultBasedKnexEntityLoader';
-import type { NullsOrdering } from './BasePostgresEntityDatabaseAdapter';
-import { OrderByOrdering } from './BasePostgresEntityDatabaseAdapter';
-import type { SQLFragment } from './SQLOperator';
+} from './AuthorizationResultBasedKnexEntityLoader.ts';
+import type { NullsOrdering } from './BasePostgresEntityDatabaseAdapter.ts';
+import { OrderByOrdering } from './BasePostgresEntityDatabaseAdapter.ts';
+import type { SQLFragment } from './SQLOperator.ts';
 
 /**
  * Base SQL query builder that provides common functionality for building SQL queries.

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -11,11 +11,11 @@ import type {
   AuthorizationResultBasedKnexEntityLoader,
   EntityLoaderLoadPageArgs,
   EntityLoaderQuerySelectionModifiers,
-} from './AuthorizationResultBasedKnexEntityLoader';
-import type { FieldEqualityCondition } from './BasePostgresEntityDatabaseAdapter';
-import { BaseSQLQueryBuilder } from './BaseSQLQueryBuilder';
-import type { SQLFragment } from './SQLOperator';
-import type { Connection, EntityKnexDataManager } from './internal/EntityKnexDataManager';
+} from './AuthorizationResultBasedKnexEntityLoader.ts';
+import type { FieldEqualityCondition } from './BasePostgresEntityDatabaseAdapter.ts';
+import { BaseSQLQueryBuilder } from './BaseSQLQueryBuilder.ts';
+import type { SQLFragment } from './SQLOperator.ts';
+import type { Connection, EntityKnexDataManager } from './internal/EntityKnexDataManager.ts';
 
 /**
  * Enforcing knex entity loader for non-data-loader-based load methods.

--- a/packages/entity-database-adapter-knex/src/KnexEntityLoaderFactory.ts
+++ b/packages/entity-database-adapter-knex/src/KnexEntityLoaderFactory.ts
@@ -3,15 +3,15 @@ import type {
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationContext,
   EntityQueryContext,
+  IEntityMetricsAdapter,
   ReadonlyEntity,
   ViewerContext,
-  IEntityMetricsAdapter,
 } from '@expo/entity';
 import { EntityConstructionUtils } from '@expo/entity';
 
-import { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader';
-import { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader';
-import type { EntityKnexDataManager } from './internal/EntityKnexDataManager';
+import { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader.ts';
+import { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader.ts';
+import type { EntityKnexDataManager } from './internal/EntityKnexDataManager.ts';
 
 /**
  * The primary entry point for loading entities via knex queries (non-data-loader methods).

--- a/packages/entity-database-adapter-knex/src/PostgresEntity.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntity.ts
@@ -7,12 +7,12 @@ import type {
 } from '@expo/entity';
 import { Entity } from '@expo/entity';
 
-import type { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader';
-import type { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader';
+import type { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader.ts';
+import type { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader.ts';
 import {
   knexLoader as knexLoaderFn,
   knexLoaderWithAuthorizationResults as knexLoaderWithAuthorizationResultsFn,
-} from './knexLoader';
+} from './knexLoader.ts';
 
 /**
  * Abstract base class for mutable entities backed by Postgres.

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -6,16 +6,16 @@ import type {
   TableFieldMultiValueEqualityCondition,
   TableFieldSingleValueEqualityCondition,
   TableQuerySelectionModifiers,
-} from './BasePostgresEntityDatabaseAdapter';
+} from './BasePostgresEntityDatabaseAdapter.ts';
 import {
   BasePostgresEntityDatabaseAdapter,
   NullsOrdering,
   OrderByOrdering,
-} from './BasePostgresEntityDatabaseAdapter';
-import { JSONArrayField, MaybeJSONArrayField } from './EntityFields';
-import type { PostgresEntityDatabaseAdapterConfiguration } from './PostgresEntityDatabaseAdapterProvider';
-import type { SQLFragment } from './SQLOperator';
-import { wrapNativePostgresCallAsync } from './errors/wrapNativePostgresCallAsync';
+} from './BasePostgresEntityDatabaseAdapter.ts';
+import { JSONArrayField, MaybeJSONArrayField } from './EntityFields.ts';
+import type { PostgresEntityDatabaseAdapterConfiguration } from './PostgresEntityDatabaseAdapterProvider.ts';
+import type { SQLFragment } from './SQLOperator.ts';
+import { wrapNativePostgresCallAsync } from './errors/wrapNativePostgresCallAsync.ts';
 
 export class PostgresEntityDatabaseAdapter<
   TFields extends Record<string, any>,

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapterProvider.ts
@@ -4,7 +4,7 @@ import type {
   IEntityDatabaseAdapterProvider,
 } from '@expo/entity';
 
-import { PostgresEntityDatabaseAdapter } from './PostgresEntityDatabaseAdapter';
+import { PostgresEntityDatabaseAdapter } from './PostgresEntityDatabaseAdapter.ts';
 
 export interface PostgresEntityDatabaseAdapterConfiguration {
   /**

--- a/packages/entity-database-adapter-knex/src/ReadonlyPostgresEntity.ts
+++ b/packages/entity-database-adapter-knex/src/ReadonlyPostgresEntity.ts
@@ -6,12 +6,12 @@ import type {
 } from '@expo/entity';
 import { ReadonlyEntity } from '@expo/entity';
 
-import type { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader';
-import type { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader';
+import type { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader.ts';
+import type { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader.ts';
 import {
   knexLoader as knexLoaderFn,
   knexLoaderWithAuthorizationResults as knexLoaderWithAuthorizationResultsFn,
-} from './knexLoader';
+} from './knexLoader.ts';
 
 /**
  * Abstract base class for readonly entities backed by Postgres.

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
@@ -4,8 +4,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/glo
 import type { Knex } from 'knex';
 import knex from 'knex';
 
-import { PostgresUniqueTestEntity } from '../__testfixtures__/PostgresUniqueTestEntity';
-import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';
+import { PostgresUniqueTestEntity } from '../__testfixtures__/PostgresUniqueTestEntity.ts';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts';
 
 describe(createWithUniqueConstraintRecoveryAsync, () => {
   let knexInstance: Knex;

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -11,16 +11,16 @@ import type { Knex } from 'knex';
 import { knex } from 'knex';
 import { setTimeout } from 'timers/promises';
 
-import type { PaginationSpecification } from '../AuthorizationResultBasedKnexEntityLoader';
-import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
-import { PaginationStrategy } from '../PaginationStrategy';
-import type { SQLFragment } from '../SQLOperator';
-import { entityField, sql, SQLFragmentHelpers, unsafeRaw } from '../SQLOperator';
-import type { PostgresTestEntityFields } from '../__testfixtures__/PostgresTestEntity';
-import { PostgresTestEntity } from '../__testfixtures__/PostgresTestEntity';
-import { PostgresTriggerTestEntity } from '../__testfixtures__/PostgresTriggerTestEntity';
-import { PostgresValidatorTestEntity } from '../__testfixtures__/PostgresValidatorTestEntity';
-import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';
+import type { PaginationSpecification } from '../AuthorizationResultBasedKnexEntityLoader.ts';
+import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter.ts';
+import { PaginationStrategy } from '../PaginationStrategy.ts';
+import type { SQLFragment } from '../SQLOperator.ts';
+import { entityField, sql, SQLFragmentHelpers, unsafeRaw } from '../SQLOperator.ts';
+import type { PostgresTestEntityFields } from '../__testfixtures__/PostgresTestEntity.ts';
+import { PostgresTestEntity } from '../__testfixtures__/PostgresTestEntity.ts';
+import { PostgresTriggerTestEntity } from '../__testfixtures__/PostgresTriggerTestEntity.ts';
+import { PostgresValidatorTestEntity } from '../__testfixtures__/PostgresValidatorTestEntity.ts';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts';
 
 describe('postgres entity integration', () => {
   let knexInstance: Knex;

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityQueryContextProvider-test.ts
@@ -4,9 +4,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, test } from '@je
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 
-import { PostgresEntityQueryContextProvider } from '../PostgresEntityQueryContextProvider';
-import { PostgresUniqueTestEntity } from '../__testfixtures__/PostgresUniqueTestEntity';
-import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';
+import { PostgresEntityQueryContextProvider } from '../PostgresEntityQueryContextProvider.ts';
+import { PostgresUniqueTestEntity } from '../__testfixtures__/PostgresUniqueTestEntity.ts';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts';
 
 describe(PostgresEntityQueryContextProvider, () => {
   let knexInstance: Knex;

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresInvalidSetup-test.ts
@@ -5,8 +5,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/glo
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 
-import { InvalidTestEntity } from '../__testfixtures__/InvalidTestEntity';
-import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';
+import { InvalidTestEntity } from '../__testfixtures__/InvalidTestEntity.ts';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts';
 
 describe('postgres entity integration', () => {
   let knexInstance: Knex;

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/errors-test.ts
@@ -13,8 +13,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/glo
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 
-import { ErrorsTestEntity } from '../__testfixtures__/ErrorsTestEntity';
-import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider';
+import { ErrorsTestEntity } from '../__testfixtures__/ErrorsTestEntity.ts';
+import { createKnexIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts';
 
 describe('postgres errors', () => {
   let knexInstance: Knex;

--- a/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__testfixtures__/PostgresTestEntity.ts
@@ -2,6 +2,7 @@ import type { EntityCompanionDefinition, ViewerContext } from '@expo/entity';
 import {
   AlwaysAllowPrivacyPolicyRule,
   BooleanField,
+  BufferField,
   DateField,
   EntityConfiguration,
   EntityPrivacyPolicy,
@@ -9,12 +10,11 @@ import {
   StringArrayField,
   StringField,
   UUIDField,
-  BufferField,
 } from '@expo/entity';
 import type { Knex } from 'knex';
 
-import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
-import { PostgresEntity } from '../PostgresEntity';
+import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields.ts';
+import { PostgresEntity } from '../PostgresEntity.ts';
 
 export type PostgresTestEntityFields = {
   id: string;

--- a/packages/entity-database-adapter-knex/src/__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts
+++ b/packages/entity-database-adapter-knex/src/__testfixtures__/createKnexIntegrationTestEntityCompanionProvider.ts
@@ -3,8 +3,8 @@ import { EntityCompanionProvider, NoOpEntityMetricsAdapter } from '@expo/entity'
 import { InMemoryFullCacheStubCacheAdapterProvider } from '@expo/entity-testing-utils';
 import type { Knex } from 'knex';
 
-import { PostgresEntityDatabaseAdapterProvider } from '../PostgresEntityDatabaseAdapterProvider';
-import { PostgresEntityQueryContextProvider } from '../PostgresEntityQueryContextProvider';
+import { PostgresEntityDatabaseAdapterProvider } from '../PostgresEntityDatabaseAdapterProvider.ts';
+import { PostgresEntityQueryContextProvider } from '../PostgresEntityQueryContextProvider.ts';
 
 export const createKnexIntegrationTestEntityCompanionProvider = (
   knex: Knex,

--- a/packages/entity-database-adapter-knex/src/__tests__/AuthorizationResultBasedKnexEntityLoader-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/AuthorizationResultBasedKnexEntityLoader-test.ts
@@ -1,30 +1,30 @@
 import type {
   EntityPrivacyPolicyEvaluationContext,
-  IEntityMetricsAdapter,
   EntityQueryContext,
+  IEntityMetricsAdapter,
 } from '@expo/entity';
-import { ViewerContext, enforceResultsAsync, EntityConstructionUtils } from '@expo/entity';
+import { enforceResultsAsync, EntityConstructionUtils, ViewerContext } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 import { anyOfClass, anything, instance, mock, spy, verify, when } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader';
-import { OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
-import { PaginationStrategy } from '../PaginationStrategy';
-import { sql } from '../SQLOperator';
-import type { TestFields } from './fixtures/TestEntity';
+import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader.ts';
+import { OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter.ts';
+import { PaginationStrategy } from '../PaginationStrategy.ts';
+import { sql } from '../SQLOperator.ts';
+import { EntityKnexDataManager } from '../internal/EntityKnexDataManager.ts';
+import type { TestFields } from './fixtures/TestEntity.ts';
 import {
   TestEntity,
   testEntityConfiguration,
   TestEntityPrivacyPolicy,
-} from './fixtures/TestEntity';
-import type { TestPaginationFields } from './fixtures/TestPaginationEntity';
+} from './fixtures/TestEntity.ts';
+import type { TestPaginationFields } from './fixtures/TestPaginationEntity.ts';
 import {
   TestPaginationEntity,
   testPaginationEntityConfiguration,
   TestPaginationPrivacyPolicy,
-} from './fixtures/TestPaginationEntity';
-import { EntityKnexDataManager } from '../internal/EntityKnexDataManager';
+} from './fixtures/TestPaginationEntity.ts';
 
 describe(AuthorizationResultBasedKnexEntityLoader, () => {
   it('loads entities with loadManyByFieldEqualityConjunction', async () => {

--- a/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
@@ -6,10 +6,10 @@ import { instance, mock } from 'ts-mockito';
 import type {
   TableFieldMultiValueEqualityCondition,
   TableFieldSingleValueEqualityCondition,
-} from '../BasePostgresEntityDatabaseAdapter';
-import { BasePostgresEntityDatabaseAdapter } from '../BasePostgresEntityDatabaseAdapter';
-import type { TestFields } from './fixtures/TestEntity';
-import { testEntityConfiguration } from './fixtures/TestEntity';
+} from '../BasePostgresEntityDatabaseAdapter.ts';
+import { BasePostgresEntityDatabaseAdapter } from '../BasePostgresEntityDatabaseAdapter.ts';
+import type { TestFields } from './fixtures/TestEntity.ts';
+import { testEntityConfiguration } from './fixtures/TestEntity.ts';
 
 class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
   TestFields,

--- a/packages/entity-database-adapter-knex/src/__tests__/EnforcingKnexEntityLoader-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/EnforcingKnexEntityLoader-test.ts
@@ -7,11 +7,11 @@ import { anything, instance, mock, when } from 'ts-mockito';
 import {
   AuthorizationResultBasedKnexEntityLoader,
   AuthorizationResultBasedSQLQueryBuilder,
-} from '../AuthorizationResultBasedKnexEntityLoader';
-import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader';
-import { PaginationStrategy } from '../PaginationStrategy';
-import { sql } from '../SQLOperator';
-import { EntityKnexDataManager } from '../internal/EntityKnexDataManager';
+} from '../AuthorizationResultBasedKnexEntityLoader.ts';
+import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader.ts';
+import { PaginationStrategy } from '../PaginationStrategy.ts';
+import { sql } from '../SQLOperator.ts';
+import { EntityKnexDataManager } from '../internal/EntityKnexDataManager.ts';
 
 describe(EnforcingKnexEntityLoader, () => {
   describe('loadFirstByFieldEqualityConjunction', () => {

--- a/packages/entity-database-adapter-knex/src/__tests__/EntityFields-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/EntityFields-test.ts
@@ -1,6 +1,6 @@
 import { describeFieldTestCase } from '@expo/entity-testing-utils';
 
-import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields';
+import { BigIntField, JSONArrayField, MaybeJSONArrayField } from '../EntityFields.ts';
 
 describeFieldTestCase(
   new JSONArrayField({ columnName: 'wat' }),

--- a/packages/entity-database-adapter-knex/src/__tests__/PostgresEntity-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/PostgresEntity-test.ts
@@ -9,11 +9,11 @@ import {
 } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 
-import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader';
-import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader';
-import { PostgresEntity } from '../PostgresEntity';
-import { ReadonlyPostgresEntity } from '../ReadonlyPostgresEntity';
-import { createUnitTestPostgresEntityCompanionProvider } from './fixtures/createUnitTestPostgresEntityCompanionProvider';
+import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader.ts';
+import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader.ts';
+import { PostgresEntity } from '../PostgresEntity.ts';
+import { ReadonlyPostgresEntity } from '../ReadonlyPostgresEntity.ts';
+import { createUnitTestPostgresEntityCompanionProvider } from './fixtures/createUnitTestPostgresEntityCompanionProvider.ts';
 
 type TestPostgresFields = {
   id: string;

--- a/packages/entity-database-adapter-knex/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/ReadonlyEntity-test.ts
@@ -1,11 +1,11 @@
 import { ViewerContext } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 
-import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader';
-import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader';
-import { knexLoader, knexLoaderWithAuthorizationResults } from '../knexLoader';
-import { TestEntity } from './fixtures/TestEntity';
-import { createUnitTestPostgresEntityCompanionProvider } from './fixtures/createUnitTestPostgresEntityCompanionProvider';
+import { AuthorizationResultBasedKnexEntityLoader } from '../AuthorizationResultBasedKnexEntityLoader.ts';
+import { EnforcingKnexEntityLoader } from '../EnforcingKnexEntityLoader.ts';
+import { knexLoader, knexLoaderWithAuthorizationResults } from '../knexLoader.ts';
+import { TestEntity } from './fixtures/TestEntity.ts';
+import { createUnitTestPostgresEntityCompanionProvider } from './fixtures/createUnitTestPostgresEntityCompanionProvider.ts';
 
 describe('knexLoader', () => {
   describe('knexLoader', () => {

--- a/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/SQLOperator-test.ts
@@ -4,18 +4,18 @@ import { describe, expect, it } from '@jest/globals';
 import {
   arrayValue,
   entityField,
+  expression,
   identifier,
-  unsafeRaw,
   sql,
   SQLEntityField,
   SQLExpression,
   SQLFragment,
   SQLFragmentHelpers,
   SQLIdentifier,
-  expression,
-} from '../SQLOperator';
-import type { TestFields } from './fixtures/TestEntity';
-import { testEntityConfiguration } from './fixtures/TestEntity';
+  unsafeRaw,
+} from '../SQLOperator.ts';
+import type { TestFields } from './fixtures/TestEntity.ts';
+import { testEntityConfiguration } from './fixtures/TestEntity.ts';
 
 const getColumnForField = (fieldName: string): string =>
   getDatabaseFieldForEntityField(testEntityConfiguration, fieldName as keyof TestFields);

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -15,13 +15,13 @@ import type {
   TableFieldSingleValueEqualityCondition,
   TableOrderByClause,
   TableQuerySelectionModifiers,
-} from '../../BasePostgresEntityDatabaseAdapter';
+} from '../../BasePostgresEntityDatabaseAdapter.ts';
 import {
   BasePostgresEntityDatabaseAdapter,
   NullsOrdering,
   OrderByOrdering,
-} from '../../BasePostgresEntityDatabaseAdapter';
-import type { SQLFragment } from '../../SQLOperator';
+} from '../../BasePostgresEntityDatabaseAdapter.ts';
+import type { SQLFragment } from '../../SQLOperator.ts';
 
 export class StubPostgresDatabaseAdapter<
   TFields extends Record<string, any>,

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapterProvider.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapterProvider.ts
@@ -4,7 +4,7 @@ import type {
   IEntityDatabaseAdapterProvider,
 } from '@expo/entity';
 
-import { StubPostgresDatabaseAdapter } from './StubPostgresDatabaseAdapter';
+import { StubPostgresDatabaseAdapter } from './StubPostgresDatabaseAdapter.ts';
 
 export class StubPostgresDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
   private readonly objectCollection = new Map();

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/TestEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/TestEntity.ts
@@ -1,17 +1,17 @@
 import type { EntityCompanionDefinition, ViewerContext } from '@expo/entity';
 import {
-  EntityConfiguration,
+  AlwaysAllowPrivacyPolicyRule,
   DateField,
+  EntityConfiguration,
+  EntityPrivacyPolicy,
   IntField,
   StringField,
   UUIDField,
-  EntityPrivacyPolicy,
-  AlwaysAllowPrivacyPolicyRule,
 } from '@expo/entity';
 import type { Result } from '@expo/results';
 import { result } from '@expo/results';
 
-import { PostgresEntity } from '../../PostgresEntity';
+import { PostgresEntity } from '../../PostgresEntity.ts';
 
 export type TestFields = {
   customIdField: string;

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/TestPaginationEntity.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/TestPaginationEntity.ts
@@ -1,20 +1,20 @@
 import type {
   EntityCompanionDefinition,
-  ViewerContext,
   EntityPrivacyPolicyEvaluationContext,
   EntityQueryContext,
+  ViewerContext,
 } from '@expo/entity';
 import {
+  DateField,
   EntityConfiguration,
   EntityPrivacyPolicy,
-  UUIDField,
-  StringField,
-  DateField,
   IntField,
   RuleEvaluationResult,
+  StringField,
+  UUIDField,
 } from '@expo/entity';
 
-import { PostgresEntity } from '../../PostgresEntity';
+import { PostgresEntity } from '../../PostgresEntity.ts';
 
 export interface TestPaginationFields {
   id: string;

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/createUnitTestPostgresEntityCompanionProvider.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/createUnitTestPostgresEntityCompanionProvider.ts
@@ -5,7 +5,7 @@ import {
   StubQueryContextProvider,
 } from '@expo/entity-testing-utils';
 
-import { StubPostgresDatabaseAdapterProvider } from './StubPostgresDatabaseAdapterProvider';
+import { StubPostgresDatabaseAdapterProvider } from './StubPostgresDatabaseAdapterProvider.ts';
 
 const queryContextProvider = new StubQueryContextProvider();
 

--- a/packages/entity-database-adapter-knex/src/errors/__tests__/wrapNativePostgresCallAsync-test.ts
+++ b/packages/entity-database-adapter-knex/src/errors/__tests__/wrapNativePostgresCallAsync-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { wrapNativePostgresCallAsync } from '../wrapNativePostgresCallAsync';
+import { wrapNativePostgresCallAsync } from '../wrapNativePostgresCallAsync.ts';
 
 describe(wrapNativePostgresCallAsync, () => {
   it('rethrows literals', async () => {

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -1,9 +1,9 @@
-import type { EntityQueryContext, IEntityMetricsAdapter, EntityConfiguration } from '@expo/entity';
+import type { EntityConfiguration, EntityQueryContext, IEntityMetricsAdapter } from '@expo/entity';
 import {
-  timeAndLogLoadEventAsync,
+  EntityDatabaseAdapterPaginationCursorInvalidError,
   EntityMetricsLoadType,
   getDatabaseFieldForEntityField,
-  EntityDatabaseAdapterPaginationCursorInvalidError,
+  timeAndLogLoadEventAsync,
 } from '@expo/entity';
 import assert from 'assert';
 
@@ -12,11 +12,11 @@ import type {
   FieldEqualityCondition,
   PostgresOrderByClause,
   PostgresQuerySelectionModifiers,
-} from '../BasePostgresEntityDatabaseAdapter';
-import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter';
-import { PaginationStrategy } from '../PaginationStrategy';
-import { SQLFragment, SQLFragmentHelpers, identifier, unsafeRaw, sql } from '../SQLOperator';
-import type { DistributiveOmit, NonNullableKeys } from './utilityTypes';
+} from '../BasePostgresEntityDatabaseAdapter.ts';
+import { NullsOrdering, OrderByOrdering } from '../BasePostgresEntityDatabaseAdapter.ts';
+import { PaginationStrategy } from '../PaginationStrategy.ts';
+import { SQLFragment, SQLFragmentHelpers, identifier, sql, unsafeRaw } from '../SQLOperator.ts';
+import type { DistributiveOmit, NonNullableKeys } from './utilityTypes.ts';
 
 interface DataManagerStandardSpecification<TFields extends Record<string, any>> {
   strategy: PaginationStrategy.STANDARD;

--- a/packages/entity-database-adapter-knex/src/internal/__tests__/EntityKnexDataManager-test.ts
+++ b/packages/entity-database-adapter-knex/src/internal/__tests__/EntityKnexDataManager-test.ts
@@ -14,12 +14,12 @@ import {
   when,
 } from 'ts-mockito';
 
-import { OrderByOrdering } from '../../BasePostgresEntityDatabaseAdapter';
-import { PaginationStrategy } from '../../PaginationStrategy';
-import { PostgresEntityDatabaseAdapter } from '../../PostgresEntityDatabaseAdapter';
-import type { TestFields } from '../../__tests__/fixtures/TestEntity';
-import { TestEntity, testEntityConfiguration } from '../../__tests__/fixtures/TestEntity';
-import { EntityKnexDataManager } from '../EntityKnexDataManager';
+import { OrderByOrdering } from '../../BasePostgresEntityDatabaseAdapter.ts';
+import { PaginationStrategy } from '../../PaginationStrategy.ts';
+import { PostgresEntityDatabaseAdapter } from '../../PostgresEntityDatabaseAdapter.ts';
+import type { TestFields } from '../../__tests__/fixtures/TestEntity.ts';
+import { TestEntity, testEntityConfiguration } from '../../__tests__/fixtures/TestEntity.ts';
+import { EntityKnexDataManager } from '../EntityKnexDataManager.ts';
 
 describe(EntityKnexDataManager, () => {
   it('loads by field equality conjunction and does not cache', async () => {

--- a/packages/entity-database-adapter-knex/src/internal/__tests__/weakMaps-test.ts
+++ b/packages/entity-database-adapter-knex/src/internal/__tests__/weakMaps-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { computeIfAbsentInWeakMap } from '../weakMaps';
+import { computeIfAbsentInWeakMap } from '../weakMaps.ts';
 
 describe(computeIfAbsentInWeakMap, () => {
   it('computes a value when absent', () => {

--- a/packages/entity-database-adapter-knex/src/internal/getKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/getKnexDataManager.ts
@@ -1,9 +1,9 @@
 import type { EntityDatabaseAdapter, EntityTableDataCoordinator } from '@expo/entity';
 import assert from 'assert';
 
-import { BasePostgresEntityDatabaseAdapter } from '../BasePostgresEntityDatabaseAdapter';
-import { EntityKnexDataManager } from './EntityKnexDataManager';
-import { computeIfAbsentInWeakMap } from './weakMaps';
+import { BasePostgresEntityDatabaseAdapter } from '../BasePostgresEntityDatabaseAdapter.ts';
+import { EntityKnexDataManager } from './EntityKnexDataManager.ts';
+import { computeIfAbsentInWeakMap } from './weakMaps.ts';
 
 const knexDataManagerCache = new WeakMap<
   EntityTableDataCoordinator<any, any>,

--- a/packages/entity-database-adapter-knex/src/internal/getKnexEntityLoaderFactory.ts
+++ b/packages/entity-database-adapter-knex/src/internal/getKnexEntityLoaderFactory.ts
@@ -6,9 +6,9 @@ import type {
   ViewerContext,
 } from '@expo/entity';
 
-import { KnexEntityLoaderFactory } from '../KnexEntityLoaderFactory';
-import { getKnexDataManager } from './getKnexDataManager';
-import { computeIfAbsentInWeakMap } from './weakMaps';
+import { KnexEntityLoaderFactory } from '../KnexEntityLoaderFactory.ts';
+import { getKnexDataManager } from './getKnexDataManager.ts';
+import { computeIfAbsentInWeakMap } from './weakMaps.ts';
 
 const knexEntityLoaderFactoryCache = new WeakMap<
   EntityCompanion<any, any, any, any, any, any>,

--- a/packages/entity-database-adapter-knex/src/knexLoader.ts
+++ b/packages/entity-database-adapter-knex/src/knexLoader.ts
@@ -6,9 +6,9 @@ import type {
   ViewerContext,
 } from '@expo/entity';
 
-import type { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader';
-import type { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader';
-import { getKnexEntityLoaderFactory } from './internal/getKnexEntityLoaderFactory';
+import type { AuthorizationResultBasedKnexEntityLoader } from './AuthorizationResultBasedKnexEntityLoader.ts';
+import type { EnforcingKnexEntityLoader } from './EnforcingKnexEntityLoader.ts';
+import { getKnexEntityLoaderFactory } from './internal/getKnexEntityLoaderFactory.ts';
 
 /**
  * Vend knex loader for loading entities via non-data-loader methods in a given query context.

--- a/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
+++ b/packages/entity-example/src/entities/AllowIfUserOwnerPrivacyRule.ts
@@ -1,9 +1,9 @@
-import { PrivacyPolicyRule, RuleEvaluationResult } from '@expo/entity';
 import type {
   EntityQueryContext,
   ReadonlyEntity,
   EntityPrivacyPolicyEvaluationContext,
 } from '@expo/entity';
+import { PrivacyPolicyRule, RuleEvaluationResult } from '@expo/entity';
 
 import type { ExampleViewerContext } from '../viewerContexts.ts';
 

--- a/packages/entity-full-integration-tests/package.json
+++ b/packages/entity-full-integration-tests/package.json
@@ -11,13 +11,14 @@
     "integration": "yarn integration:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "@expo/entity-cache-adapter-redis": "workspace:^",

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -12,12 +12,12 @@ import type { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis'
 import { RedisCacheInvalidationStrategy } from '@expo/entity-cache-adapter-redis';
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 import { URL } from 'url';
 
-import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
+import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider.ts';
 
 interface TestFields {
   id: string;

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -12,12 +12,12 @@ import type { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis'
 import { RedisCacheInvalidationStrategy } from '@expo/entity-cache-adapter-redis';
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 import { URL } from 'url';
 
-import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
+import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider.ts';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function createTestEntityDefinitonWithCacheKeyVersion(cacheKeyVersion: number) {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -3,14 +3,14 @@ import type { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis'
 import { RedisCacheInvalidationStrategy } from '@expo/entity-cache-adapter-redis';
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 import { URL } from 'url';
 
-import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
-import ChildEntity from './entities/ChildEntity';
-import ParentEntity from './entities/ParentEntity';
+import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider.ts';
+import ChildEntity from './entities/ChildEntity.ts';
+import ParentEntity from './entities/ParentEntity.ts';
 
 async function createOrTruncatePostgresTablesAsync(knex: Knex): Promise<void> {
   await knex.schema.createTable('parents', (table) => {

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -11,13 +11,13 @@ import type { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis'
 import { RedisCacheInvalidationStrategy } from '@expo/entity-cache-adapter-redis';
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
-import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
+import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider.ts';
 
 interface TestFields {
   id: string;

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -12,13 +12,13 @@ import type { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis'
 import { RedisCacheInvalidationStrategy } from '@expo/entity-cache-adapter-redis';
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import type { Knex } from 'knex';
 import { knex } from 'knex';
 import { URL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 
-import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider';
+import { createFullIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createFullIntegrationTestEntityCompanionProvider.ts';
 
 interface CategoryFields {
   id: string;

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ChildEntity.ts
@@ -8,7 +8,7 @@ import {
   UUIDField,
 } from '@expo/entity';
 
-import ParentEntity from './ParentEntity';
+import ParentEntity from './ParentEntity.ts';
 
 interface ChildFields {
   id: string;

--- a/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/entities/ParentEntity.ts
@@ -7,7 +7,7 @@ import {
   UUIDField,
 } from '@expo/entity';
 
-import ChildEntity from './ChildEntity';
+import ChildEntity from './ChildEntity.ts';
 
 interface ParentFields {
   id: string;

--- a/packages/entity-ip-address-field/package.json
+++ b/packages/entity-ip-address-field/package.json
@@ -19,13 +19,14 @@
     "test": "yarn test:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "ip-address": "^10.1.0"

--- a/packages/entity-ip-address-field/src/__tests__/EntityFields-test.ts
+++ b/packages/entity-ip-address-field/src/__tests__/EntityFields-test.ts
@@ -1,6 +1,6 @@
 import { describeFieldTestCase } from '@expo/entity-testing-utils';
 
-import { IPAddressField } from '../EntityFields';
+import { IPAddressField } from '../EntityFields.ts';
 
 describeFieldTestCase(
   new IPAddressField({ columnName: 'wat' }),

--- a/packages/entity-secondary-cache-local-memory/package.json
+++ b/packages/entity-secondary-cache-local-memory/package.json
@@ -20,13 +20,14 @@
     "integration": "yarn integration:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "@expo/entity-cache-adapter-local-memory": "workspace:^"

--- a/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
+++ b/packages/entity-secondary-cache-local-memory/src/__tests__/LocalMemorySecondaryEntityCache-test.ts
@@ -27,7 +27,7 @@ import nullthrows from '@expo/nullthrows';
 import { TTLCache } from '@isaacs/ttlcache';
 import { describe, expect, it } from '@jest/globals';
 
-import { LocalMemorySecondaryEntityCache } from '../LocalMemorySecondaryEntityCache';
+import { LocalMemorySecondaryEntityCache } from '../LocalMemorySecondaryEntityCache.ts';
 
 export type LocalMemoryTestEntityFields = {
   id: string;

--- a/packages/entity-secondary-cache-redis/package.json
+++ b/packages/entity-secondary-cache-redis/package.json
@@ -19,13 +19,14 @@
     "integration": "yarn integration:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "@expo/entity-cache-adapter-redis": "workspace:^"

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -4,16 +4,19 @@ import type { GenericRedisCacheContext } from '@expo/entity-cache-adapter-redis'
 import { RedisCacheInvalidationStrategy } from '@expo/entity-cache-adapter-redis';
 import nullthrows from '@expo/nullthrows';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { URL } from 'url';
 
-import { RedisSecondaryEntityCache } from '../RedisSecondaryEntityCache';
+import { RedisSecondaryEntityCache } from '../RedisSecondaryEntityCache.ts';
 import type {
   RedisTestEntityFields,
   RedisTestEntityPrivacyPolicy,
-} from '../__testfixtures__/RedisTestEntity';
-import { RedisTestEntity, redisTestEntityConfiguration } from '../__testfixtures__/RedisTestEntity';
-import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider';
+} from '../__testfixtures__/RedisTestEntity.ts';
+import {
+  RedisTestEntity,
+  redisTestEntityConfiguration,
+} from '../__testfixtures__/RedisTestEntity.ts';
+import { createRedisIntegrationTestEntityCompanionProvider } from '../__testfixtures__/createRedisIntegrationTestEntityCompanionProvider.ts';
 
 class TestViewerContext extends ViewerContext {}
 

--- a/packages/entity-testing-utils/package.json
+++ b/packages/entity-testing-utils/package.json
@@ -19,13 +19,14 @@
     "test": "yarn test:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
     "lodash": "^4.17.21",

--- a/packages/entity-testing-utils/src/StubDatabaseAdapterProvider.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapterProvider.ts
@@ -4,7 +4,7 @@ import type {
   IEntityDatabaseAdapterProvider,
 } from '@expo/entity';
 
-import { StubDatabaseAdapter } from './StubDatabaseAdapter';
+import { StubDatabaseAdapter } from './StubDatabaseAdapter.ts';
 
 export class StubDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
   private readonly objectCollection = new Map();

--- a/packages/entity-testing-utils/src/TSMockitoExtensions.ts
+++ b/packages/entity-testing-utils/src/TSMockitoExtensions.ts
@@ -5,8 +5,8 @@ import {
   SingleFieldHolder,
   SingleFieldValueHolder,
 } from '@expo/entity';
-import isEqualWith from 'lodash/isEqualWith';
-import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
+import { isEqualWith } from 'lodash';
+import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher.js';
 
 export function isEqualWithEntityAware(expected: any, actual: any): boolean {
   return isEqualWith(expected, actual, (expected: any, actual: any): boolean | undefined => {

--- a/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/PrivacyPolicyRuleTestUtils-test.ts
@@ -1,14 +1,14 @@
 import type { EntityPrivacyPolicyRuleEvaluationContext } from '@expo/entity';
 import {
-  EntityQueryContext,
-  ViewerContext,
   AlwaysAllowPrivacyPolicyRule,
   AlwaysDenyPrivacyPolicyRule,
+  EntityQueryContext,
+  ViewerContext,
 } from '@expo/entity';
 import { describe } from '@jest/globals';
 import { anything, instance, mock } from 'ts-mockito';
 
-import { describePrivacyPolicyRuleWithAsyncTestCase } from '../PrivacyPolicyRuleTestUtils';
+import { describePrivacyPolicyRuleWithAsyncTestCase } from '../PrivacyPolicyRuleTestUtils.ts';
 
 describe(describePrivacyPolicyRuleWithAsyncTestCase, () => {
   describe('default args do not execute', () => {

--- a/packages/entity-testing-utils/src/__tests__/StubCacheAdapter-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/StubCacheAdapter-test.ts
@@ -1,21 +1,21 @@
 import {
+  CacheStatus,
   CompositeFieldHolder,
   CompositeFieldValueHolder,
   CompositeFieldValueHolderMap,
   SingleFieldHolder,
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
-  CacheStatus,
 } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
 
 import {
-  InMemoryFullCacheStubCacheAdapterProvider,
   InMemoryFullCacheStubCacheAdapter,
+  InMemoryFullCacheStubCacheAdapterProvider,
   NoCacheStubCacheAdapter,
-} from '../StubCacheAdapter';
-import type { TestFields } from '../__testfixtures__/TestEntity';
-import { testEntityConfiguration } from '../__testfixtures__/TestEntity';
+} from '../StubCacheAdapter.ts';
+import type { TestFields } from '../__testfixtures__/TestEntity.ts';
+import { testEntityConfiguration } from '../__testfixtures__/TestEntity.ts';
 
 describe(NoCacheStubCacheAdapter, () => {
   describe('loadManyAsync', () => {

--- a/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
@@ -9,15 +9,15 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 import { validate, version } from 'uuid';
 
-import { StubDatabaseAdapter } from '../StubDatabaseAdapter';
-import type { DateIDTestFields } from '../__testfixtures__/DateIDTestEntity';
-import { dateIDTestEntityConfiguration } from '../__testfixtures__/DateIDTestEntity';
-import type { SimpleTestFields } from '../__testfixtures__/SimpleTestEntity';
-import { simpleTestEntityConfiguration } from '../__testfixtures__/SimpleTestEntity';
-import type { TestFields } from '../__testfixtures__/TestEntity';
-import { testEntityConfiguration } from '../__testfixtures__/TestEntity';
-import type { NumberKeyFields } from '../__testfixtures__/TestEntityNumberKey';
-import { numberKeyEntityConfiguration } from '../__testfixtures__/TestEntityNumberKey';
+import { StubDatabaseAdapter } from '../StubDatabaseAdapter.ts';
+import type { DateIDTestFields } from '../__testfixtures__/DateIDTestEntity.ts';
+import { dateIDTestEntityConfiguration } from '../__testfixtures__/DateIDTestEntity.ts';
+import type { SimpleTestFields } from '../__testfixtures__/SimpleTestEntity.ts';
+import { simpleTestEntityConfiguration } from '../__testfixtures__/SimpleTestEntity.ts';
+import type { TestFields } from '../__testfixtures__/TestEntity.ts';
+import { testEntityConfiguration } from '../__testfixtures__/TestEntity.ts';
+import type { NumberKeyFields } from '../__testfixtures__/TestEntityNumberKey.ts';
+import { numberKeyEntityConfiguration } from '../__testfixtures__/TestEntityNumberKey.ts';
 
 // uuid keeps state internally for v7 generation, so we fix the time for all tests for consistent test results
 const expectedTime = new Date('2024-06-03T20:16:33.761Z');

--- a/packages/entity-testing-utils/src/__tests__/TSMockitoExtensions-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/TSMockitoExtensions-test.ts
@@ -5,7 +5,7 @@ import {
   deepEqualEntityAware,
   DeepEqualEntityAwareMatcher,
   isEqualWithEntityAware,
-} from '../TSMockitoExtensions';
+} from '../TSMockitoExtensions.ts';
 
 describe(deepEqualEntityAware, () => {
   it('should return a DeepEqualEntityAwareMatcher', () => {

--- a/packages/entity-testing-utils/src/createUnitTestEntityCompanionProvider.ts
+++ b/packages/entity-testing-utils/src/createUnitTestEntityCompanionProvider.ts
@@ -1,9 +1,9 @@
 import type { IEntityMetricsAdapter } from '@expo/entity';
 import { EntityCompanionProvider, NoOpEntityMetricsAdapter } from '@expo/entity';
 
-import { InMemoryFullCacheStubCacheAdapterProvider } from './StubCacheAdapter';
-import { StubDatabaseAdapterProvider } from './StubDatabaseAdapterProvider';
-import { StubQueryContextProvider } from './StubQueryContextProvider';
+import { InMemoryFullCacheStubCacheAdapterProvider } from './StubCacheAdapter.ts';
+import { StubDatabaseAdapterProvider } from './StubDatabaseAdapterProvider.ts';
+import { StubQueryContextProvider } from './StubQueryContextProvider.ts';
 
 const queryContextProvider = new StubQueryContextProvider();
 

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -19,13 +19,14 @@
     "test": "yarn test:all --rootDir $(pwd)"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "entity"
   ],
   "author": "Expo",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@expo/results": "^1.0.0",
     "dataloader": "^2.2.3",

--- a/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
@@ -1,11 +1,11 @@
 import type { Result } from '@expo/results';
 import { result } from '@expo/results';
 
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * An association loader is a set of convenience methods for loading entities

--- a/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityLoader.ts
@@ -3,25 +3,25 @@ import type { Result } from '@expo/results';
 import { result } from '@expo/results';
 import invariant from 'invariant';
 
-import type { IEntityClass } from './Entity';
+import type { IEntityClass } from './Entity.ts';
 import type {
   EntityCompositeField,
   EntityCompositeFieldValue,
   EntityConfiguration,
-} from './EntityConfiguration';
-import type { EntityConstructionUtils } from './EntityConstructionUtils';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { EntityNotFoundError } from './errors/EntityNotFoundError';
-import type { CompositeFieldHolder } from './internal/CompositeFieldHolder';
-import { CompositeFieldValueHolder } from './internal/CompositeFieldHolder';
-import { CompositeFieldValueMap } from './internal/CompositeFieldValueMap';
-import type { EntityDataManager } from './internal/EntityDataManager';
-import { SingleFieldHolder, SingleFieldValueHolder } from './internal/SingleFieldHolder';
-import { mapKeys, mapMap } from './utils/collections/maps';
-import { areSetsEqual } from './utils/collections/sets';
+} from './EntityConfiguration.ts';
+import type { EntityConstructionUtils } from './EntityConstructionUtils.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { EntityNotFoundError } from './errors/EntityNotFoundError.ts';
+import type { CompositeFieldHolder } from './internal/CompositeFieldHolder.ts';
+import { CompositeFieldValueHolder } from './internal/CompositeFieldHolder.ts';
+import { CompositeFieldValueMap } from './internal/CompositeFieldValueMap.ts';
+import type { EntityDataManager } from './internal/EntityDataManager.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from './internal/SingleFieldHolder.ts';
+import { mapKeys, mapMap } from './utils/collections/maps.ts';
+import { areSetsEqual } from './utils/collections/sets.ts';
 
 /**
  * Authorization-result-based entity loader. All normal loads are batched,

--- a/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
@@ -2,36 +2,36 @@ import type { Result } from '@expo/results';
 import { asyncResult, enforceAsyncResult, result } from '@expo/results';
 import invariant from 'invariant';
 
-import type { Entity, IEntityClass } from './Entity';
-import type { EntityCompanionProvider } from './EntityCompanionProvider';
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { EntityDatabaseAdapter } from './EntityDatabaseAdapter';
-import { EntityEdgeDeletionBehavior } from './EntityFieldDefinition';
-import type { EntityLoaderFactory } from './EntityLoaderFactory';
+import type { Entity, IEntityClass } from './Entity.ts';
+import type { EntityCompanionProvider } from './EntityCompanionProvider.ts';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { EntityDatabaseAdapter } from './EntityDatabaseAdapter.ts';
+import { EntityEdgeDeletionBehavior } from './EntityFieldDefinition.ts';
+import type { EntityLoaderFactory } from './EntityLoaderFactory.ts';
 import type {
   EntityCascadingDeletionInfo,
   EntityTriggerMutationInfo,
   EntityValidatorMutationInfo,
-} from './EntityMutationInfo';
-import { EntityMutationType } from './EntityMutationInfo';
+} from './EntityMutationInfo.ts';
+import { EntityMutationType } from './EntityMutationInfo.ts';
 import type {
   EntityMutationTrigger,
   EntityMutationTriggerConfiguration,
   EntityNonTransactionalMutationTrigger,
-} from './EntityMutationTriggerConfiguration';
+} from './EntityMutationTriggerConfiguration.ts';
 import type {
   EntityMutationValidator,
   EntityMutationValidatorConfiguration,
-} from './EntityMutationValidatorConfiguration';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext';
-import type { ViewerContext } from './ViewerContext';
-import { enforceResultsAsync } from './entityUtils';
-import { EntityInvalidFieldValueError } from './errors/EntityInvalidFieldValueError';
-import { timeAndLogMutationEventAsync } from './metrics/EntityMetricsUtils';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
-import { EntityMetricsMutationType } from './metrics/IEntityMetricsAdapter';
-import { mapMapAsync } from './utils/collections/maps';
+} from './EntityMutationValidatorConfiguration.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext, EntityTransactionalQueryContext } from './EntityQueryContext.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { enforceResultsAsync } from './entityUtils.ts';
+import { EntityInvalidFieldValueError } from './errors/EntityInvalidFieldValueError.ts';
+import { timeAndLogMutationEventAsync } from './metrics/EntityMetricsUtils.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
+import { EntityMetricsMutationType } from './metrics/IEntityMetricsAdapter.ts';
+import { mapMapAsync } from './utils/collections/maps.ts';
 
 /**
  * Base class for entity mutators. Mutators are builder-like class instances that are

--- a/packages/entity/src/ComposedEntityCacheAdapter.ts
+++ b/packages/entity/src/ComposedEntityCacheAdapter.ts
@@ -1,9 +1,9 @@
 import nullthrows from '@expo/nullthrows';
 
-import type { IEntityCacheAdapter } from './IEntityCacheAdapter';
-import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from './internal/ReadThroughEntityCache';
-import { CacheStatus } from './internal/ReadThroughEntityCache';
+import type { IEntityCacheAdapter } from './IEntityCacheAdapter.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from './internal/ReadThroughEntityCache.ts';
+import { CacheStatus } from './internal/ReadThroughEntityCache.ts';
 
 /**
  * A IEntityCacheAdapter that composes other IEntityCacheAdapter instances.

--- a/packages/entity/src/ComposedSecondaryEntityCache.ts
+++ b/packages/entity/src/ComposedSecondaryEntityCache.ts
@@ -1,6 +1,6 @@
 import nullthrows from '@expo/nullthrows';
 
-import type { ISecondaryEntityCache } from './EntitySecondaryCacheLoader';
+import type { ISecondaryEntityCache } from './EntitySecondaryCacheLoader.ts';
 
 /**
  * A ISecondaryEntityCache that composes other ISecondaryEntityCache instances.

--- a/packages/entity/src/EnforcingEntityAssociationLoader.ts
+++ b/packages/entity/src/EnforcingEntityAssociationLoader.ts
@@ -3,12 +3,12 @@ import { enforceAsyncResult } from '@expo/results';
 import type {
   AuthorizationResultBasedEntityAssociationLoader,
   EntityLoadThroughDirective,
-} from './AuthorizationResultBasedEntityAssociationLoader';
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { enforceResultsAsync } from './entityUtils';
+} from './AuthorizationResultBasedEntityAssociationLoader.ts';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { enforceResultsAsync } from './entityUtils.ts';
 
 /**
  * An association loader is a set of convenience methods for loading entities

--- a/packages/entity/src/EnforcingEntityCreator.ts
+++ b/packages/entity/src/EnforcingEntityCreator.ts
@@ -1,9 +1,9 @@
 import { enforceAsyncResult } from '@expo/results';
 
-import type { AuthorizationResultBasedCreateMutator } from './AuthorizationResultBasedEntityMutator';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedCreateMutator } from './AuthorizationResultBasedEntityMutator.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Enforcing entity creator. All creates

--- a/packages/entity/src/EnforcingEntityDeleter.ts
+++ b/packages/entity/src/EnforcingEntityDeleter.ts
@@ -1,9 +1,9 @@
 import { enforceAsyncResult } from '@expo/results';
 
-import type { AuthorizationResultBasedDeleteMutator } from './AuthorizationResultBasedEntityMutator';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedDeleteMutator } from './AuthorizationResultBasedEntityMutator.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Enforcing entity deleter. All deletes

--- a/packages/entity/src/EnforcingEntityLoader.ts
+++ b/packages/entity/src/EnforcingEntityLoader.ts
@@ -1,11 +1,11 @@
-import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
-import type { EntityCompositeField, EntityCompositeFieldValue } from './EntityConfiguration';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { CompositeFieldValueHolder } from './internal/CompositeFieldHolder';
-import { CompositeFieldValueMap } from './internal/CompositeFieldValueMap';
-import { mapMap } from './utils/collections/maps';
+import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader.ts';
+import type { EntityCompositeField, EntityCompositeFieldValue } from './EntityConfiguration.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { CompositeFieldValueHolder } from './internal/CompositeFieldHolder.ts';
+import { CompositeFieldValueMap } from './internal/CompositeFieldValueMap.ts';
+import { mapMap } from './utils/collections/maps.ts';
 
 /**
  * Enforcing entity loader. All normal loads are batched,

--- a/packages/entity/src/EnforcingEntityUpdater.ts
+++ b/packages/entity/src/EnforcingEntityUpdater.ts
@@ -1,9 +1,9 @@
 import { enforceAsyncResult } from '@expo/results';
 
-import type { AuthorizationResultBasedUpdateMutator } from './AuthorizationResultBasedEntityMutator';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedUpdateMutator } from './AuthorizationResultBasedEntityMutator.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Enforcing entity updater. All updates

--- a/packages/entity/src/Entity.ts
+++ b/packages/entity/src/Entity.ts
@@ -2,18 +2,18 @@ import type {
   AuthorizationResultBasedCreateMutator,
   AuthorizationResultBasedDeleteMutator,
   AuthorizationResultBasedUpdateMutator,
-} from './AuthorizationResultBasedEntityMutator';
-import type { EnforcingEntityCreator } from './EnforcingEntityCreator';
-import type { EnforcingEntityDeleter } from './EnforcingEntityDeleter';
-import type { EnforcingEntityUpdater } from './EnforcingEntityUpdater';
-import type { EntityCompanionDefinition } from './EntityCompanionProvider';
-import { EntityCreator } from './EntityCreator';
-import { EntityDeleter } from './EntityDeleter';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import { EntityUpdater } from './EntityUpdater';
-import { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+} from './AuthorizationResultBasedEntityMutator.ts';
+import type { EnforcingEntityCreator } from './EnforcingEntityCreator.ts';
+import type { EnforcingEntityDeleter } from './EnforcingEntityDeleter.ts';
+import type { EnforcingEntityUpdater } from './EnforcingEntityUpdater.ts';
+import type { EntityCompanionDefinition } from './EntityCompanionProvider.ts';
+import { EntityCreator } from './EntityCreator.ts';
+import { EntityDeleter } from './EntityDeleter.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import { EntityUpdater } from './EntityUpdater.ts';
+import { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Entity is a privacy-first data model.

--- a/packages/entity/src/EntityAssociationLoader.ts
+++ b/packages/entity/src/EntityAssociationLoader.ts
@@ -1,9 +1,9 @@
-import { AuthorizationResultBasedEntityAssociationLoader } from './AuthorizationResultBasedEntityAssociationLoader';
-import { EnforcingEntityAssociationLoader } from './EnforcingEntityAssociationLoader';
-import type { IEntityClass } from './Entity';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import { AuthorizationResultBasedEntityAssociationLoader } from './AuthorizationResultBasedEntityAssociationLoader.ts';
+import { EnforcingEntityAssociationLoader } from './EnforcingEntityAssociationLoader.ts';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * An association loader is a set of convenience methods for loading entities

--- a/packages/entity/src/EntityCompanion.ts
+++ b/packages/entity/src/EntityCompanion.ts
@@ -1,13 +1,16 @@
-import type { EntityCompanionDefinition, EntityCompanionProvider } from './EntityCompanionProvider';
-import { EntityLoaderFactory } from './EntityLoaderFactory';
-import { EntityMutatorFactory } from './EntityMutatorFactory';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContextProvider } from './EntityQueryContextProvider';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import type { EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
-import { mergeEntityMutationTriggerConfigurations } from './utils/mergeEntityMutationTriggerConfigurations';
+import type {
+  EntityCompanionDefinition,
+  EntityCompanionProvider,
+} from './EntityCompanionProvider.ts';
+import { EntityLoaderFactory } from './EntityLoaderFactory.ts';
+import { EntityMutatorFactory } from './EntityMutatorFactory.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContextProvider } from './EntityQueryContextProvider.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import type { EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
+import { mergeEntityMutationTriggerConfigurations } from './utils/mergeEntityMutationTriggerConfigurations.ts';
 
 export interface IPrivacyPolicyClass<TPrivacyPolicy> {
   new (): TPrivacyPolicy;

--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -1,20 +1,20 @@
 import invariant from 'invariant';
 
-import type { IEntityClass } from './Entity';
-import type { IPrivacyPolicyClass } from './EntityCompanion';
-import { EntityCompanion } from './EntityCompanion';
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration';
-import type { EntityMutationValidatorConfiguration } from './EntityMutationValidatorConfiguration';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContextProvider } from './EntityQueryContextProvider';
-import type { IEntityCacheAdapterProvider } from './IEntityCacheAdapterProvider';
-import type { IEntityDatabaseAdapterProvider } from './IEntityDatabaseAdapterProvider';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
-import { computeIfAbsent } from './utils/collections/maps';
+import type { IEntityClass } from './Entity.ts';
+import type { IPrivacyPolicyClass } from './EntityCompanion.ts';
+import { EntityCompanion } from './EntityCompanion.ts';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration.ts';
+import type { EntityMutationValidatorConfiguration } from './EntityMutationValidatorConfiguration.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContextProvider } from './EntityQueryContextProvider.ts';
+import type { IEntityCacheAdapterProvider } from './IEntityCacheAdapterProvider.ts';
+import type { IEntityDatabaseAdapterProvider } from './IEntityDatabaseAdapterProvider.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { EntityTableDataCoordinator } from './internal/EntityTableDataCoordinator.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
+import { computeIfAbsent } from './utils/collections/maps.ts';
 
 /**
  * Backing database and transaction type for an entity. The definitions and implementations

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -1,11 +1,11 @@
 import invariant from 'invariant';
 
-import type { IEntityClass } from './Entity';
-import type { CacheAdapterFlavor, DatabaseAdapterFlavor } from './EntityCompanionProvider';
-import type { EntityFieldDefinition } from './EntityFieldDefinition';
-import type { SerializedCompositeFieldHolder } from './internal/CompositeFieldHolder';
-import { CompositeFieldHolder } from './internal/CompositeFieldHolder';
-import { invertMap, mapMap, reduceMap } from './utils/collections/maps';
+import type { IEntityClass } from './Entity.ts';
+import type { CacheAdapterFlavor, DatabaseAdapterFlavor } from './EntityCompanionProvider.ts';
+import type { EntityFieldDefinition } from './EntityFieldDefinition.ts';
+import type { SerializedCompositeFieldHolder } from './internal/CompositeFieldHolder.ts';
+import { CompositeFieldHolder } from './internal/CompositeFieldHolder.ts';
+import { invertMap, mapMap, reduceMap } from './utils/collections/maps.ts';
 
 /**
  * A composite field is an unordered set of fields by which entities can be loaded in a batched

--- a/packages/entity/src/EntityConstructionUtils.ts
+++ b/packages/entity/src/EntityConstructionUtils.ts
@@ -3,19 +3,19 @@ import type { Result } from '@expo/results';
 import { asyncResult, result } from '@expo/results';
 import invariant from 'invariant';
 
-import type { IEntityClass } from './Entity';
-import type { EntityConfiguration } from './EntityConfiguration';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
 import type {
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationContext,
-} from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { pick } from './entityUtils';
-import { EntityInvalidFieldValueError } from './errors/EntityInvalidFieldValueError';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
-import { mapMapAsync } from './utils/collections/maps';
+} from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { pick } from './entityUtils.ts';
+import { EntityInvalidFieldValueError } from './errors/EntityInvalidFieldValueError.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
+import { mapMapAsync } from './utils/collections/maps.ts';
 
 /**
  * Common entity loader utilities for entity construction and authorization.

--- a/packages/entity/src/EntityCreator.ts
+++ b/packages/entity/src/EntityCreator.ts
@@ -1,10 +1,10 @@
-import type { AuthorizationResultBasedCreateMutator } from './AuthorizationResultBasedEntityMutator';
-import { EnforcingEntityCreator } from './EnforcingEntityCreator';
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedCreateMutator } from './AuthorizationResultBasedEntityMutator.ts';
+import { EnforcingEntityCreator } from './EnforcingEntityCreator.ts';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * The primary interface for creating entities.

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -1,21 +1,21 @@
 import invariant from 'invariant';
 
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { EntityQueryContext } from './EntityQueryContext';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
 import {
   EntityDatabaseAdapterEmptyInsertResultError,
   EntityDatabaseAdapterEmptyUpdateResultError,
   EntityDatabaseAdapterExcessiveDeleteResultError,
   EntityDatabaseAdapterExcessiveInsertResultError,
   EntityDatabaseAdapterExcessiveUpdateResultError,
-} from './errors/EntityDatabaseAdapterError';
-import type { FieldTransformerMap } from './internal/EntityFieldTransformationUtils';
+} from './errors/EntityDatabaseAdapterError.ts';
+import type { FieldTransformerMap } from './internal/EntityFieldTransformationUtils.ts';
 import {
   getDatabaseFieldForEntityField,
   transformDatabaseObjectToFields,
   transformFieldsToDatabaseObject,
-} from './internal/EntityFieldTransformationUtils';
-import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
+} from './internal/EntityFieldTransformationUtils.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces.ts';
 
 /**
  * A database adapter is an interface by which entity objects can be

--- a/packages/entity/src/EntityDeleter.ts
+++ b/packages/entity/src/EntityDeleter.ts
@@ -1,10 +1,10 @@
-import type { AuthorizationResultBasedDeleteMutator } from './AuthorizationResultBasedEntityMutator';
-import { EnforcingEntityDeleter } from './EnforcingEntityDeleter';
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedDeleteMutator } from './AuthorizationResultBasedEntityMutator.ts';
+import { EnforcingEntityDeleter } from './EnforcingEntityDeleter.ts';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * The primary interface for deleting entities.

--- a/packages/entity/src/EntityFieldDefinition.ts
+++ b/packages/entity/src/EntityFieldDefinition.ts
@@ -1,7 +1,7 @@
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 export enum EntityEdgeDeletionBehavior {
   /**

--- a/packages/entity/src/EntityFields.ts
+++ b/packages/entity/src/EntityFields.ts
@@ -1,8 +1,8 @@
 import type {
   EntityFieldDefinitionOptions,
   EntityFieldDefinitionOptionsExplicitCache,
-} from './EntityFieldDefinition';
-import { EntityFieldDefinition } from './EntityFieldDefinition';
+} from './EntityFieldDefinition.ts';
+import { EntityFieldDefinition } from './EntityFieldDefinition.ts';
 
 // Use our own regex since the `uuid` package doesn't support validating UUIDv6/7/8 yet
 const UUID_REGEX =

--- a/packages/entity/src/EntityInvalidationUtils.ts
+++ b/packages/entity/src/EntityInvalidationUtils.ts
@@ -1,13 +1,13 @@
-import type { IEntityClass } from './Entity';
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityTransactionalQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import type { EntityDataManager } from './internal/EntityDataManager';
-import type { LoadPair } from './internal/EntityLoadInterfaces';
-import { SingleFieldHolder, SingleFieldValueHolder } from './internal/SingleFieldHolder';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityTransactionalQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import type { EntityDataManager } from './internal/EntityDataManager.ts';
+import type { LoadPair } from './internal/EntityLoadInterfaces.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from './internal/SingleFieldHolder.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
 
 /**
  * Entity invalidation utilities.

--- a/packages/entity/src/EntityLoader.ts
+++ b/packages/entity/src/EntityLoader.ts
@@ -1,10 +1,10 @@
-import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
-import { EnforcingEntityLoader } from './EnforcingEntityLoader';
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader.ts';
+import { EnforcingEntityLoader } from './EnforcingEntityLoader.ts';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * The primary interface for loading entities. All normal loads are batched,

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -1,16 +1,16 @@
-import { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
-import type { EntityCompanion } from './EntityCompanion';
-import { EntityConstructionUtils } from './EntityConstructionUtils';
-import { EntityInvalidationUtils } from './EntityInvalidationUtils';
+import { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader.ts';
+import type { EntityCompanion } from './EntityCompanion.ts';
+import { EntityConstructionUtils } from './EntityConstructionUtils.ts';
+import { EntityInvalidationUtils } from './EntityInvalidationUtils.ts';
 import type {
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationContext,
-} from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import type { EntityDataManager } from './internal/EntityDataManager';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
+} from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import type { EntityDataManager } from './internal/EntityDataManager.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
 
 /**
  * The primary entry point for loading entities.

--- a/packages/entity/src/EntityMutationInfo.ts
+++ b/packages/entity/src/EntityMutationInfo.ts
@@ -1,5 +1,5 @@
-import type { Entity } from './Entity';
-import type { ViewerContext } from './ViewerContext';
+import type { Entity } from './Entity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 export enum EntityMutationType {
   CREATE,

--- a/packages/entity/src/EntityMutationTriggerConfiguration.ts
+++ b/packages/entity/src/EntityMutationTriggerConfiguration.ts
@@ -1,7 +1,7 @@
-import type { EntityTriggerMutationInfo } from './EntityMutationInfo';
-import type { EntityTransactionalQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { EntityTriggerMutationInfo } from './EntityMutationInfo.ts';
+import type { EntityTransactionalQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Interface to define trigger behavior for entities.

--- a/packages/entity/src/EntityMutationValidatorConfiguration.ts
+++ b/packages/entity/src/EntityMutationValidatorConfiguration.ts
@@ -1,7 +1,7 @@
-import type { EntityValidatorMutationInfo } from './EntityMutationInfo';
-import type { EntityTransactionalQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { EntityValidatorMutationInfo } from './EntityMutationInfo.ts';
+import type { EntityTransactionalQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Interface to define validator behavior for entities.

--- a/packages/entity/src/EntityMutatorFactory.ts
+++ b/packages/entity/src/EntityMutatorFactory.ts
@@ -2,19 +2,19 @@ import {
   AuthorizationResultBasedCreateMutator,
   AuthorizationResultBasedDeleteMutator,
   AuthorizationResultBasedUpdateMutator,
-} from './AuthorizationResultBasedEntityMutator';
-import type { Entity, IEntityClass } from './Entity';
-import type { EntityCompanionProvider } from './EntityCompanionProvider';
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { EntityDatabaseAdapter } from './EntityDatabaseAdapter';
-import type { EntityLoaderFactory } from './EntityLoaderFactory';
-import type { EntityCascadingDeletionInfo } from './EntityMutationInfo';
-import type { EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration';
-import type { EntityMutationValidatorConfiguration } from './EntityMutationValidatorConfiguration';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ViewerContext } from './ViewerContext';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
+} from './AuthorizationResultBasedEntityMutator.ts';
+import type { Entity, IEntityClass } from './Entity.ts';
+import type { EntityCompanionProvider } from './EntityCompanionProvider.ts';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { EntityDatabaseAdapter } from './EntityDatabaseAdapter.ts';
+import type { EntityLoaderFactory } from './EntityLoaderFactory.ts';
+import type { EntityCascadingDeletionInfo } from './EntityMutationInfo.ts';
+import type { EntityMutationTriggerConfiguration } from './EntityMutationTriggerConfiguration.ts';
+import type { EntityMutationValidatorConfiguration } from './EntityMutationValidatorConfiguration.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
 
 /**
  * The primary interface for creating, mutating, and deleting entities.

--- a/packages/entity/src/EntityPrivacyPolicy.ts
+++ b/packages/entity/src/EntityPrivacyPolicy.ts
@@ -1,12 +1,12 @@
-import type { EntityCascadingDeletionInfo } from './EntityMutationInfo';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { EntityNotAuthorizedError } from './errors/EntityNotAuthorizedError';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
-import { EntityMetricsAuthorizationResult } from './metrics/IEntityMetricsAdapter';
-import type { PrivacyPolicyRule } from './rules/PrivacyPolicyRule';
-import { RuleEvaluationResult } from './rules/PrivacyPolicyRule';
+import type { EntityCascadingDeletionInfo } from './EntityMutationInfo.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { EntityNotAuthorizedError } from './errors/EntityNotAuthorizedError.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
+import { EntityMetricsAuthorizationResult } from './metrics/IEntityMetricsAdapter.ts';
+import type { PrivacyPolicyRule } from './rules/PrivacyPolicyRule.ts';
+import { RuleEvaluationResult } from './rules/PrivacyPolicyRule.ts';
 
 /**
  * Information about the reason this privacy policy is being evaluated.

--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import type { EntityQueryContextProvider } from './EntityQueryContextProvider';
+import type { EntityQueryContextProvider } from './EntityQueryContextProvider.ts';
 
 export type PostCommitCallback = (...args: any) => Promise<any>;
 export type PreCommitCallback = (

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
-import type { TransactionConfig } from './EntityQueryContext';
+import type { TransactionConfig } from './EntityQueryContext.ts';
 import {
   EntityNestedTransactionalQueryContext,
   EntityNonTransactionalQueryContext,
   EntityTransactionalQueryContext,
   TransactionalDataLoaderMode,
-} from './EntityQueryContext';
+} from './EntityQueryContext.ts';
 
 /**
  * A query context provider vends transactional and non-transactional query contexts.

--- a/packages/entity/src/EntitySecondaryCacheLoader.ts
+++ b/packages/entity/src/EntitySecondaryCacheLoader.ts
@@ -1,12 +1,12 @@
 import type { Result } from '@expo/results';
 
-import type { IEntityClass } from './Entity';
-import type { EntityConstructionUtils } from './EntityConstructionUtils';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { mapMap } from './utils/collections/maps';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityConstructionUtils } from './EntityConstructionUtils.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { mapMap } from './utils/collections/maps.ts';
 
 /**
  * An interface that knows how to load many objects from a cache by load params and invalidate

--- a/packages/entity/src/EntityUpdater.ts
+++ b/packages/entity/src/EntityUpdater.ts
@@ -1,10 +1,10 @@
-import type { AuthorizationResultBasedUpdateMutator } from './AuthorizationResultBasedEntityMutator';
-import { EnforcingEntityUpdater } from './EnforcingEntityUpdater';
-import type { IEntityClass } from './Entity';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedUpdateMutator } from './AuthorizationResultBasedEntityMutator.ts';
+import { EnforcingEntityUpdater } from './EnforcingEntityUpdater.ts';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * The primary interface for updating entities.

--- a/packages/entity/src/GenericEntityCacheAdapter.ts
+++ b/packages/entity/src/GenericEntityCacheAdapter.ts
@@ -1,10 +1,10 @@
 import invariant from 'invariant';
 
-import type { IEntityCacheAdapter } from './IEntityCacheAdapter';
-import type { IEntityGenericCacher } from './IEntityGenericCacher';
-import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from './internal/ReadThroughEntityCache';
-import { mapKeys } from './utils/collections/maps';
+import type { IEntityCacheAdapter } from './IEntityCacheAdapter.ts';
+import type { IEntityGenericCacher } from './IEntityGenericCacher.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from './internal/ReadThroughEntityCache.ts';
+import { mapKeys } from './utils/collections/maps.ts';
 
 /**
  * A standard IEntityCacheAdapter that coordinates caching through an IEntityGenericCacher.

--- a/packages/entity/src/GenericSecondaryEntityCache.ts
+++ b/packages/entity/src/GenericSecondaryEntityCache.ts
@@ -1,9 +1,9 @@
 import invariant from 'invariant';
 
-import type { ISecondaryEntityCache } from './EntitySecondaryCacheLoader';
-import type { IEntityGenericCacher } from './IEntityGenericCacher';
-import { CacheStatus } from './internal/ReadThroughEntityCache';
-import { filterMap, zipToMap } from './utils/collections/maps';
+import type { ISecondaryEntityCache } from './EntitySecondaryCacheLoader.ts';
+import type { IEntityGenericCacher } from './IEntityGenericCacher.ts';
+import { CacheStatus } from './internal/ReadThroughEntityCache.ts';
+import { filterMap, zipToMap } from './utils/collections/maps.ts';
 
 /**
  * A custom secondary read-through entity cache is a way to add a custom second layer of caching for a particular

--- a/packages/entity/src/IEntityCacheAdapter.ts
+++ b/packages/entity/src/IEntityCacheAdapter.ts
@@ -1,7 +1,7 @@
 /* c8 ignore start - interface only */
 
-import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from './internal/ReadThroughEntityCache';
+import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from './internal/ReadThroughEntityCache.ts';
 
 /**
  * A cache adapter is an interface by which objects can be

--- a/packages/entity/src/IEntityCacheAdapterProvider.ts
+++ b/packages/entity/src/IEntityCacheAdapterProvider.ts
@@ -1,7 +1,7 @@
 /* c8 ignore start - interface only */
 
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { IEntityCacheAdapter } from './IEntityCacheAdapter';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { IEntityCacheAdapter } from './IEntityCacheAdapter.ts';
 
 /**
  * A cache adapter provider vends cache adapters for a particular cache adapter type.

--- a/packages/entity/src/IEntityDatabaseAdapterProvider.ts
+++ b/packages/entity/src/IEntityDatabaseAdapterProvider.ts
@@ -1,7 +1,7 @@
 /* c8 ignore start - interface only */
 
-import type { EntityConfiguration } from './EntityConfiguration';
-import type { EntityDatabaseAdapter } from './EntityDatabaseAdapter';
+import type { EntityConfiguration } from './EntityConfiguration.ts';
+import type { EntityDatabaseAdapter } from './EntityDatabaseAdapter.ts';
 
 /**
  * A database adapter provider vends database adapters for a particular database adapter type.

--- a/packages/entity/src/IEntityGenericCacher.ts
+++ b/packages/entity/src/IEntityGenericCacher.ts
@@ -1,7 +1,7 @@
 /* c8 ignore start - interface only */
 
-import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from './internal/ReadThroughEntityCache';
+import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from './internal/ReadThroughEntityCache.ts';
 
 /**
  * A generic cacher stores and loads key-value pairs. It also supports negative caching - it stores the absence

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -1,16 +1,16 @@
 import invariant from 'invariant';
 
-import type { AuthorizationResultBasedEntityAssociationLoader } from './AuthorizationResultBasedEntityAssociationLoader';
-import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
-import type { EnforcingEntityAssociationLoader } from './EnforcingEntityAssociationLoader';
-import type { EnforcingEntityLoader } from './EnforcingEntityLoader';
-import type { IEntityClass } from './Entity';
-import { EntityAssociationLoader } from './EntityAssociationLoader';
-import type { EntityInvalidationUtils } from './EntityInvalidationUtils';
-import { EntityLoader } from './EntityLoader';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ViewerContext } from './ViewerContext';
+import type { AuthorizationResultBasedEntityAssociationLoader } from './AuthorizationResultBasedEntityAssociationLoader.ts';
+import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader.ts';
+import type { EnforcingEntityAssociationLoader } from './EnforcingEntityAssociationLoader.ts';
+import type { EnforcingEntityLoader } from './EnforcingEntityLoader.ts';
+import type { IEntityClass } from './Entity.ts';
+import { EntityAssociationLoader } from './EntityAssociationLoader.ts';
+import type { EntityInvalidationUtils } from './EntityInvalidationUtils.ts';
+import { EntityLoader } from './EntityLoader.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * A readonly entity exposes only the read functionality of an Entity. Used as the base

--- a/packages/entity/src/ViewerContext.ts
+++ b/packages/entity/src/ViewerContext.ts
@@ -1,14 +1,14 @@
-import type { IEntityClass } from './Entity';
-import type { DatabaseAdapterFlavor, EntityCompanionProvider } from './EntityCompanionProvider';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
+import type { IEntityClass } from './Entity.ts';
+import type { DatabaseAdapterFlavor, EntityCompanionProvider } from './EntityCompanionProvider.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
 import type {
   EntityQueryContext,
   EntityTransactionalQueryContext,
   TransactionConfig,
-} from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion';
-import { ViewerScopedEntityCompanionProvider } from './ViewerScopedEntityCompanionProvider';
+} from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion.ts';
+import { ViewerScopedEntityCompanionProvider } from './ViewerScopedEntityCompanionProvider.ts';
 
 /**
  * A viewer context encapsulates all information necessary to evaluate an EntityPrivacyPolicy.

--- a/packages/entity/src/ViewerScopedEntityCompanion.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanion.ts
@@ -1,11 +1,11 @@
-import type { EntityCompanion } from './EntityCompanion';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContextProvider } from './EntityQueryContextProvider';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { ViewerScopedEntityLoaderFactory } from './ViewerScopedEntityLoaderFactory';
-import { ViewerScopedEntityMutatorFactory } from './ViewerScopedEntityMutatorFactory';
-import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter';
+import type { EntityCompanion } from './EntityCompanion.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContextProvider } from './EntityQueryContextProvider.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { ViewerScopedEntityLoaderFactory } from './ViewerScopedEntityLoaderFactory.ts';
+import { ViewerScopedEntityMutatorFactory } from './ViewerScopedEntityMutatorFactory.ts';
+import type { IEntityMetricsAdapter } from './metrics/IEntityMetricsAdapter.ts';
 
 /**
  * Provides a simpler API for loading and mutating entities by injecting the ViewerContext

--- a/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
+++ b/packages/entity/src/ViewerScopedEntityCompanionProvider.ts
@@ -1,9 +1,9 @@
-import type { IEntityClass } from './Entity';
-import type { EntityCompanionProvider } from './EntityCompanionProvider';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
-import { ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion';
+import type { IEntityClass } from './Entity.ts';
+import type { EntityCompanionProvider } from './EntityCompanionProvider.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
+import { ViewerScopedEntityCompanion } from './ViewerScopedEntityCompanion.ts';
 
 /**
  * Provides viewer-scoped entity companions providers for a simpler API.

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -1,14 +1,14 @@
-import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader';
-import type { EntityConstructionUtils } from './EntityConstructionUtils';
-import type { EntityInvalidationUtils } from './EntityInvalidationUtils';
-import type { EntityLoaderFactory } from './EntityLoaderFactory';
+import type { AuthorizationResultBasedEntityLoader } from './AuthorizationResultBasedEntityLoader.ts';
+import type { EntityConstructionUtils } from './EntityConstructionUtils.ts';
+import type { EntityInvalidationUtils } from './EntityInvalidationUtils.ts';
+import type { EntityLoaderFactory } from './EntityLoaderFactory.ts';
 import type {
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationContext,
-} from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+} from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Provides a cleaner API for loading entities by passing through the ViewerContext.

--- a/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityMutatorFactory.ts
@@ -2,13 +2,13 @@ import type {
   AuthorizationResultBasedCreateMutator,
   AuthorizationResultBasedDeleteMutator,
   AuthorizationResultBasedUpdateMutator,
-} from './AuthorizationResultBasedEntityMutator';
-import type { EntityCascadingDeletionInfo } from './EntityMutationInfo';
-import type { EntityMutatorFactory } from './EntityMutatorFactory';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy';
-import type { EntityQueryContext } from './EntityQueryContext';
-import type { ReadonlyEntity } from './ReadonlyEntity';
-import type { ViewerContext } from './ViewerContext';
+} from './AuthorizationResultBasedEntityMutator.ts';
+import type { EntityCascadingDeletionInfo } from './EntityMutationInfo.ts';
+import type { EntityMutatorFactory } from './EntityMutatorFactory.ts';
+import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from './EntityQueryContext.ts';
+import type { ReadonlyEntity } from './ReadonlyEntity.ts';
+import type { ViewerContext } from './ViewerContext.ts';
 
 /**
  * Provides a cleaner API for mutating entities by passing through the ViewerContext.

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
@@ -2,12 +2,12 @@ import { enforceAsyncResult } from '@expo/results';
 import { describe, expect, it } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader';
-import { enforceResultsAsync } from '../entityUtils';
-import { TestEntity } from '../utils/__testfixtures__/TestEntity';
-import { TestEntity2 } from '../utils/__testfixtures__/TestEntity2';
-import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader.ts';
+import { enforceResultsAsync } from '../entityUtils.ts';
+import { TestEntity } from '../utils/__testfixtures__/TestEntity.ts';
+import { TestEntity2 } from '../utils/__testfixtures__/TestEntity2.ts';
+import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(AuthorizationResultBasedEntityAssociationLoader, () => {
   describe('loadAssociatedEntityAsync', () => {

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-constructor-test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
-import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import { Entity } from '../Entity';
-import type { EntityCompanionDefinition } from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { EntityConstructionUtils } from '../EntityConstructionUtils';
-import { StringField } from '../EntityFields';
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import { ViewerContext } from '../ViewerContext';
-import { EntityDataManager } from '../internal/EntityDataManager';
-import { ReadThroughEntityCache } from '../internal/ReadThroughEntityCache';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
-import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule';
-import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter';
-import { StubDatabaseAdapter } from '../utils/__testfixtures__/StubDatabaseAdapter';
-import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider';
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { Entity } from '../Entity.ts';
+import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { EntityConstructionUtils } from '../EntityConstructionUtils.ts';
+import { StringField } from '../EntityFields.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { EntityDataManager } from '../internal/EntityDataManager.ts';
+import { ReadThroughEntityCache } from '../internal/ReadThroughEntityCache.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { StubDatabaseAdapter } from '../utils/__testfixtures__/StubDatabaseAdapter.ts';
+import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider.ts';
 
 export type TestFields = {
   id: string;

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -3,32 +3,35 @@ import { describe, expect, it } from '@jest/globals';
 import { anyOfClass, anything, instance, mock, spy, verify, when } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import { EntityConstructionUtils } from '../EntityConstructionUtils';
-import { EntityInvalidationUtils } from '../EntityInvalidationUtils';
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import { ViewerContext } from '../ViewerContext';
-import { enforceResultsAsync } from '../entityUtils';
-import { EntityNotFoundError } from '../errors/EntityNotFoundError';
-import { CompositeFieldHolder, CompositeFieldValueHolder } from '../internal/CompositeFieldHolder';
-import { EntityDataManager } from '../internal/EntityDataManager';
-import { ReadThroughEntityCache } from '../internal/ReadThroughEntityCache';
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { EntityConstructionUtils } from '../EntityConstructionUtils.ts';
+import { EntityInvalidationUtils } from '../EntityInvalidationUtils.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { enforceResultsAsync } from '../entityUtils.ts';
+import { EntityNotFoundError } from '../errors/EntityNotFoundError.ts';
+import {
+  CompositeFieldHolder,
+  CompositeFieldValueHolder,
+} from '../internal/CompositeFieldHolder.ts';
+import { EntityDataManager } from '../internal/EntityDataManager.ts';
+import { ReadThroughEntityCache } from '../internal/ReadThroughEntityCache.ts';
 import {
   SingleFieldHolder,
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
-} from '../internal/SingleFieldHolder';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
-import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter';
-import { StubDatabaseAdapter } from '../utils/__testfixtures__/StubDatabaseAdapter';
-import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider';
-import { deepEqualEntityAware } from '../utils/__testfixtures__/TSMockitoExtensions';
-import type { TestFields } from '../utils/__testfixtures__/TestEntity';
+} from '../internal/SingleFieldHolder.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
+import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { StubDatabaseAdapter } from '../utils/__testfixtures__/StubDatabaseAdapter.ts';
+import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider.ts';
+import { deepEqualEntityAware } from '../utils/__testfixtures__/TSMockitoExtensions.ts';
+import type { TestFields } from '../utils/__testfixtures__/TestEntity.ts';
 import {
   TestEntity,
   TestEntityPrivacyPolicy,
   testEntityConfiguration,
-} from '../utils/__testfixtures__/TestEntity';
+} from '../utils/__testfixtures__/TestEntity.ts';
 
 describe(AuthorizationResultBasedEntityLoader, () => {
   it('loads entities', async () => {

--- a/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/ComposedCacheAdapter-test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { ComposedEntityCacheAdapter } from '../ComposedEntityCacheAdapter';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { UUIDField } from '../EntityFields';
-import type { IEntityCacheAdapter } from '../IEntityCacheAdapter';
-import type { IEntityLoadKey, IEntityLoadValue } from '../internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from '../internal/ReadThroughEntityCache';
-import { CacheStatus } from '../internal/ReadThroughEntityCache';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
+import { ComposedEntityCacheAdapter } from '../ComposedEntityCacheAdapter.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { UUIDField } from '../EntityFields.ts';
+import type { IEntityCacheAdapter } from '../IEntityCacheAdapter.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from '../internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from '../internal/ReadThroughEntityCache.ts';
+import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/ComposedSecondaryEntityCache-test.ts
@@ -2,8 +2,8 @@ import nullthrows from '@expo/nullthrows';
 import { describe, expect, it } from '@jest/globals';
 import invariant from 'invariant';
 
-import { ComposedSecondaryEntityCache } from '../ComposedSecondaryEntityCache';
-import type { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader';
+import { ComposedSecondaryEntityCache } from '../ComposedSecondaryEntityCache.ts';
+import type { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader.ts';
 
 type TestFields = { id: string };
 type TestLoadParams = { lp: string };

--- a/packages/entity/src/__tests__/EnforcingEntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityAssociationLoader-test.ts
@@ -2,8 +2,8 @@ import { result } from '@expo/results';
 import { describe, expect, it } from '@jest/globals';
 import { anything, instance, mock, when } from 'ts-mockito';
 
-import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader';
-import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader';
+import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader.ts';
+import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader.ts';
 
 describe(EnforcingEntityAssociationLoader, () => {
   describe('loadAssociatedEntityAsync', () => {

--- a/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EnforcingEntityLoader-test.ts
@@ -2,10 +2,10 @@ import { result } from '@expo/results';
 import { describe, expect, it } from '@jest/globals';
 import { anything, instance, mock, when } from 'ts-mockito';
 
-import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import { EnforcingEntityLoader } from '../EnforcingEntityLoader';
-import { CompositeFieldValueHolder } from '../internal/CompositeFieldHolder';
-import { CompositeFieldValueMap } from '../internal/CompositeFieldValueMap';
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { EnforcingEntityLoader } from '../EnforcingEntityLoader.ts';
+import { CompositeFieldValueHolder } from '../internal/CompositeFieldHolder.ts';
+import { CompositeFieldValueMap } from '../internal/CompositeFieldValueMap.ts';
 
 describe(EnforcingEntityLoader, () => {
   describe('loadManyByFieldEqualingManyAsync', () => {

--- a/packages/entity/src/__tests__/Entity-test.ts
+++ b/packages/entity/src/__tests__/Entity-test.ts
@@ -4,14 +4,14 @@ import {
   AuthorizationResultBasedCreateMutator,
   AuthorizationResultBasedDeleteMutator,
   AuthorizationResultBasedUpdateMutator,
-} from '../AuthorizationResultBasedEntityMutator';
-import { EnforcingEntityCreator } from '../EnforcingEntityCreator';
-import { EnforcingEntityDeleter } from '../EnforcingEntityDeleter';
-import { EnforcingEntityUpdater } from '../EnforcingEntityUpdater';
-import { Entity } from '../Entity';
-import { ViewerContext } from '../ViewerContext';
-import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../AuthorizationResultBasedEntityMutator.ts';
+import { EnforcingEntityCreator } from '../EnforcingEntityCreator.ts';
+import { EnforcingEntityDeleter } from '../EnforcingEntityDeleter.ts';
+import { EnforcingEntityUpdater } from '../EnforcingEntityUpdater.ts';
+import { Entity } from '../Entity.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(Entity, () => {
   describe('creator', () => {

--- a/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityAssociationLoader-test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader';
-import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader';
-import { EntityAssociationLoader } from '../EntityAssociationLoader';
-import { ViewerContext } from '../ViewerContext';
-import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader.ts';
+import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader.ts';
+import { EntityAssociationLoader } from '../EntityAssociationLoader.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(EntityAssociationLoader, () => {
   describe('enforcing', () => {

--- a/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
+++ b/packages/entity/src/__tests__/EntityCommonUseCases-test.ts
@@ -2,23 +2,23 @@ import { enforceAsyncResult } from '@expo/results';
 import { expect, it } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Entity } from '../Entity';
+import { Entity } from '../Entity.ts';
 import type {
   EntityCompanionDefinition,
   EntityCompanionProvider,
-} from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { UUIDField } from '../EntityFields';
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import { ViewerContext } from '../ViewerContext';
-import { enforceResultsAsync } from '../entityUtils';
-import { EntityNotAuthorizedError } from '../errors/EntityNotAuthorizedError';
-import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule';
-import { AlwaysDenyPrivacyPolicyRule } from '../rules/AlwaysDenyPrivacyPolicyRule';
-import { PrivacyPolicyRule, RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { UUIDField } from '../EntityFields.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { enforceResultsAsync } from '../entityUtils.ts';
+import { EntityNotAuthorizedError } from '../errors/EntityNotAuthorizedError.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../rules/AlwaysDenyPrivacyPolicyRule.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from '../rules/PrivacyPolicyRule.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 class TestUserViewerContext extends ViewerContext {
   constructor(

--- a/packages/entity/src/__tests__/EntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanion-test.ts
@@ -1,21 +1,21 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock, when } from 'ts-mockito';
 
-import { EntityCompanion } from '../EntityCompanion';
-import { EntityCompanionProvider } from '../EntityCompanionProvider';
-import { EntityLoaderFactory } from '../EntityLoaderFactory';
-import type { EntityMutationTriggerConfiguration } from '../EntityMutationTriggerConfiguration';
-import { EntityMutatorFactory } from '../EntityMutatorFactory';
-import type { ViewerContext } from '../ViewerContext';
-import type { EntityTableDataCoordinator } from '../internal/EntityTableDataCoordinator';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
-import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter';
-import type { TestMTFields } from '../utils/__testfixtures__/TestEntityWithMutationTriggers';
+import { EntityCompanion } from '../EntityCompanion.ts';
+import { EntityCompanionProvider } from '../EntityCompanionProvider.ts';
+import { EntityLoaderFactory } from '../EntityLoaderFactory.ts';
+import type { EntityMutationTriggerConfiguration } from '../EntityMutationTriggerConfiguration.ts';
+import { EntityMutatorFactory } from '../EntityMutatorFactory.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import type { EntityTableDataCoordinator } from '../internal/EntityTableDataCoordinator.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
+import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter.ts';
+import type { TestMTFields } from '../utils/__testfixtures__/TestEntityWithMutationTriggers.ts';
 import {
   testEntityMTConfiguration,
   TestEntityWithMutationTriggers,
   TestMutationTrigger,
-} from '../utils/__testfixtures__/TestEntityWithMutationTriggers';
+} from '../utils/__testfixtures__/TestEntityWithMutationTriggers.ts';
 
 describe(EntityCompanion, () => {
   it('correctly instantiates mutator and loader factories', () => {

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { Entity } from '../Entity';
-import type { EntityCompanionDefinition } from '../EntityCompanionProvider';
-import { EntityCompanionProvider } from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { StringField } from '../EntityFields';
-import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import type { ViewerContext } from '../ViewerContext';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { Entity } from '../Entity.ts';
+import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
+import { EntityCompanionProvider } from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { StringField } from '../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 type BlahFields = {
   hello: string;

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, test } from '@jest/globals';
 
-import { EntityConfiguration } from '../EntityConfiguration';
-import { StringField, UUIDField } from '../EntityFields';
-import { CompositeFieldHolder } from '../internal/CompositeFieldHolder';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { StringField, UUIDField } from '../EntityFields.ts';
+import { CompositeFieldHolder } from '../internal/CompositeFieldHolder.ts';
 
 describe(EntityConfiguration, () => {
   describe('when valid', () => {

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -1,20 +1,23 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
-import { EntityDatabaseAdapter } from '../EntityDatabaseAdapter';
-import { EntityQueryContext } from '../EntityQueryContext';
+import { EntityDatabaseAdapter } from '../EntityDatabaseAdapter.ts';
+import { EntityQueryContext } from '../EntityQueryContext.ts';
 import {
   EntityDatabaseAdapterEmptyInsertResultError,
   EntityDatabaseAdapterEmptyUpdateResultError,
   EntityDatabaseAdapterExcessiveDeleteResultError,
   EntityDatabaseAdapterExcessiveInsertResultError,
   EntityDatabaseAdapterExcessiveUpdateResultError,
-} from '../errors/EntityDatabaseAdapterError';
-import { CompositeFieldHolder, CompositeFieldValueHolder } from '../internal/CompositeFieldHolder';
-import type { FieldTransformerMap } from '../internal/EntityFieldTransformationUtils';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
-import type { TestFields } from '../utils/__testfixtures__/TestEntity';
-import { testEntityConfiguration } from '../utils/__testfixtures__/TestEntity';
+} from '../errors/EntityDatabaseAdapterError.ts';
+import {
+  CompositeFieldHolder,
+  CompositeFieldValueHolder,
+} from '../internal/CompositeFieldHolder.ts';
+import type { FieldTransformerMap } from '../internal/EntityFieldTransformationUtils.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder.ts';
+import type { TestFields } from '../utils/__testfixtures__/TestEntity.ts';
+import { testEntityConfiguration } from '../utils/__testfixtures__/TestEntity.ts';
 
 class TestEntityDatabaseAdapter extends EntityDatabaseAdapter<TestFields, 'customIdField'> {
   private readonly fetchResults: object[];

--- a/packages/entity/src/__tests__/EntityEdges-test.ts
+++ b/packages/entity/src/__tests__/EntityEdges-test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it } from '@jest/globals';
 import invariant from 'invariant';
 
-import { Entity } from '../Entity';
-import type { EntityCompanionDefinition } from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition';
-import { UUIDField } from '../EntityFields';
-import type { EntityTriggerMutationInfo } from '../EntityMutationInfo';
-import { EntityMutationType } from '../EntityMutationInfo';
-import { EntityMutationTrigger } from '../EntityMutationTriggerConfiguration';
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import { EntityAuthorizationAction, EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext, EntityTransactionalQueryContext } from '../EntityQueryContext';
-import { CacheStatus } from '../internal/ReadThroughEntityCache';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
-import { PrivacyPolicyRule, RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
-import type { InMemoryFullCacheStubCacheAdapter } from '../utils/__testfixtures__/StubCacheAdapter';
-import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { Entity } from '../Entity.ts';
+import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition.ts';
+import { UUIDField } from '../EntityFields.ts';
+import type { EntityTriggerMutationInfo } from '../EntityMutationInfo.ts';
+import { EntityMutationType } from '../EntityMutationInfo.ts';
+import { EntityMutationTrigger } from '../EntityMutationTriggerConfiguration.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import { EntityAuthorizationAction, EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext, EntityTransactionalQueryContext } from '../EntityQueryContext.ts';
+import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from '../rules/PrivacyPolicyRule.ts';
+import type { InMemoryFullCacheStubCacheAdapter } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 interface OtherFields {
   id: string;

--- a/packages/entity/src/__tests__/EntityFields-test.ts
+++ b/packages/entity/src/__tests__/EntityFields-test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from '@jest/globals';
 import { v1 as uuidv1, v3 as uuidv3, v4 as uuidv4, v5 as uuidv5, v7 as uuidv7 } from 'uuid';
 
-import { EntityFieldDefinition } from '../EntityFieldDefinition';
+import { EntityFieldDefinition } from '../EntityFieldDefinition.ts';
 import {
   BooleanField,
   BufferField,
@@ -14,8 +14,8 @@ import {
   StringArrayField,
   StringField,
   UUIDField,
-} from '../EntityFields';
-import { describeFieldTestCase } from '../utils/__testfixtures__/describeFieldTestCase';
+} from '../EntityFields.ts';
+import { describeFieldTestCase } from '../utils/__testfixtures__/describeFieldTestCase.ts';
 
 class TestFieldDefinition extends EntityFieldDefinition<string, false> {
   protected validateInputValueInternal(value: string): boolean {

--- a/packages/entity/src/__tests__/EntityLoader-test.ts
+++ b/packages/entity/src/__tests__/EntityLoader-test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import { EnforcingEntityLoader } from '../EnforcingEntityLoader';
-import { EntityInvalidationUtils } from '../EntityInvalidationUtils';
-import { EntityLoader } from '../EntityLoader';
-import { ViewerContext } from '../ViewerContext';
-import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { EnforcingEntityLoader } from '../EnforcingEntityLoader.ts';
+import { EntityInvalidationUtils } from '../EntityInvalidationUtils.ts';
+import { EntityLoader } from '../EntityLoader.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(EntityLoader, () => {
   describe('enforcing', () => {

--- a/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-MutationCacheConsistency-test.ts
@@ -1,17 +1,17 @@
 import { describe, test } from '@jest/globals';
 
-import { Entity } from '../Entity';
-import type { EntityCompanionDefinition } from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { UUIDField } from '../EntityFields';
-import type { EntityTriggerMutationInfo } from '../EntityMutationInfo';
-import { EntityMutationType } from '../EntityMutationInfo';
-import { EntityNonTransactionalMutationTrigger } from '../EntityMutationTriggerConfiguration';
-import { EntityMutatorFactory } from '../EntityMutatorFactory';
-import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import { ViewerContext } from '../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { Entity } from '../Entity.ts';
+import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { UUIDField } from '../EntityFields.ts';
+import type { EntityTriggerMutationInfo } from '../EntityMutationInfo.ts';
+import { EntityMutationType } from '../EntityMutationInfo.ts';
+import { EntityNonTransactionalMutationTrigger } from '../EntityMutationTriggerConfiguration.ts';
+import { EntityMutatorFactory } from '../EntityMutatorFactory.ts';
+import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/__tests__/EntityMutator-SingleCompositeFieldCacheConsistency-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-SingleCompositeFieldCacheConsistency-test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { EntityMutatorFactory } from '../EntityMutatorFactory';
-import { ViewerContext } from '../ViewerContext';
-import { TestEntity } from '../utils/__testfixtures__/TestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { EntityMutatorFactory } from '../EntityMutatorFactory.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { TestEntity } from '../utils/__testfixtures__/TestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(EntityMutatorFactory, () => {
   test('cache consistency across single and composite field mutations', async () => {

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -13,48 +13,48 @@ import {
 } from 'ts-mockito';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import { EntityCompanionProvider } from '../EntityCompanionProvider';
-import type { EntityConfiguration } from '../EntityConfiguration';
-import { EntityConstructionUtils } from '../EntityConstructionUtils';
-import type { EntityDatabaseAdapter } from '../EntityDatabaseAdapter';
-import { EntityLoaderFactory } from '../EntityLoaderFactory';
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { EntityCompanionProvider } from '../EntityCompanionProvider.ts';
+import type { EntityConfiguration } from '../EntityConfiguration.ts';
+import { EntityConstructionUtils } from '../EntityConstructionUtils.ts';
+import type { EntityDatabaseAdapter } from '../EntityDatabaseAdapter.ts';
+import { EntityLoaderFactory } from '../EntityLoaderFactory.ts';
 import type {
   EntityCascadingDeletionInfo,
   EntityTriggerMutationInfo,
   EntityValidatorMutationInfo,
-} from '../EntityMutationInfo';
-import { EntityMutationType } from '../EntityMutationInfo';
-import type { EntityMutationTriggerConfiguration } from '../EntityMutationTriggerConfiguration';
+} from '../EntityMutationInfo.ts';
+import { EntityMutationType } from '../EntityMutationInfo.ts';
+import type { EntityMutationTriggerConfiguration } from '../EntityMutationTriggerConfiguration.ts';
 import {
   EntityMutationTrigger,
   EntityNonTransactionalMutationTrigger,
-} from '../EntityMutationTriggerConfiguration';
-import type { EntityMutationValidatorConfiguration } from '../EntityMutationValidatorConfiguration';
-import { EntityMutationValidator } from '../EntityMutationValidatorConfiguration';
-import { EntityMutatorFactory } from '../EntityMutatorFactory';
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import { EntityTransactionalQueryContext } from '../EntityQueryContext';
-import type { IEntityDatabaseAdapterProvider } from '../IEntityDatabaseAdapterProvider';
-import { ViewerContext } from '../ViewerContext';
-import { enforceResultsAsync } from '../entityUtils';
-import { EntityDataManager } from '../internal/EntityDataManager';
-import { ReadThroughEntityCache } from '../internal/ReadThroughEntityCache';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
-import { EntityMetricsMutationType } from '../metrics/IEntityMetricsAdapter';
-import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter';
-import type { SimpleTestFields } from '../utils/__testfixtures__/SimpleTestEntity';
+} from '../EntityMutationTriggerConfiguration.ts';
+import type { EntityMutationValidatorConfiguration } from '../EntityMutationValidatorConfiguration.ts';
+import { EntityMutationValidator } from '../EntityMutationValidatorConfiguration.ts';
+import { EntityMutatorFactory } from '../EntityMutatorFactory.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import { EntityTransactionalQueryContext } from '../EntityQueryContext.ts';
+import type { IEntityDatabaseAdapterProvider } from '../IEntityDatabaseAdapterProvider.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { enforceResultsAsync } from '../entityUtils.ts';
+import { EntityDataManager } from '../internal/EntityDataManager.ts';
+import { ReadThroughEntityCache } from '../internal/ReadThroughEntityCache.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
+import { EntityMetricsMutationType } from '../metrics/IEntityMetricsAdapter.ts';
+import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter.ts';
+import type { SimpleTestFields } from '../utils/__testfixtures__/SimpleTestEntity.ts';
 import {
   SimpleTestEntity,
   simpleTestEntityConfiguration,
   SimpleTestEntityPrivacyPolicy,
-} from '../utils/__testfixtures__/SimpleTestEntity';
-import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter';
-import { StubDatabaseAdapter } from '../utils/__testfixtures__/StubDatabaseAdapter';
-import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider';
-import type { TestEntityPrivacyPolicy, TestFields } from '../utils/__testfixtures__/TestEntity';
-import { TestEntity, testEntityConfiguration } from '../utils/__testfixtures__/TestEntity';
+} from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { NoCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { StubDatabaseAdapter } from '../utils/__testfixtures__/StubDatabaseAdapter.ts';
+import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider.ts';
+import type { TestEntityPrivacyPolicy, TestFields } from '../utils/__testfixtures__/TestEntity.ts';
+import { TestEntity, testEntityConfiguration } from '../utils/__testfixtures__/TestEntity.ts';
 
 class TestMutationValidator extends EntityMutationValidator<
   TestFields,

--- a/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
+++ b/packages/entity/src/__tests__/EntityPrivacyPolicy-test.ts
@@ -1,29 +1,29 @@
 import { describe, expect, it } from '@jest/globals';
 import { anyOfClass, anything, instance, mock, objectContaining, spy, verify } from 'ts-mockito';
 
-import { Entity } from '../Entity';
-import type { EntityCompanionDefinition } from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { UUIDField } from '../EntityFields';
+import { Entity } from '../Entity.ts';
+import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { UUIDField } from '../EntityFields.ts';
 import type {
   EntityPrivacyPolicyEvaluationContext,
   EntityPrivacyPolicyEvaluator,
   EntityPrivacyPolicyRuleEvaluationContext,
-} from '../EntityPrivacyPolicy';
+} from '../EntityPrivacyPolicy.ts';
 import {
   EntityAuthorizationAction,
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationMode,
-} from '../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../EntityQueryContext';
-import { ViewerContext } from '../ViewerContext';
-import { EntityNotAuthorizedError } from '../errors/EntityNotAuthorizedError';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
-import { EntityMetricsAuthorizationResult } from '../metrics/IEntityMetricsAdapter';
-import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule';
-import { AlwaysDenyPrivacyPolicyRule } from '../rules/AlwaysDenyPrivacyPolicyRule';
-import { AlwaysSkipPrivacyPolicyRule } from '../rules/AlwaysSkipPrivacyPolicyRule';
-import { PrivacyPolicyRule, RuleEvaluationResult } from '../rules/PrivacyPolicyRule';
+} from '../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../EntityQueryContext.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { EntityNotAuthorizedError } from '../errors/EntityNotAuthorizedError.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
+import { EntityMetricsAuthorizationResult } from '../metrics/IEntityMetricsAdapter.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../rules/AlwaysDenyPrivacyPolicyRule.ts';
+import { AlwaysSkipPrivacyPolicyRule } from '../rules/AlwaysSkipPrivacyPolicyRule.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from '../rules/PrivacyPolicyRule.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -2,19 +2,19 @@ import { describe, expect, it, jest } from '@jest/globals';
 import assert from 'assert';
 import invariant from 'invariant';
 
-import { EntityCompanionProvider } from '../EntityCompanionProvider';
-import type { TransactionConfig } from '../EntityQueryContext';
+import { EntityCompanionProvider } from '../EntityCompanionProvider.ts';
+import type { TransactionConfig } from '../EntityQueryContext.ts';
 import {
   EntityQueryContext,
   TransactionalDataLoaderMode,
   TransactionIsolationLevel,
-} from '../EntityQueryContext';
-import { EntityQueryContextProvider } from '../EntityQueryContextProvider';
-import { ViewerContext } from '../ViewerContext';
-import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter';
-import { InMemoryFullCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter';
-import { StubDatabaseAdapterProvider } from '../utils/__testfixtures__/StubDatabaseAdapterProvider';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../EntityQueryContext.ts';
+import { EntityQueryContextProvider } from '../EntityQueryContextProvider.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter.ts';
+import { InMemoryFullCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { StubDatabaseAdapterProvider } from '../utils/__testfixtures__/StubDatabaseAdapterProvider.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(EntityQueryContext, () => {
   describe('callbacks', () => {

--- a/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
+++ b/packages/entity/src/__tests__/EntitySecondaryCacheLoader-test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from '@jest/globals';
 import { anyOfClass, anything, deepEqual, instance, mock, spy, verify, when } from 'ts-mockito';
 
-import { EntityNonTransactionalQueryContext } from '../EntityQueryContext';
-import type { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader';
-import { EntitySecondaryCacheLoader } from '../EntitySecondaryCacheLoader';
-import { ViewerContext } from '../ViewerContext';
+import { EntityNonTransactionalQueryContext } from '../EntityQueryContext.ts';
+import type { ISecondaryEntityCache } from '../EntitySecondaryCacheLoader.ts';
+import { EntitySecondaryCacheLoader } from '../EntitySecondaryCacheLoader.ts';
+import { ViewerContext } from '../ViewerContext.ts';
 import type {
   SimpleTestEntityPrivacyPolicy,
   SimpleTestFields,
-} from '../utils/__testfixtures__/SimpleTestEntity';
-import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 type TestLoadParams = { id: string };
 

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { Entity } from '../Entity';
-import type { EntityCompanionDefinition } from '../EntityCompanionProvider';
-import { EntityConfiguration } from '../EntityConfiguration';
-import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition';
-import { UUIDField } from '../EntityFields';
-import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import { CacheStatus } from '../internal/ReadThroughEntityCache';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder';
-import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule';
-import type { InMemoryFullCacheStubCacheAdapter } from '../utils/__testfixtures__/StubCacheAdapter';
-import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { Entity } from '../Entity.ts';
+import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition.ts';
+import { UUIDField } from '../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import type { InMemoryFullCacheStubCacheAdapter } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 interface CategoryFields {
   id: string;

--- a/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
+++ b/packages/entity/src/__tests__/GenericEntityCacheAdapter-test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from '@jest/globals';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
-import { GenericEntityCacheAdapter } from '../GenericEntityCacheAdapter';
-import type { IEntityGenericCacher } from '../IEntityGenericCacher';
-import { EntityCacheAdapterTransientError } from '../errors/EntityCacheAdapterError';
-import { CacheStatus } from '../internal/ReadThroughEntityCache';
+import { GenericEntityCacheAdapter } from '../GenericEntityCacheAdapter.ts';
+import type { IEntityGenericCacher } from '../IEntityGenericCacher.ts';
+import { EntityCacheAdapterTransientError } from '../errors/EntityCacheAdapterError.ts';
+import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
 import {
   SingleFieldHolder,
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
-} from '../internal/SingleFieldHolder';
-import { deepEqualEntityAware } from '../utils/__testfixtures__/TSMockitoExtensions';
+} from '../internal/SingleFieldHolder.ts';
+import { deepEqualEntityAware } from '../utils/__testfixtures__/TSMockitoExtensions.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/__tests__/GenericSecondaryEntityCache-test.ts
+++ b/packages/entity/src/__tests__/GenericSecondaryEntityCache-test.ts
@@ -1,19 +1,19 @@
 import nullthrows from '@expo/nullthrows';
 import { describe, expect, it } from '@jest/globals';
 
-import type { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import type { EntityConstructionUtils } from '../EntityConstructionUtils';
-import { EntitySecondaryCacheLoader } from '../EntitySecondaryCacheLoader';
-import { GenericSecondaryEntityCache } from '../GenericSecondaryEntityCache';
-import type { IEntityGenericCacher } from '../IEntityGenericCacher';
-import { ViewerContext } from '../ViewerContext';
-import type { IEntityLoadKey, IEntityLoadValue } from '../internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from '../internal/ReadThroughEntityCache';
-import { CacheStatus } from '../internal/ReadThroughEntityCache';
-import type { TestEntityPrivacyPolicy, TestFields } from '../utils/__testfixtures__/TestEntity';
-import { TestEntity } from '../utils/__testfixtures__/TestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
-import { mapMapAsync } from '../utils/collections/maps';
+import type { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import type { EntityConstructionUtils } from '../EntityConstructionUtils.ts';
+import { EntitySecondaryCacheLoader } from '../EntitySecondaryCacheLoader.ts';
+import { GenericSecondaryEntityCache } from '../GenericSecondaryEntityCache.ts';
+import type { IEntityGenericCacher } from '../IEntityGenericCacher.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from '../internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from '../internal/ReadThroughEntityCache.ts';
+import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
+import type { TestEntityPrivacyPolicy, TestFields } from '../utils/__testfixtures__/TestEntity.ts';
+import { TestEntity } from '../utils/__testfixtures__/TestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
+import { mapMapAsync } from '../utils/collections/maps.ts';
 
 type TestLoadParams = { intValue: number };
 

--- a/packages/entity/src/__tests__/ReadonlyEntity-test.ts
+++ b/packages/entity/src/__tests__/ReadonlyEntity-test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
-import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader';
-import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader';
-import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader';
-import { EnforcingEntityLoader } from '../EnforcingEntityLoader';
-import { EntityInvalidationUtils } from '../EntityInvalidationUtils';
-import { ReadonlyEntity } from '../ReadonlyEntity';
-import { ViewerContext } from '../ViewerContext';
-import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity';
-import { TestEntity } from '../utils/__testfixtures__/TestEntity';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { AuthorizationResultBasedEntityAssociationLoader } from '../AuthorizationResultBasedEntityAssociationLoader.ts';
+import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { EnforcingEntityAssociationLoader } from '../EnforcingEntityAssociationLoader.ts';
+import { EnforcingEntityLoader } from '../EnforcingEntityLoader.ts';
+import { EntityInvalidationUtils } from '../EntityInvalidationUtils.ts';
+import { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { SimpleTestEntity } from '../utils/__testfixtures__/SimpleTestEntity.ts';
+import { TestEntity } from '../utils/__testfixtures__/TestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(ReadonlyEntity, () => {
   describe('getID', () => {

--- a/packages/entity/src/__tests__/ViewerContext-test.ts
+++ b/packages/entity/src/__tests__/ViewerContext-test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { EntityQueryContext } from '../EntityQueryContext';
-import { ViewerContext } from '../ViewerContext';
-import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { EntityQueryContext } from '../EntityQueryContext.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(ViewerContext, () => {
   describe('getQueryContextForDatabaseAdapterFlavor', () => {

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanion-test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
-import type { EntityCompanion } from '../EntityCompanion';
-import { ViewerContext } from '../ViewerContext';
-import { ViewerScopedEntityCompanion } from '../ViewerScopedEntityCompanion';
-import { ViewerScopedEntityLoaderFactory } from '../ViewerScopedEntityLoaderFactory';
-import { ViewerScopedEntityMutatorFactory } from '../ViewerScopedEntityMutatorFactory';
+import type { EntityCompanion } from '../EntityCompanion.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { ViewerScopedEntityCompanion } from '../ViewerScopedEntityCompanion.ts';
+import { ViewerScopedEntityLoaderFactory } from '../ViewerScopedEntityLoaderFactory.ts';
+import { ViewerScopedEntityMutatorFactory } from '../ViewerScopedEntityMutatorFactory.ts';
 import type {
   TestEntity,
   TestEntityPrivacyPolicy,
   TestFields,
-} from '../utils/__testfixtures__/TestEntity';
+} from '../utils/__testfixtures__/TestEntity.ts';
 
 describe(ViewerScopedEntityCompanion, () => {
   it('returns viewer scoped loader and mutator factory', () => {

--- a/packages/entity/src/__tests__/ViewerScopedEntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityCompanionProvider-test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
-import { EntityCompanionProvider } from '../EntityCompanionProvider';
-import { ViewerContext } from '../ViewerContext';
-import { ViewerScopedEntityCompanion } from '../ViewerScopedEntityCompanion';
-import { ViewerScopedEntityCompanionProvider } from '../ViewerScopedEntityCompanionProvider';
-import { TestEntity } from '../utils/__testfixtures__/TestEntity';
+import { EntityCompanionProvider } from '../EntityCompanionProvider.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { ViewerScopedEntityCompanion } from '../ViewerScopedEntityCompanion.ts';
+import { ViewerScopedEntityCompanionProvider } from '../ViewerScopedEntityCompanionProvider.ts';
+import { TestEntity } from '../utils/__testfixtures__/TestEntity.ts';
 
 describe(ViewerScopedEntityCompanionProvider, () => {
   it('returns viewer scoped entity companion', () => {

--- a/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityLoaderFactory-test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from '@jest/globals';
 import { instance, mock, verify } from 'ts-mockito';
 
-import { EntityLoaderFactory } from '../EntityLoaderFactory';
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../EntityQueryContext';
-import { ViewerContext } from '../ViewerContext';
-import { ViewerScopedEntityLoaderFactory } from '../ViewerScopedEntityLoaderFactory';
+import { EntityLoaderFactory } from '../EntityLoaderFactory.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../EntityQueryContext.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { ViewerScopedEntityLoaderFactory } from '../ViewerScopedEntityLoaderFactory.ts';
 
 describe(ViewerScopedEntityLoaderFactory, () => {
   it('correctly scopes viewer to entity loads', async () => {

--- a/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
+++ b/packages/entity/src/__tests__/ViewerScopedEntityMutatorFactory-test.ts
@@ -1,15 +1,15 @@
 import { describe, it } from '@jest/globals';
 import { instance, mock, verify } from 'ts-mockito';
 
-import { EntityMutatorFactory } from '../EntityMutatorFactory';
-import { EntityQueryContext } from '../EntityQueryContext';
-import { ViewerContext } from '../ViewerContext';
-import { ViewerScopedEntityMutatorFactory } from '../ViewerScopedEntityMutatorFactory';
+import { EntityMutatorFactory } from '../EntityMutatorFactory.ts';
+import { EntityQueryContext } from '../EntityQueryContext.ts';
+import { ViewerContext } from '../ViewerContext.ts';
+import { ViewerScopedEntityMutatorFactory } from '../ViewerScopedEntityMutatorFactory.ts';
 import type {
   TestEntity,
   TestEntityPrivacyPolicy,
   TestFields,
-} from '../utils/__testfixtures__/TestEntity';
+} from '../utils/__testfixtures__/TestEntity.ts';
 
 describe(ViewerScopedEntityMutatorFactory, () => {
   it('correctly scopes viewer to entity mutations', async () => {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableDisjointRows-test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { StrictEnumField, StringField, UUIDField } from '../../EntityFields';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import { ViewerContext } from '../../ViewerContext';
-import { failedResults, successfulResults } from '../../entityUtils';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
-import { createUnitTestEntityCompanionProvider } from '../../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { StrictEnumField, StringField, UUIDField } from '../../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { failedResults, successfulResults } from '../../entityUtils.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { createUnitTestEntityCompanionProvider } from '../../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe('Two entities backed by the same table', () => {
   test('load by different types', async () => {

--- a/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
+++ b/packages/entity/src/__tests__/cases/TwoEntitySameTableOverlappingRows-test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { StringField, UUIDField } from '../../EntityFields';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
-import { createUnitTestEntityCompanionProvider } from '../../utils/__testfixtures__/createUnitTestEntityCompanionProvider';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { StringField, UUIDField } from '../../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { createUnitTestEntityCompanionProvider } from '../../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe('Two entities backed by the same table', () => {
   test('mutate through different types and keep consistent cache and dataloader', async () => {

--- a/packages/entity/src/__tests__/entityUtils-test.ts
+++ b/packages/entity/src/__tests__/entityUtils-test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   enforceResultsAsync,
-  successfulResults,
   failedResults,
-  successfulResultsFilterMap,
   failedResultsFilterMap,
-  pick,
   partitionArray,
-} from '../entityUtils';
+  pick,
+  successfulResults,
+  successfulResultsFilterMap,
+} from '../entityUtils.ts';
 
 describe(enforceResultsAsync, () => {
   it('throws when any result is an error', async () => {

--- a/packages/entity/src/errors/EntityCacheAdapterError.ts
+++ b/packages/entity/src/errors/EntityCacheAdapterError.ts
@@ -1,4 +1,4 @@
-import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
+import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError.ts';
 
 /**
  * Base class for errors thrown by the entity cache adapter.

--- a/packages/entity/src/errors/EntityDatabaseAdapterError.ts
+++ b/packages/entity/src/errors/EntityDatabaseAdapterError.ts
@@ -1,4 +1,4 @@
-import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
+import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError.ts';
 
 /**
  * Base class for all errors related to the database adapter.

--- a/packages/entity/src/errors/EntityInvalidFieldValueError.ts
+++ b/packages/entity/src/errors/EntityInvalidFieldValueError.ts
@@ -1,8 +1,8 @@
-import type { IEntityClass } from '../Entity';
-import type { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
+import type { IEntityClass } from '../Entity.ts';
+import type { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError.ts';
 
 /**
  * Error thrown when an entity field has an invalid value, either during load or mutation.

--- a/packages/entity/src/errors/EntityNotAuthorizedError.ts
+++ b/packages/entity/src/errors/EntityNotAuthorizedError.ts
@@ -1,7 +1,7 @@
-import { EntityAuthorizationAction } from '../EntityPrivacyPolicy';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
+import { EntityAuthorizationAction } from '../EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError.ts';
 
 /**
  * Error thrown when viewer context is not authorized to perform an action on an entity.

--- a/packages/entity/src/errors/EntityNotFoundError.ts
+++ b/packages/entity/src/errors/EntityNotFoundError.ts
@@ -1,8 +1,8 @@
-import type { IEntityClass } from '../Entity';
-import type { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError';
+import type { IEntityClass } from '../Entity.ts';
+import type { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { EntityError, EntityErrorCode, EntityErrorState } from './EntityError.ts';
 
 type EntityNotFoundOptions<
   TFields extends Record<string, any>,

--- a/packages/entity/src/errors/__tests__/EntityDatabaseAdapterError-test.ts
+++ b/packages/entity/src/errors/__tests__/EntityDatabaseAdapterError-test.ts
@@ -15,8 +15,8 @@ import {
   EntityDatabaseAdapterTransientError,
   EntityDatabaseAdapterUniqueConstraintError,
   EntityDatabaseAdapterUnknownError,
-} from '../EntityDatabaseAdapterError';
-import { EntityErrorCode, EntityErrorState } from '../EntityError';
+} from '../EntityDatabaseAdapterError.ts';
+import { EntityErrorCode, EntityErrorState } from '../EntityError.ts';
 
 describe(EntityDatabaseAdapterError, () => {
   // necessary for coverage within the entity package since these errors are

--- a/packages/entity/src/errors/__tests__/EntityError-test.ts
+++ b/packages/entity/src/errors/__tests__/EntityError-test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from '@jest/globals';
 import { instance, mock } from 'ts-mockito';
 
-import { ViewerContext } from '../../ViewerContext';
-import { SimpleTestEntity } from '../../utils/__testfixtures__/SimpleTestEntity';
-import { EntityCacheAdapterTransientError } from '../EntityCacheAdapterError';
-import { EntityErrorCode, EntityErrorState } from '../EntityError';
-import { EntityInvalidFieldValueError } from '../EntityInvalidFieldValueError';
-import { EntityNotAuthorizedError } from '../EntityNotAuthorizedError';
-import { EntityNotFoundError } from '../EntityNotFoundError';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { SimpleTestEntity } from '../../utils/__testfixtures__/SimpleTestEntity.ts';
+import { EntityCacheAdapterTransientError } from '../EntityCacheAdapterError.ts';
+import { EntityErrorCode, EntityErrorState } from '../EntityError.ts';
+import { EntityInvalidFieldValueError } from '../EntityInvalidFieldValueError.ts';
+import { EntityNotAuthorizedError } from '../EntityNotAuthorizedError.ts';
+import { EntityNotFoundError } from '../EntityNotFoundError.ts';
 
 describe('EntityError subclasses', () => {
   it('EntityNotFoundError has correct state and code', () => {

--- a/packages/entity/src/internal/CompositeFieldHolder.ts
+++ b/packages/entity/src/internal/CompositeFieldHolder.ts
@@ -4,11 +4,11 @@ import type {
   EntityCompositeField,
   EntityCompositeFieldValue,
   EntityConfiguration,
-} from '../EntityConfiguration';
-import { pick } from '../entityUtils';
-import { getDatabaseFieldForEntityField } from './EntityFieldTransformationUtils';
-import type { IEntityLoadKey, IEntityLoadValue } from '../internal/EntityLoadInterfaces';
-import { EntityLoadMethodType, LoadValueMap } from '../internal/EntityLoadInterfaces';
+} from '../EntityConfiguration.ts';
+import { pick } from '../entityUtils.ts';
+import { getDatabaseFieldForEntityField } from './EntityFieldTransformationUtils.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from '../internal/EntityLoadInterfaces.ts';
+import { EntityLoadMethodType, LoadValueMap } from '../internal/EntityLoadInterfaces.ts';
 
 declare const CompositeFieldHolderSerializedBrand: unique symbol;
 

--- a/packages/entity/src/internal/CompositeFieldValueMap.ts
+++ b/packages/entity/src/internal/CompositeFieldValueMap.ts
@@ -1,6 +1,6 @@
-import type { EntityCompositeField, EntityCompositeFieldValue } from '../EntityConfiguration';
-import type { SerializedCompositeFieldValueHolder } from './CompositeFieldHolder';
-import { CompositeFieldValueHolder } from './CompositeFieldHolder';
+import type { EntityCompositeField, EntityCompositeFieldValue } from '../EntityConfiguration.ts';
+import type { SerializedCompositeFieldValueHolder } from './CompositeFieldHolder.ts';
+import { CompositeFieldValueHolder } from './CompositeFieldHolder.ts';
 
 /**
  * @internal

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -1,23 +1,23 @@
 import DataLoader from 'dataloader';
 import invariant from 'invariant';
 
-import type { EntityDatabaseAdapter } from '../EntityDatabaseAdapter';
-import type { EntityQueryContext, EntityTransactionalQueryContext } from '../EntityQueryContext';
-import { TransactionalDataLoaderMode } from '../EntityQueryContext';
-import type { EntityQueryContextProvider } from '../EntityQueryContextProvider';
-import { partitionErrors } from '../entityUtils';
-import type { IEntityLoadKey, IEntityLoadValue, LoadPair } from './EntityLoadInterfaces';
-import type { ReadThroughEntityCache } from './ReadThroughEntityCache';
+import type { EntityDatabaseAdapter } from '../EntityDatabaseAdapter.ts';
+import type { EntityQueryContext, EntityTransactionalQueryContext } from '../EntityQueryContext.ts';
+import { TransactionalDataLoaderMode } from '../EntityQueryContext.ts';
+import type { EntityQueryContextProvider } from '../EntityQueryContextProvider.ts';
+import { partitionErrors } from '../entityUtils.ts';
+import type { IEntityLoadKey, IEntityLoadValue, LoadPair } from './EntityLoadInterfaces.ts';
+import type { ReadThroughEntityCache } from './ReadThroughEntityCache.ts';
 import {
   timeAndLogLoadMapEventAsync,
   timeAndLogLoadOneEventAsync,
-} from '../metrics/EntityMetricsUtils';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
+} from '../metrics/EntityMetricsUtils.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
 import {
   EntityMetricsLoadType,
   IncrementLoadCountEventType,
-} from '../metrics/IEntityMetricsAdapter';
-import { computeIfAbsent } from '../utils/collections/maps';
+} from '../metrics/IEntityMetricsAdapter.ts';
+import { computeIfAbsent } from '../utils/collections/maps.ts';
 
 type DataLoaderMap<TFields extends Record<string, any>> = Map<
   string,

--- a/packages/entity/src/internal/EntityFieldTransformationUtils.ts
+++ b/packages/entity/src/internal/EntityFieldTransformationUtils.ts
@@ -1,7 +1,7 @@
 import nullthrows from '@expo/nullthrows';
 import invariant from 'invariant';
 
-import type { EntityConfiguration } from '../EntityConfiguration';
+import type { EntityConfiguration } from '../EntityConfiguration.ts';
 
 /**
  * @internal

--- a/packages/entity/src/internal/EntityLoadInterfaces.ts
+++ b/packages/entity/src/internal/EntityLoadInterfaces.ts
@@ -1,6 +1,6 @@
-import type { EntityConfiguration } from '../EntityConfiguration';
-import type { ISerializable } from '../utils/collections/SerializableKeyMap';
-import { SerializableKeyMap } from '../utils/collections/SerializableKeyMap';
+import type { EntityConfiguration } from '../EntityConfiguration.ts';
+import type { ISerializable } from '../utils/collections/SerializableKeyMap.ts';
+import { SerializableKeyMap } from '../utils/collections/SerializableKeyMap.ts';
 
 /**
  * Load method type identifier of a load key. Used for keying data loaders and identification in metrics.

--- a/packages/entity/src/internal/EntityTableDataCoordinator.ts
+++ b/packages/entity/src/internal/EntityTableDataCoordinator.ts
@@ -1,12 +1,12 @@
-import type { EntityConfiguration } from '../EntityConfiguration';
-import type { EntityDatabaseAdapter } from '../EntityDatabaseAdapter';
-import type { EntityQueryContextProvider } from '../EntityQueryContextProvider';
-import type { IEntityCacheAdapter } from '../IEntityCacheAdapter';
-import type { IEntityCacheAdapterProvider } from '../IEntityCacheAdapterProvider';
-import type { IEntityDatabaseAdapterProvider } from '../IEntityDatabaseAdapterProvider';
-import { EntityDataManager } from './EntityDataManager';
-import { ReadThroughEntityCache } from './ReadThroughEntityCache';
-import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter';
+import type { EntityConfiguration } from '../EntityConfiguration.ts';
+import type { EntityDatabaseAdapter } from '../EntityDatabaseAdapter.ts';
+import type { EntityQueryContextProvider } from '../EntityQueryContextProvider.ts';
+import type { IEntityCacheAdapter } from '../IEntityCacheAdapter.ts';
+import type { IEntityCacheAdapterProvider } from '../IEntityCacheAdapterProvider.ts';
+import type { IEntityDatabaseAdapterProvider } from '../IEntityDatabaseAdapterProvider.ts';
+import { EntityDataManager } from './EntityDataManager.ts';
+import { ReadThroughEntityCache } from './ReadThroughEntityCache.ts';
+import type { IEntityMetricsAdapter } from '../metrics/IEntityMetricsAdapter.ts';
 
 /**
  * Responsible for orchestrating fetching and caching of entity data from a

--- a/packages/entity/src/internal/ReadThroughEntityCache.ts
+++ b/packages/entity/src/internal/ReadThroughEntityCache.ts
@@ -1,9 +1,9 @@
 import invariant from 'invariant';
 
-import type { EntityConfiguration } from '../EntityConfiguration';
-import type { IEntityCacheAdapter } from '../IEntityCacheAdapter';
-import type { IEntityLoadKey, IEntityLoadValue } from './EntityLoadInterfaces';
-import { filterMap } from '../utils/collections/maps';
+import type { EntityConfiguration } from '../EntityConfiguration.ts';
+import type { IEntityCacheAdapter } from '../IEntityCacheAdapter.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from './EntityLoadInterfaces.ts';
+import { filterMap } from '../utils/collections/maps.ts';
 
 /**
  * @internal

--- a/packages/entity/src/internal/SingleFieldHolder.ts
+++ b/packages/entity/src/internal/SingleFieldHolder.ts
@@ -1,9 +1,9 @@
 import invariant from 'invariant';
 
-import type { EntityConfiguration } from '../EntityConfiguration';
-import { getDatabaseFieldForEntityField } from './EntityFieldTransformationUtils';
-import type { IEntityLoadKey, IEntityLoadValue } from './EntityLoadInterfaces';
-import { EntityLoadMethodType, LoadValueMap } from './EntityLoadInterfaces';
+import type { EntityConfiguration } from '../EntityConfiguration.ts';
+import { getDatabaseFieldForEntityField } from './EntityFieldTransformationUtils.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from './EntityLoadInterfaces.ts';
+import { EntityLoadMethodType, LoadValueMap } from './EntityLoadInterfaces.ts';
 
 /**
  * A load key that represents a single field (fieldName) on an entity.

--- a/packages/entity/src/internal/__tests__/CompositeFieldHolder-test.ts
+++ b/packages/entity/src/internal/__tests__/CompositeFieldHolder-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder';
+import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder.ts';
 
 type TestFields = {
   id: string;

--- a/packages/entity/src/internal/__tests__/CompositeFieldValueMap-test.ts
+++ b/packages/entity/src/internal/__tests__/CompositeFieldValueMap-test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 
-import type { EntityCompositeFieldValue } from '../../EntityConfiguration';
-import { CompositeFieldValueHolder } from '../CompositeFieldHolder';
-import { CompositeFieldValueMap } from '../CompositeFieldValueMap';
+import type { EntityCompositeFieldValue } from '../../EntityConfiguration.ts';
+import { CompositeFieldValueHolder } from '../CompositeFieldHolder.ts';
+import { CompositeFieldValueMap } from '../CompositeFieldValueMap.ts';
 
 describe(CompositeFieldValueMap, () => {
   it('behaves like a ReadonlyMap', () => {

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -10,27 +10,27 @@ import {
   when,
 } from 'ts-mockito';
 
-import type { EntityDatabaseAdapter } from '../../EntityDatabaseAdapter';
-import { TransactionalDataLoaderMode } from '../../EntityQueryContext';
-import type { IEntityMetricsAdapter } from '../../metrics/IEntityMetricsAdapter';
+import type { EntityDatabaseAdapter } from '../../EntityDatabaseAdapter.ts';
+import { TransactionalDataLoaderMode } from '../../EntityQueryContext.ts';
+import type { IEntityMetricsAdapter } from '../../metrics/IEntityMetricsAdapter.ts';
 import {
   EntityMetricsLoadType,
   IncrementLoadCountEventType,
-} from '../../metrics/IEntityMetricsAdapter';
-import { NoOpEntityMetricsAdapter } from '../../metrics/NoOpEntityMetricsAdapter';
+} from '../../metrics/IEntityMetricsAdapter.ts';
+import { NoOpEntityMetricsAdapter } from '../../metrics/NoOpEntityMetricsAdapter.ts';
 import {
   InMemoryFullCacheStubCacheAdapterProvider,
   NoCacheStubCacheAdapterProvider,
-} from '../../utils/__testfixtures__/StubCacheAdapter';
-import { StubDatabaseAdapter } from '../../utils/__testfixtures__/StubDatabaseAdapter';
-import { StubQueryContextProvider } from '../../utils/__testfixtures__/StubQueryContextProvider';
-import type { TestFields } from '../../utils/__testfixtures__/TestEntity';
-import { TestEntity, testEntityConfiguration } from '../../utils/__testfixtures__/TestEntity';
-import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder';
-import { EntityDataManager } from '../EntityDataManager';
-import { EntityLoadMethodType } from '../EntityLoadInterfaces';
-import { ReadThroughEntityCache } from '../ReadThroughEntityCache';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../SingleFieldHolder';
+} from '../../utils/__testfixtures__/StubCacheAdapter.ts';
+import { StubDatabaseAdapter } from '../../utils/__testfixtures__/StubDatabaseAdapter.ts';
+import { StubQueryContextProvider } from '../../utils/__testfixtures__/StubQueryContextProvider.ts';
+import type { TestFields } from '../../utils/__testfixtures__/TestEntity.ts';
+import { TestEntity, testEntityConfiguration } from '../../utils/__testfixtures__/TestEntity.ts';
+import { CompositeFieldHolder, CompositeFieldValueHolder } from '../CompositeFieldHolder.ts';
+import { EntityDataManager } from '../EntityDataManager.ts';
+import { EntityLoadMethodType } from '../EntityLoadInterfaces.ts';
+import { ReadThroughEntityCache } from '../ReadThroughEntityCache.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../SingleFieldHolder.ts';
 
 const getObjects = (): Map<string, TestFields[]> =>
   new Map([

--- a/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityFieldTransformationUtils-test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { StringField, UUIDField } from '../../EntityFields';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { StringField, UUIDField } from '../../EntityFields.ts';
 import {
   getDatabaseFieldForEntityField,
   transformCacheObjectToFields,
   transformDatabaseObjectToFields,
   transformFieldsToCacheObject,
   transformFieldsToDatabaseObject,
-} from '../EntityFieldTransformationUtils';
+} from '../EntityFieldTransformationUtils.ts';
 
 type BlahT = {
   id: string;

--- a/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
+++ b/packages/entity/src/internal/__tests__/ReadThroughEntityCache-test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { UUIDField } from '../../EntityFields';
-import type { IEntityCacheAdapter } from '../../IEntityCacheAdapter';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { UUIDField } from '../../EntityFields.ts';
+import type { IEntityCacheAdapter } from '../../IEntityCacheAdapter.ts';
 import {
   deepEqualEntityAware,
   isEqualWithEntityAware,
-} from '../../utils/__testfixtures__/TSMockitoExtensions';
-import { CacheStatus, ReadThroughEntityCache } from '../ReadThroughEntityCache';
+} from '../../utils/__testfixtures__/TSMockitoExtensions.ts';
+import { CacheStatus, ReadThroughEntityCache } from '../ReadThroughEntityCache.ts';
 import {
   SingleFieldHolder,
   SingleFieldValueHolder,
   SingleFieldValueHolderMap,
-} from '../SingleFieldHolder';
+} from '../SingleFieldHolder.ts';
 
 type BlahFields = {
   id: string;

--- a/packages/entity/src/metrics/EntityMetricsUtils.ts
+++ b/packages/entity/src/metrics/EntityMetricsUtils.ts
@@ -1,11 +1,11 @@
-import type { EntityQueryContext } from '../EntityQueryContext';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
 import type {
   EntityMetricsLoadType,
   EntityMetricsMutationType,
   IEntityMetricsAdapter,
-} from './IEntityMetricsAdapter';
-import type { IEntityLoadValue } from '../internal/EntityLoadInterfaces';
-import { reduceMap } from '../utils/collections/maps';
+} from './IEntityMetricsAdapter.ts';
+import type { IEntityLoadValue } from '../internal/EntityLoadInterfaces.ts';
+import { reduceMap } from '../utils/collections/maps.ts';
 
 export const timeAndLogLoadEventAsync =
   (

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -1,8 +1,8 @@
 import type {
   EntityAuthorizationAction,
   EntityPrivacyPolicyEvaluationMode,
-} from '../EntityPrivacyPolicy';
-import type { EntityLoadMethodType } from '../internal/EntityLoadInterfaces';
+} from '../EntityPrivacyPolicy.ts';
+import type { EntityLoadMethodType } from '../internal/EntityLoadInterfaces.ts';
 
 export enum EntityMetricsLoadType {
   LOAD_MANY,

--- a/packages/entity/src/metrics/NoOpEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/NoOpEntityMetricsAdapter.ts
@@ -4,7 +4,7 @@ import type {
   EntityMetricsMutationEvent,
   IEntityMetricsAdapter,
   IncrementLoadCountEvent,
-} from './IEntityMetricsAdapter';
+} from './IEntityMetricsAdapter.ts';
 
 export class NoOpEntityMetricsAdapter implements IEntityMetricsAdapter {
   logAuthorizationEvent(_authorizationEvent: EntityMetricsAuthorizationEvent): void {}

--- a/packages/entity/src/metrics/__tests__/EntityMetricsUtils-test.ts
+++ b/packages/entity/src/metrics/__tests__/EntityMetricsUtils-test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from '@jest/globals';
 import { anyNumber, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
-import type { EntityQueryContext } from '../../EntityQueryContext';
+import type { EntityQueryContext } from '../../EntityQueryContext.ts';
 import {
   timeAndLogLoadEventAsync,
   timeAndLogLoadMapEventAsync,
   timeAndLogMutationEventAsync,
-} from '../EntityMetricsUtils';
-import type { IEntityMetricsAdapter } from '../IEntityMetricsAdapter';
-import { EntityMetricsLoadType, EntityMetricsMutationType } from '../IEntityMetricsAdapter';
+} from '../EntityMetricsUtils.ts';
+import type { IEntityMetricsAdapter } from '../IEntityMetricsAdapter.ts';
+import { EntityMetricsLoadType, EntityMetricsMutationType } from '../IEntityMetricsAdapter.ts';
 
 describe(timeAndLogLoadEventAsync, () => {
   it('returns the result from the wrapped promise and logs', async () => {

--- a/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
@@ -1,8 +1,8 @@
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 export class AllowIfAllSubRulesAllowPrivacyPolicyRule<
   TFields extends object,

--- a/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts
@@ -1,8 +1,8 @@
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 export class AllowIfAnySubRuleAllowsPrivacyPolicyRule<
   TFields extends object,

--- a/packages/entity/src/rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfInParentCascadeDeletionPrivacyPolicyRule.ts
@@ -1,12 +1,12 @@
-import type { IEntityClass } from '../Entity';
+import type { IEntityClass } from '../Entity.ts';
 import type {
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationContext,
-} from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+} from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 /**
  * Directive for specifying the parent relationship in AllowIfInParentCascadeDeletionPrivacyPolicyRule.

--- a/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysAllowPrivacyPolicyRule.ts
@@ -1,8 +1,8 @@
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 /**
  * Privacy policy rule that always allows.

--- a/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysDenyPrivacyPolicyRule.ts
@@ -1,8 +1,8 @@
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 /**
  * Privacy policy rule that always denies.

--- a/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AlwaysSkipPrivacyPolicyRule.ts
@@ -1,8 +1,8 @@
-import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+import type { EntityPrivacyPolicyEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 /**
  * A no-op policy rule that always skips.

--- a/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts
@@ -1,8 +1,8 @@
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { PrivacyPolicyRule, RuleEvaluationResult } from './PrivacyPolicyRule.ts';
 
 export class EvaluateIfEntityFieldPredicatePrivacyPolicyRule<
   TFields extends object,

--- a/packages/entity/src/rules/PrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/PrivacyPolicyRule.ts
@@ -1,7 +1,7 @@
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
 
 export enum RuleEvaluationResult {
   /**

--- a/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
@@ -1,13 +1,13 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import { AllowIfAllSubRulesAllowPrivacyPolicyRule } from '../AllowIfAllSubRulesAllowPrivacyPolicyRule';
-import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
-import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule';
-import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import { AllowIfAllSubRulesAllowPrivacyPolicyRule } from '../AllowIfAllSubRulesAllowPrivacyPolicyRule.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule.ts';
+import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule.ts';
 
 describePrivacyPolicyRule(
   new AllowIfAllSubRulesAllowPrivacyPolicyRule([

--- a/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAnySubRuleAllowsPrivacyPolicyRule-test.ts
@@ -1,13 +1,13 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import { AllowIfAnySubRuleAllowsPrivacyPolicyRule } from '../AllowIfAnySubRuleAllowsPrivacyPolicyRule';
-import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
-import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule';
-import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import { AllowIfAnySubRuleAllowsPrivacyPolicyRule } from '../AllowIfAnySubRuleAllowsPrivacyPolicyRule.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule.ts';
+import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule.ts';
 
 describePrivacyPolicyRule(
   new AllowIfAnySubRuleAllowsPrivacyPolicyRule([

--- a/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfInParentCascadeDeletionPrivacyPolicyRule-test.ts
@@ -1,12 +1,12 @@
 import { anything, instance, mock, when } from 'ts-mockito';
 
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ReadonlyEntity } from '../../ReadonlyEntity';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import { AllowIfInParentCascadeDeletionPrivacyPolicyRule } from '../AllowIfInParentCascadeDeletionPrivacyPolicyRule';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ReadonlyEntity } from '../../ReadonlyEntity.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import { AllowIfInParentCascadeDeletionPrivacyPolicyRule } from '../AllowIfInParentCascadeDeletionPrivacyPolicyRule.ts';
 
 // Define test field types
 type ParentFields = {

--- a/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysAllowPrivacyPolicyRule-test.ts
@@ -1,10 +1,10 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule.ts';
 
 describePrivacyPolicyRule(new AlwaysAllowPrivacyPolicyRule(), {
   allowCases: [

--- a/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysDenyPrivacyPolicyRule-test.ts
@@ -1,10 +1,10 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../AlwaysDenyPrivacyPolicyRule.ts';
 
 describePrivacyPolicyRule(new AlwaysDenyPrivacyPolicyRule(), {
   denyCases: [

--- a/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AlwaysSkipPrivacyPolicyRule-test.ts
@@ -1,10 +1,10 @@
 import { anything, instance, mock } from 'ts-mockito';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import { AlwaysSkipPrivacyPolicyRule } from '../AlwaysSkipPrivacyPolicyRule.ts';
 
 describePrivacyPolicyRule(new AlwaysSkipPrivacyPolicyRule(), {
   skipCases: [

--- a/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/EvaluateIfEntityFieldPredicatePrivacyPolicyRule-test.ts
@@ -1,13 +1,13 @@
-import { mock, instance, when } from 'ts-mockito';
+import { instance, mock, when } from 'ts-mockito';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils';
-import type { TestFields } from '../../utils/__testfixtures__/TestEntity';
-import { TestEntity } from '../../utils/__testfixtures__/TestEntity';
-import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule';
-import { EvaluateIfEntityFieldPredicatePrivacyPolicyRule } from '../EvaluateIfEntityFieldPredicatePrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { describePrivacyPolicyRule } from '../../utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts';
+import type { TestFields } from '../../utils/__testfixtures__/TestEntity.ts';
+import { TestEntity } from '../../utils/__testfixtures__/TestEntity.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../AlwaysAllowPrivacyPolicyRule.ts';
+import { EvaluateIfEntityFieldPredicatePrivacyPolicyRule } from '../EvaluateIfEntityFieldPredicatePrivacyPolicyRule.ts';
 
 const entityBlahMock = mock(TestEntity);
 when(entityBlahMock.getField('testIndexedField')).thenReturn('1');

--- a/packages/entity/src/utils/EntityCreationUtils.ts
+++ b/packages/entity/src/utils/EntityCreationUtils.ts
@@ -1,10 +1,10 @@
-import type { IEntityClass } from '../Entity';
-import type { EntityPrivacyPolicy } from '../EntityPrivacyPolicy';
-import type { EntityTransactionalQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { EntityDatabaseAdapterUniqueConstraintError } from '../errors/EntityDatabaseAdapterError';
-import { EntityNotFoundError } from '../errors/EntityNotFoundError';
+import type { IEntityClass } from '../Entity.ts';
+import type { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
+import type { EntityTransactionalQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { EntityDatabaseAdapterUniqueConstraintError } from '../errors/EntityDatabaseAdapterError.ts';
+import { EntityNotFoundError } from '../errors/EntityNotFoundError.ts';
 
 /**
  * Create an entity if it doesn't exist, or get the existing entity if it does.

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -1,20 +1,20 @@
 import type { Result } from '@expo/results';
 import { asyncResult } from '@expo/results';
 
-import type { Entity, IEntityClass } from '../Entity';
+import type { Entity, IEntityClass } from '../Entity.ts';
 import {
   EntityEdgeDeletionAuthorizationInferenceBehavior,
   EntityEdgeDeletionBehavior,
-} from '../EntityFieldDefinition';
+} from '../EntityFieldDefinition.ts';
 import type {
   EntityPrivacyPolicy,
   EntityPrivacyPolicyEvaluationContext,
-} from '../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../EntityQueryContext';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
-import { failedResults, partitionArray } from '../entityUtils';
-import { EntityNotAuthorizedError } from '../errors/EntityNotAuthorizedError';
+} from '../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
+import { failedResults, partitionArray } from '../entityUtils.ts';
+import { EntityNotAuthorizedError } from '../errors/EntityNotAuthorizedError.ts';
 
 export type EntityPrivacyEvaluationResultSuccess = {
   allowed: true;

--- a/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
+++ b/packages/entity/src/utils/__testfixtures__/PrivacyPolicyRuleTestUtils.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from '@jest/globals';
 
-import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../../EntityQueryContext';
-import type { ReadonlyEntity } from '../../ReadonlyEntity';
-import type { ViewerContext } from '../../ViewerContext';
-import type { PrivacyPolicyRule } from '../../rules/PrivacyPolicyRule';
-import { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule';
+import type { EntityPrivacyPolicyRuleEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../../ReadonlyEntity.ts';
+import type { ViewerContext } from '../../ViewerContext.ts';
+import type { PrivacyPolicyRule } from '../../rules/PrivacyPolicyRule.ts';
+import { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule.ts';
 
 export interface Case<
   TFields extends Record<string, any>,

--- a/packages/entity/src/utils/__testfixtures__/SimpleTestEntity.ts
+++ b/packages/entity/src/utils/__testfixtures__/SimpleTestEntity.ts
@@ -1,10 +1,10 @@
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { UUIDField } from '../../EntityFields';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import type { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { UUIDField } from '../../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import type { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
 
 export type SimpleTestFields = {
   id: string;

--- a/packages/entity/src/utils/__testfixtures__/StubCacheAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubCacheAdapter.ts
@@ -1,11 +1,11 @@
 import invariant from 'invariant';
 
-import type { EntityConfiguration } from '../../EntityConfiguration';
-import type { IEntityCacheAdapter } from '../../IEntityCacheAdapter';
-import type { IEntityCacheAdapterProvider } from '../../IEntityCacheAdapterProvider';
-import type { IEntityLoadKey, IEntityLoadValue } from '../../internal/EntityLoadInterfaces';
-import type { CacheLoadResult } from '../../internal/ReadThroughEntityCache';
-import { CacheStatus } from '../../internal/ReadThroughEntityCache';
+import type { EntityConfiguration } from '../../EntityConfiguration.ts';
+import type { IEntityCacheAdapter } from '../../IEntityCacheAdapter.ts';
+import type { IEntityCacheAdapterProvider } from '../../IEntityCacheAdapterProvider.ts';
+import type { IEntityLoadKey, IEntityLoadValue } from '../../internal/EntityLoadInterfaces.ts';
+import type { CacheLoadResult } from '../../internal/ReadThroughEntityCache.ts';
+import { CacheStatus } from '../../internal/ReadThroughEntityCache.ts';
 
 export class NoCacheStubCacheAdapterProvider implements IEntityCacheAdapterProvider {
   getCacheAdapter<TFields extends Record<string, any>, TIDField extends keyof TFields>(

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -1,15 +1,15 @@
 import invariant from 'invariant';
 import { v7 as uuidv7 } from 'uuid';
 
-import type { EntityConfiguration } from '../../EntityConfiguration';
-import { EntityDatabaseAdapter } from '../../EntityDatabaseAdapter';
-import { IntField, StringField } from '../../EntityFields';
-import type { FieldTransformerMap } from '../../internal/EntityFieldTransformationUtils';
+import type { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { EntityDatabaseAdapter } from '../../EntityDatabaseAdapter.ts';
+import { IntField, StringField } from '../../EntityFields.ts';
+import type { FieldTransformerMap } from '../../internal/EntityFieldTransformationUtils.ts';
 import {
   getDatabaseFieldForEntityField,
   transformFieldsToDatabaseObject,
-} from '../../internal/EntityFieldTransformationUtils';
-import { computeIfAbsent, mapMap } from '../collections/maps';
+} from '../../internal/EntityFieldTransformationUtils.ts';
+import { computeIfAbsent, mapMap } from '../collections/maps.ts';
 
 export class StubDatabaseAdapter<
   TFields extends Record<string, any>,

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapterProvider.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapterProvider.ts
@@ -1,7 +1,7 @@
-import type { EntityConfiguration } from '../../EntityConfiguration';
-import type { EntityDatabaseAdapter } from '../../EntityDatabaseAdapter';
-import type { IEntityDatabaseAdapterProvider } from '../../IEntityDatabaseAdapterProvider';
-import { StubDatabaseAdapter } from '../__testfixtures__/StubDatabaseAdapter';
+import type { EntityConfiguration } from '../../EntityConfiguration.ts';
+import type { EntityDatabaseAdapter } from '../../EntityDatabaseAdapter.ts';
+import type { IEntityDatabaseAdapterProvider } from '../../IEntityDatabaseAdapterProvider.ts';
+import { StubDatabaseAdapter } from '../__testfixtures__/StubDatabaseAdapter.ts';
 
 export class StubDatabaseAdapterProvider implements IEntityDatabaseAdapterProvider {
   private readonly objectCollection = new Map();

--- a/packages/entity/src/utils/__testfixtures__/StubQueryContextProvider.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubQueryContextProvider.ts
@@ -1,5 +1,5 @@
-import type { TransactionConfig } from '../../EntityQueryContext';
-import { EntityQueryContextProvider } from '../../EntityQueryContextProvider';
+import type { TransactionConfig } from '../../EntityQueryContext.ts';
+import { EntityQueryContextProvider } from '../../EntityQueryContextProvider.ts';
 
 export class StubQueryContextProvider extends EntityQueryContextProvider {
   protected getQueryInterface(): any {

--- a/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
+++ b/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
@@ -1,12 +1,12 @@
-import isEqualWith from 'lodash/isEqualWith';
-import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
+import { isEqualWith } from 'lodash';
+import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher.js';
 
 import {
   CompositeFieldHolder,
   CompositeFieldValueHolder,
-} from '../../internal/CompositeFieldHolder';
-import { SingleFieldHolder, SingleFieldValueHolder } from '../../internal/SingleFieldHolder';
-import { SerializableKeyMap } from '../collections/SerializableKeyMap';
+} from '../../internal/CompositeFieldHolder.ts';
+import { SingleFieldHolder, SingleFieldValueHolder } from '../../internal/SingleFieldHolder.ts';
+import { SerializableKeyMap } from '../collections/SerializableKeyMap.ts';
 
 export function isEqualWithEntityAware(expected: any, actual: any): boolean {
   return isEqualWith(expected, actual, (expected: any, actual: any): boolean | undefined => {

--- a/packages/entity/src/utils/__testfixtures__/TestEntity.ts
+++ b/packages/entity/src/utils/__testfixtures__/TestEntity.ts
@@ -1,13 +1,13 @@
 import type { Result } from '@expo/results';
 import { result } from '@expo/results';
 
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { DateField, IntField, StringField, UUIDField } from '../../EntityFields';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import type { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { DateField, IntField, StringField, UUIDField } from '../../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import type { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
 
 export type TestFields = {
   customIdField: string;

--- a/packages/entity/src/utils/__testfixtures__/TestEntity2.ts
+++ b/packages/entity/src/utils/__testfixtures__/TestEntity2.ts
@@ -1,10 +1,10 @@
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { UUIDField } from '../../EntityFields';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import type { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { UUIDField } from '../../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import type { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
 
 export type Test2Fields = {
   id: string;

--- a/packages/entity/src/utils/__testfixtures__/TestEntityWithMutationTriggers.ts
+++ b/packages/entity/src/utils/__testfixtures__/TestEntityWithMutationTriggers.ts
@@ -1,16 +1,16 @@
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { StringField, UUIDField } from '../../EntityFields';
-import type { EntityTriggerMutationInfo } from '../../EntityMutationInfo';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { StringField, UUIDField } from '../../EntityFields.ts';
+import type { EntityTriggerMutationInfo } from '../../EntityMutationInfo.ts';
 import {
   EntityMutationTrigger,
   EntityNonTransactionalMutationTrigger,
-} from '../../EntityMutationTriggerConfiguration';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../../EntityQueryContext';
-import type { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
+} from '../../EntityMutationTriggerConfiguration.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../../EntityQueryContext.ts';
+import type { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
 
 export type TestMTFields = {
   id: string;

--- a/packages/entity/src/utils/__testfixtures__/TestViewerContext.ts
+++ b/packages/entity/src/utils/__testfixtures__/TestViewerContext.ts
@@ -1,3 +1,3 @@
-import { ViewerContext } from '../../ViewerContext';
+import { ViewerContext } from '../../ViewerContext.ts';
 
 export class TestViewerContext extends ViewerContext {}

--- a/packages/entity/src/utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts
+++ b/packages/entity/src/utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts
@@ -1,9 +1,9 @@
-import { InMemoryFullCacheStubCacheAdapterProvider } from './StubCacheAdapter';
-import { StubDatabaseAdapterProvider } from './StubDatabaseAdapterProvider';
-import { StubQueryContextProvider } from './StubQueryContextProvider';
-import { EntityCompanionProvider } from '../../EntityCompanionProvider';
-import type { IEntityMetricsAdapter } from '../../metrics/IEntityMetricsAdapter';
-import { NoOpEntityMetricsAdapter } from '../../metrics/NoOpEntityMetricsAdapter';
+import { InMemoryFullCacheStubCacheAdapterProvider } from './StubCacheAdapter.ts';
+import { StubDatabaseAdapterProvider } from './StubDatabaseAdapterProvider.ts';
+import { StubQueryContextProvider } from './StubQueryContextProvider.ts';
+import { EntityCompanionProvider } from '../../EntityCompanionProvider.ts';
+import type { IEntityMetricsAdapter } from '../../metrics/IEntityMetricsAdapter.ts';
+import { NoOpEntityMetricsAdapter } from '../../metrics/NoOpEntityMetricsAdapter.ts';
 
 const queryContextProvider = new StubQueryContextProvider();
 

--- a/packages/entity/src/utils/__testfixtures__/describeFieldTestCase.ts
+++ b/packages/entity/src/utils/__testfixtures__/describeFieldTestCase.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import type { EntityFieldDefinition } from '../../EntityFieldDefinition';
+import type { EntityFieldDefinition } from '../../EntityFieldDefinition.ts';
 
 export function describeFieldTestCase<T>(
   fieldDefinition: EntityFieldDefinition<T, any>,

--- a/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import type { EntityTransactionalQueryContext } from '../../EntityQueryContext';
-import { ViewerContext } from '../../ViewerContext';
-import { EntityDatabaseAdapterUniqueConstraintError } from '../../errors/EntityDatabaseAdapterError';
-import { EntityNotFoundError } from '../../errors/EntityNotFoundError';
+import type { EntityTransactionalQueryContext } from '../../EntityQueryContext.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { EntityDatabaseAdapterUniqueConstraintError } from '../../errors/EntityDatabaseAdapterError.ts';
+import { EntityNotFoundError } from '../../errors/EntityNotFoundError.ts';
 import {
   createOrGetExistingAsync,
   createWithUniqueConstraintRecoveryAsync,
-} from '../EntityCreationUtils';
-import { SimpleTestEntity } from '../__testfixtures__/SimpleTestEntity';
-import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../EntityCreationUtils.ts';
+import { SimpleTestEntity } from '../__testfixtures__/SimpleTestEntity.ts';
+import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 type TArgs = object;
 

--- a/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityPrivacyUtils-test.ts
@@ -1,30 +1,30 @@
 import nullthrows from '@expo/nullthrows';
 import { describe, expect, it } from '@jest/globals';
 
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
-import { EntityEdgeDeletionBehavior } from '../../EntityFieldDefinition';
-import { UUIDField } from '../../EntityFields';
-import type { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy';
-import { EntityAuthorizationAction, EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import type { EntityQueryContext } from '../../EntityQueryContext';
-import type { ReadonlyEntity } from '../../ReadonlyEntity';
-import { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
-import { AlwaysDenyPrivacyPolicyRule } from '../../rules/AlwaysDenyPrivacyPolicyRule';
-import { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
+import { EntityEdgeDeletionBehavior } from '../../EntityFieldDefinition.ts';
+import { UUIDField } from '../../EntityFields.ts';
+import type { EntityPrivacyPolicyEvaluationContext } from '../../EntityPrivacyPolicy.ts';
+import { EntityAuthorizationAction, EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import type { EntityQueryContext } from '../../EntityQueryContext.ts';
+import type { ReadonlyEntity } from '../../ReadonlyEntity.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../../rules/AlwaysDenyPrivacyPolicyRule.ts';
+import { RuleEvaluationResult } from '../../rules/PrivacyPolicyRule.ts';
 import type {
   EntityPrivacyEvaluationResult,
   EntityPrivacyEvaluationResultFailure,
-} from '../EntityPrivacyUtils';
+} from '../EntityPrivacyUtils.ts';
 import {
   canViewerDeleteAsync,
   canViewerUpdateAsync,
   getCanViewerDeleteResultAsync,
   getCanViewerUpdateResultAsync,
-} from '../EntityPrivacyUtils';
-import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../EntityPrivacyUtils.ts';
+import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 function assertEntityPrivacyEvaluationResultFailure(
   evaluationResult: EntityPrivacyEvaluationResult,

--- a/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
+++ b/packages/entity/src/utils/__tests__/canViewerDeleteAsync-edgeDeletionPermissionInferenceBehavior-test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { Entity } from '../../Entity';
-import type { EntityCompanionDefinition } from '../../EntityCompanionProvider';
-import { EntityConfiguration } from '../../EntityConfiguration';
+import { Entity } from '../../Entity.ts';
+import type { EntityCompanionDefinition } from '../../EntityCompanionProvider.ts';
+import { EntityConfiguration } from '../../EntityConfiguration.ts';
 import {
   EntityEdgeDeletionAuthorizationInferenceBehavior,
   EntityEdgeDeletionBehavior,
-} from '../../EntityFieldDefinition';
-import { UUIDField } from '../../EntityFields';
-import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy';
-import type { ReadonlyEntity } from '../../ReadonlyEntity';
-import { ViewerContext } from '../../ViewerContext';
-import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule';
-import { AlwaysDenyPrivacyPolicyRule } from '../../rules/AlwaysDenyPrivacyPolicyRule';
-import { canViewerDeleteAsync } from '../EntityPrivacyUtils';
-import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider';
+} from '../../EntityFieldDefinition.ts';
+import { UUIDField } from '../../EntityFields.ts';
+import { EntityPrivacyPolicy } from '../../EntityPrivacyPolicy.ts';
+import type { ReadonlyEntity } from '../../ReadonlyEntity.ts';
+import { ViewerContext } from '../../ViewerContext.ts';
+import { AlwaysAllowPrivacyPolicyRule } from '../../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { AlwaysDenyPrivacyPolicyRule } from '../../rules/AlwaysDenyPrivacyPolicyRule.ts';
+import { canViewerDeleteAsync } from '../EntityPrivacyUtils.ts';
+import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 describe(canViewerDeleteAsync, () => {
   describe('edgeDeletionPermissionInferenceBehavior', () => {

--- a/packages/entity/src/utils/__tests__/mergeEntityMutationTriggerConfigurations-test.ts
+++ b/packages/entity/src/utils/__tests__/mergeEntityMutationTriggerConfigurations-test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { TestMutationTrigger } from '../__testfixtures__/TestEntityWithMutationTriggers';
-import { mergeEntityMutationTriggerConfigurations } from '../mergeEntityMutationTriggerConfigurations';
+import { TestMutationTrigger } from '../__testfixtures__/TestEntityWithMutationTriggers.ts';
+import { mergeEntityMutationTriggerConfigurations } from '../mergeEntityMutationTriggerConfigurations.ts';
 
 describe(mergeEntityMutationTriggerConfigurations, () => {
   it('successfully merges triggers', async () => {

--- a/packages/entity/src/utils/collections/__tests__/SerializableKeyMap-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/SerializableKeyMap-test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
-import type { ISerializable } from '../SerializableKeyMap';
-import { SerializableKeyMap } from '../SerializableKeyMap';
+import type { ISerializable } from '../SerializableKeyMap.ts';
+import { SerializableKeyMap } from '../SerializableKeyMap.ts';
 
 describe(SerializableKeyMap, () => {
   it('behaves as a Map/ReadonlyMap', () => {

--- a/packages/entity/src/utils/collections/__tests__/maps-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/maps-test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   computeIfAbsent,
+  filterMap,
+  invertMap,
+  mapKeys,
   mapMap,
   mapMapAsync,
-  zipToMap,
-  invertMap,
   reduceMap,
-  filterMap,
   reduceMapAsync,
-  mapKeys,
-} from '../maps';
+  zipToMap,
+} from '../maps.ts';
 
 describe(computeIfAbsent, () => {
   it('computes a value when absent', () => {

--- a/packages/entity/src/utils/collections/__tests__/sets-test.ts
+++ b/packages/entity/src/utils/collections/__tests__/sets-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { areSetsEqual } from '../sets';
+import { areSetsEqual } from '../sets.ts';
 
 describe(areSetsEqual, () => {
   it.each([

--- a/packages/entity/src/utils/mergeEntityMutationTriggerConfigurations.ts
+++ b/packages/entity/src/utils/mergeEntityMutationTriggerConfigurations.ts
@@ -1,6 +1,6 @@
-import type { EntityMutationTriggerConfiguration } from '../EntityMutationTriggerConfiguration';
-import type { ReadonlyEntity } from '../ReadonlyEntity';
-import type { ViewerContext } from '../ViewerContext';
+import type { EntityMutationTriggerConfiguration } from '../EntityMutationTriggerConfiguration.ts';
+import type { ReadonlyEntity } from '../ReadonlyEntity.ts';
+import type { ViewerContext } from '../ViewerContext.ts';
 
 function nonNullish<TValue>(value: TValue | null | undefined): value is NonNullable<TValue> {
   return value !== null && value !== undefined;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "${configDir}/build",
-    "sourceMap": true,
-    "rewriteRelativeImportExtensions": true
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
# Why

It's been around for a while, and using it makes our built code a lot easier to read.

# How

- Drop support for node 16 (a breaking change), 
- replace `consistent-type-imports` lint rule with `verbatimModuleSyntax` tsconfig setting
- for every package now complaining that its source uses `import` statements but its a commonjs package, add `"type": "module"` to its package.json file
- add `.ts` to the end of every relative import
- fix ioredis imports
 
# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests!
