### PR TITLE
chore: update renovate to batch and schedule to decrease attention cost

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,13 +6,34 @@
     "customManagers:githubActionsVersions",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "schedule": ["before 9am on monday"],
+  "vulnerabilityAlerts": {
+    "schedule": ["at any time"]
+  },
   "packageRules": [
     {
       "matchFileNames": [
         "packages/entity-example/**",
         "packages/entity-full-integration-tests/**"
       ],
-      "extends": [ ":pinAllExceptPeerDependencies" ]
+      "extends": [":pinAllExceptPeerDependencies"]
+    },
+    {
+      "matchManagers": ["github-actions", "custom.regex"],
+      "matchFileNames": [".github/**"],
+      "groupName": "CI workflows"
+    },
+    {
+      "matchPackagePatterns": ["^eslint"],
+      "groupName": "eslint"
+    },
+    {
+      "matchPackagePatterns": ["^@types/"],
+      "groupName": "type definitions"
+    },
+    {
+      "matchPackagePatterns": ["^jest", "^ts-jest", "^@jest/"],
+      "groupName": "jest"
     }
   ]
 }


### PR DESCRIPTION
# Why

For this repo, I think it's important for things to be up-to-date (not skip any version). It is somewhat of a bellwether of what is coming soon to applications that use this as their ORM.

But, it is quite consuming of attention to have renovate each day.

# How

This changes it to be once-weekly create a batch (except for vulns) and to also group them when possible.

# Test Plan

Inspect. The JSONSchema validates in vscode.