### PR TITLE
chore: replace lodash with lodash-es

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   transform: { '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }] },
   // ESM modules that need to be transformed
-  transformIgnorePatterns: ['node_modules/(?!(uuid|@expo)/)'],
+  transformIgnorePatterns: ['node_modules/(?!(uuid|@expo|lodash-es)/)'],
   collectCoverageFrom: [
     'packages/*/src/**',
     '!packages/*/src/index.ts',

--- a/packages/entity-testing-utils/package.json
+++ b/packages/entity-testing-utils/package.json
@@ -29,7 +29,7 @@
   "type": "module",
   "dependencies": {
     "@expo/entity": "workspace:^",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.23",
     "ts-mockito": "^2.6.1"
   },
   "peerDependencies": {
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@jest/globals": "30.2.0",
-    "@types/lodash": "4.17.24",
+    "@types/lodash-es": "4.17.12",
     "@types/node": "24.12.0",
     "typescript": "5.9.3"
   }

--- a/packages/entity-testing-utils/src/TSMockitoExtensions.ts
+++ b/packages/entity-testing-utils/src/TSMockitoExtensions.ts
@@ -5,7 +5,7 @@ import {
   SingleFieldHolder,
   SingleFieldValueHolder,
 } from '@expo/entity';
-import { isEqualWith } from 'lodash';
+import { isEqualWith } from 'lodash-es';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher.js';
 
 export function isEqualWithEntityAware(expected: any, actual: any): boolean {

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -35,9 +35,9 @@
   "devDependencies": {
     "@jest/globals": "30.2.0",
     "@types/invariant": "2.2.37",
-    "@types/lodash": "4.17.24",
+    "@types/lodash-es": "4.17.12",
     "@types/node": "24.12.0",
-    "lodash": "4.17.23",
+    "lodash-es": "4.17.23",
     "ts-mockito": "2.6.1",
     "typescript": "5.9.3",
     "uuid": "13.0.0"

--- a/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
+++ b/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
@@ -1,4 +1,4 @@
-import { isEqualWith } from 'lodash';
+import { isEqualWith } from 'lodash-es';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher.js';
 
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,9 +1854,9 @@ __metadata:
   dependencies:
     "@expo/entity": "workspace:^"
     "@jest/globals": "npm:30.2.0"
-    "@types/lodash": "npm:4.17.24"
+    "@types/lodash-es": "npm:4.17.12"
     "@types/node": "npm:24.12.0"
-    lodash: "npm:^4.17.21"
+    lodash-es: "npm:^4.17.23"
     ts-mockito: "npm:^2.6.1"
     typescript: "npm:5.9.3"
   peerDependencies:
@@ -1871,11 +1871,11 @@ __metadata:
     "@expo/results": "npm:^1.0.0"
     "@jest/globals": "npm:30.2.0"
     "@types/invariant": "npm:2.2.37"
-    "@types/lodash": "npm:4.17.24"
+    "@types/lodash-es": "npm:4.17.12"
     "@types/node": "npm:24.12.0"
     dataloader: "npm:^2.2.3"
     invariant: "npm:^2.2.4"
-    lodash: "npm:4.17.23"
+    lodash-es: "npm:4.17.23"
     ts-mockito: "npm:2.6.1"
     typescript: "npm:5.9.3"
     uuid: "npm:13.0.0"
@@ -3864,7 +3864,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:4.17.24":
+"@types/lodash-es@npm:4.17.12":
+  version: 4.17.12
+  resolution: "@types/lodash-es@npm:4.17.12"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10c0/5d12d2cede07f07ab067541371ed1b838a33edb3c35cb81b73284e93c6fd0c4bbeaefee984e69294bffb53f62d7272c5d679fdba8e595ff71e11d00f2601dde0
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
   version: 4.17.24
   resolution: "@types/lodash@npm:4.17.24"
   checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
@@ -9531,6 +9540,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash-es@npm:4.17.23, lodash-es@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash-es@npm:4.17.23"
+  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -9573,7 +9589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23, lodash@npm:^4.17.21, lodash@npm:^4.17.5":
+"lodash@npm:^4.17.21, lodash@npm:^4.17.5":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6


### PR DESCRIPTION
# Why

This is what esm consumers are supposed to do, and it's required to run jest with ESM.

# How

Drop-in replacement.

# Test Plan

Ran all the ci checks.