### PR TITLE
fix: remove unused arg from EntityInvalidationUtils

### DIFF
--- a/packages/entity/src/EntityInvalidationUtils.ts
+++ b/packages/entity/src/EntityInvalidationUtils.ts
@@ -1,6 +1,4 @@
-import type { IEntityClass } from './Entity.ts';
 import type { EntityConfiguration } from './EntityConfiguration.ts';
-import type { EntityPrivacyPolicy } from './EntityPrivacyPolicy.ts';
 import type { EntityTransactionalQueryContext } from './EntityQueryContext.ts';
 import type { ReadonlyEntity } from './ReadonlyEntity.ts';
 import type { ViewerContext } from './ViewerContext.ts';
@@ -18,25 +16,10 @@ export class EntityInvalidationUtils<
   TIDField extends keyof NonNullable<Pick<TFields, TSelectedFields>>,
   TViewerContext extends ViewerContext,
   TEntity extends ReadonlyEntity<TFields, TIDField, TViewerContext, TSelectedFields>,
-  TPrivacyPolicy extends EntityPrivacyPolicy<
-    TFields,
-    TIDField,
-    TViewerContext,
-    TEntity,
-    TSelectedFields
-  >,
   TSelectedFields extends keyof TFields,
 > {
   constructor(
     private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
-    _entityClass: IEntityClass<
-      TFields,
-      TIDField,
-      TViewerContext,
-      TEntity,
-      TPrivacyPolicy,
-      TSelectedFields
-    >,
     private readonly dataManager: EntityDataManager<TFields, TIDField>,
     protected readonly metricsAdapter: IEntityMetricsAdapter,
   ) {}

--- a/packages/entity/src/EntityLoaderFactory.ts
+++ b/packages/entity/src/EntityLoaderFactory.ts
@@ -47,12 +47,10 @@ export class EntityLoaderFactory<
     TIDField,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy,
     TSelectedFields
   > {
     return new EntityInvalidationUtils(
       this.entityCompanion.entityCompanionDefinition.entityConfiguration,
-      this.entityCompanion.entityCompanionDefinition.entityClass,
       this.dataManager,
       this.metricsAdapter,
     );

--- a/packages/entity/src/ReadonlyEntity.ts
+++ b/packages/entity/src/ReadonlyEntity.ts
@@ -257,14 +257,7 @@ export abstract class ReadonlyEntity<
       TMSelectedFields
     >,
     viewerContext: TMViewerContext2,
-  ): EntityInvalidationUtils<
-    TMFields,
-    TMIDField,
-    TMViewerContext,
-    TMEntity,
-    TMPrivacyPolicy,
-    TMSelectedFields
-  > {
+  ): EntityInvalidationUtils<TMFields, TMIDField, TMViewerContext, TMEntity, TMSelectedFields> {
     return viewerContext
       .getViewerScopedEntityCompanionForClass(this)
       .getLoaderFactory()

--- a/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
+++ b/packages/entity/src/ViewerScopedEntityLoaderFactory.ts
@@ -44,7 +44,6 @@ export class ViewerScopedEntityLoaderFactory<
     TIDField,
     TViewerContext,
     TEntity,
-    TPrivacyPolicy,
     TSelectedFields
   > {
     return this.entityLoaderFactory.invalidationUtils();

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityLoader-test.ts
@@ -409,7 +409,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     const id1 = uuidv4();
     const invalidationUtils = new EntityInvalidationUtils(
       testEntityConfiguration,
-      TestEntity,
       dataManagerInstance,
       metricsAdapter,
     );
@@ -488,7 +487,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
 
     const invalidationUtils = new EntityInvalidationUtils(
       testEntityConfiguration,
-      TestEntity,
       dataManagerInstance,
       metricsAdapter,
     );
@@ -560,7 +558,6 @@ describe(AuthorizationResultBasedEntityLoader, () => {
     await new StubQueryContextProvider().runInTransactionAsync(async (queryContext) => {
       const invalidationUtils = new EntityInvalidationUtils(
         testEntityConfiguration,
-        TestEntity,
         dataManagerInstance,
         metricsAdapter,
       );


### PR DESCRIPTION
# Why

This argument was unused, remove it.

# How

Was checking whether EntityInvalidationUtils was the same instance (or same behaviorally) across multiple entities backed by the same table (share a config, different TSelectedFields). Being able to remove this arg proves it since the other args aren't entity-type-specific and are only configuration-specitic.

# Test Plan

`yarn tsc`