### PR TITLE
fix: only throw EntityDatabaseAdapterPaginationCursorInvalidError from cursor decoding logic

### DIFF
--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -2196,6 +2196,32 @@ describe('postgres entity integration', () => {
             },
           }),
         ).rejects.toThrow("Cursor is missing required 'id' field.");
+
+        // Try with valid base64-encoded JSON that decodes to a non-object primitive
+        const primitiveCursor = Buffer.from(JSON.stringify(12345)).toString('base64url');
+        await expect(
+          PostgresTestEntity.knexLoader(vc).loadPageAsync({
+            first: 10,
+            after: primitiveCursor,
+            pagination: {
+              strategy: PaginationStrategy.STANDARD,
+              orderBy: [],
+            },
+          }),
+        ).rejects.toThrow("Cursor is missing required 'id' field.");
+
+        // Try with valid base64-encoded JSON string primitive
+        const stringPrimitiveCursor = Buffer.from(JSON.stringify('hello')).toString('base64url');
+        await expect(
+          PostgresTestEntity.knexLoader(vc).loadPageAsync({
+            first: 10,
+            after: stringPrimitiveCursor,
+            pagination: {
+              strategy: PaginationStrategy.STANDARD,
+              orderBy: [],
+            },
+          }),
+        ).rejects.toThrow("Cursor is missing required 'id' field.");
       });
 
       it('performs pagination with both loader types', async () => {

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -559,6 +559,7 @@ export class EntityKnexDataManager<
 
   private decodeOpaqueCursor(cursor: string): TFields[TIDField] {
     let parsedCursor: any;
+
     try {
       const decoded = Buffer.from(cursor, 'base64url').toString();
       parsedCursor = JSON.parse(decoded);
@@ -569,13 +570,13 @@ export class EntityKnexDataManager<
       );
     }
 
-    if (!('id' in parsedCursor)) {
-      throw new EntityDatabaseAdapterPaginationCursorInvalidError(
-        `Cursor is missing required 'id' field. Parsed cursor: ${JSON.stringify(parsedCursor)}`,
-      );
+    if (typeof parsedCursor === 'object' && 'id' in parsedCursor) {
+      return parsedCursor.id;
     }
 
-    return parsedCursor.id;
+    throw new EntityDatabaseAdapterPaginationCursorInvalidError(
+      `Cursor is missing required 'id' field. Parsed cursor: ${JSON.stringify(parsedCursor)}`,
+    );
   }
 
   private resolveSearchFieldToSQLFragment(


### PR DESCRIPTION
# Why

Noticed that this could throw a TypeError if the decoded JSON wasn't an object:

> TypeError: Cannot use 'in' operator to search for 'id' in blah

# How

Add check that this is an object type ahead of using `in` operator.

# Test Plan

Add new tests for this, run them.