### PR TITLE
feat: add `updateWithoutReloadingAsync` to skip `RETURNING *` and post-update reload

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -278,6 +278,34 @@ export class StubPostgresDatabaseAdapter<
     return [objectCollection[objectIndex]];
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number> {
+    if (Object.keys(object).length === 0) {
+      throw new Error(`Empty update (${tableIdField} = ${id})`);
+    }
+
+    const objectCollection = this.getObjectCollectionForTable(tableName);
+
+    const objectIndex = objectCollection.findIndex((obj) => {
+      return obj[tableIdField] === id;
+    });
+
+    if (objectIndex < 0) {
+      return 0;
+    }
+
+    objectCollection[objectIndex] = {
+      ...objectCollection[objectIndex],
+      ...object,
+    };
+    return 1;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     tableName: string,

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -646,6 +646,86 @@ describe(StubPostgresDatabaseAdapter, () => {
     });
   });
 
+  describe('updateWithoutReturningAsync', () => {
+    it('updates a record and returns void', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubPostgresDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 3,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+      await databaseAdapter.updateWithoutReturningAsync(queryContext, 'customIdField', 'hello', {
+        stringField: 'b',
+      });
+
+      const reloaded = await databaseAdapter.fetchManyWhereAsync(
+        queryContext,
+        new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
+        [new SingleFieldValueHolder('hello')],
+      );
+      expect(reloaded.get(new SingleFieldValueHolder('hello'))).toMatchObject([
+        { stringField: 'b' },
+      ]);
+    });
+
+    it('throws error when empty update', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubPostgresDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 3,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+      await expect(
+        databaseAdapter.updateWithoutReturningAsync(queryContext, 'customIdField', 'hello', {}),
+      ).rejects.toThrow('Empty update (custom_id = hello)');
+    });
+
+    it('throws error when updating nonexistent record', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        new Map(),
+      );
+      await expect(
+        databaseAdapter.updateWithoutReturningAsync(queryContext, 'customIdField', 'nope', {
+          stringField: 'b',
+        }),
+      ).rejects.toThrow('Empty results from database adapter update');
+    });
+  });
+
   describe('deleteAsync', () => {
     it('deletes an object', async () => {
       const queryContext = instance(mock(EntityQueryContext));

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -263,6 +263,18 @@ export class PostgresEntityDatabaseAdapter<
     );
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number> {
+    return await wrapNativePostgresCallAsync(() =>
+      queryInterface.update(object).into(tableName).where(tableIdField, id),
+    );
+  }
+
   protected async deleteInternalAsync(
     queryInterface: Knex,
     tableName: string,

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -84,6 +84,21 @@ describe('postgres entity integration', () => {
     ).rejects.toThrow(EntityDatabaseAdapterEmptyUpdateResultError);
   });
 
+  it('supports updateWithoutReloadingAsync', async () => {
+    const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+    const entity = await PostgresTestEntity.creator(vc)
+      .setField('name', 'hello')
+      .setField('hasACat', false)
+      .createAsync();
+
+    await PostgresTestEntity.updater(entity)
+      .setField('hasACat', true)
+      .updateWithoutReloadingAsync();
+
+    const loadedEntity = await PostgresTestEntity.loader(vc).loadByIDAsync(entity.getID());
+    expect(loadedEntity.getField('hasACat')).toBe(true);
+  });
+
   describe('empty creates and updates', () => {
     it('allows empty create', async () => {
       const vc = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));

--- a/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
@@ -120,6 +120,16 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
     return this.updateResults;
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _tableIdField: string,
+    _id: any,
+    _object: object,
+  ): Promise<number> {
+    return this.updateResults.length;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     _tableName: string,

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -279,6 +279,34 @@ export class StubPostgresDatabaseAdapter<
     return [objectCollection[objectIndex]];
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number> {
+    if (Object.keys(object).length === 0) {
+      throw new Error(`Empty update (${tableIdField} = ${id})`);
+    }
+
+    const objectCollection = this.getObjectCollectionForTable(tableName);
+
+    const objectIndex = objectCollection.findIndex((obj) => {
+      return obj[tableIdField] === id;
+    });
+
+    if (objectIndex < 0) {
+      return 0;
+    }
+
+    objectCollection[objectIndex] = {
+      ...objectCollection[objectIndex],
+      ...object,
+    };
+    return 1;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     tableName: string,

--- a/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
+++ b/packages/entity-example/src/adapters/InMemoryDatabaseAdapter.ts
@@ -108,6 +108,32 @@ class InMemoryDatabaseAdapter<
     return [dbObjects[objectIndex]];
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number> {
+    if (Object.keys(object).length === 0) {
+      throw new Error(`Empty update (${tableIdField} = ${id})`);
+    }
+
+    const objectIndex = dbObjects.findIndex((obj) => {
+      return obj[tableIdField] === id;
+    });
+
+    if (objectIndex < 0) {
+      return 0;
+    }
+
+    dbObjects[objectIndex] = {
+      ...dbObjects[objectIndex],
+      ...object,
+    };
+    return 1;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     _tableName: string,

--- a/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
@@ -160,6 +160,37 @@ export class StubDatabaseAdapter<
     return [objectCollection[objectIndex]];
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number> {
+    // SQL does not support empty updates, mirror behavior here for better test simulation
+    if (Object.keys(object).length === 0) {
+      throw new Error(`Empty update (${tableIdField} = ${id})`);
+    }
+
+    const objectCollection = this.getObjectCollectionForTable(tableName);
+
+    const objectIndex = objectCollection.findIndex((obj) => {
+      return obj[tableIdField] === id;
+    });
+
+    // SQL updates to a nonexistent row succeed but affect 0 rows,
+    // mirror that behavior here for better test simulation
+    if (objectIndex < 0) {
+      return 0;
+    }
+
+    objectCollection[objectIndex] = {
+      ...objectCollection[objectIndex],
+      ...object,
+    };
+    return 1;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     tableName: string,

--- a/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
@@ -535,6 +535,48 @@ export class AuthorizationResultBasedUpdateMutator<
     )(this.updateInTransactionAsync(false));
   }
 
+  /**
+   * Commit the changes to the entity after authorizing against update privacy rules.
+   * Unlike {@link updateAsync}, this method does not reload the entity from the database
+   * after the update. This is useful for fire-and-forget writes where the caller
+   * discards the result.
+   *
+   * The UPDATE query omits RETURNING *, and the post-update SELECT is skipped.
+   * Authorization, validators, before-triggers, and cache invalidation still run.
+   *
+   * @throws if the entity has `afterUpdate`, `afterAll`, or `afterCommit` triggers,
+   * since those triggers would be silently skipped without a reload
+   * @returns void result, where result error can be UnauthorizedError
+   */
+  async updateWithoutReloadingAsync(): Promise<Result<void>> {
+    const skippedTriggerKinds: string[] = [];
+    if (this.mutationTriggers.afterUpdate?.length) {
+      skippedTriggerKinds.push('afterUpdate');
+    }
+    if (this.mutationTriggers.afterAll?.length) {
+      skippedTriggerKinds.push('afterAll');
+    }
+    if (this.mutationTriggers.afterCommit?.length) {
+      skippedTriggerKinds.push('afterCommit');
+    }
+    if (skippedTriggerKinds.length > 0) {
+      throw new Error(
+        `${this.entityClass.name}.updateWithoutReloadingAsync cannot be used when the entity has triggers that run after an update (${skippedTriggerKinds.join(', ')}). Use updateAsync instead.`,
+      );
+    }
+
+    return await timeAndLogMutationEventAsync(
+      this.metricsAdapter,
+      EntityMetricsMutationType.UPDATE,
+      this.entityClass.name,
+      this.queryContext,
+    )(
+      this.queryContext.runInTransactionIfNotInTransactionAsync((innerQueryContext) =>
+        this.updateWithoutReloadingInternalAsync(innerQueryContext),
+      ),
+    );
+  }
+
   private async updateInTransactionAsync(skipDatabaseUpdate: boolean): Promise<Result<TEntity>> {
     return await this.queryContext.runInTransactionIfNotInTransactionAsync((innerQueryContext) =>
       this.updateInternalAsync(innerQueryContext, skipDatabaseUpdate),
@@ -682,6 +724,95 @@ export class AuthorizationResultBasedUpdateMutator<
     );
 
     return result(updatedEntity);
+  }
+
+  private async updateWithoutReloadingInternalAsync(
+    queryContext: EntityTransactionalQueryContext,
+  ): Promise<Result<void>> {
+    this.validateFields(this.updatedFields);
+    this.ensureStableIDField(this.updatedFields);
+
+    const invalidationUtils = this.entityLoaderFactory.invalidationUtils();
+    const constructionUtils = this.entityLoaderFactory.constructionUtils(
+      this.viewerContext,
+      queryContext,
+      {
+        previousValue: this.originalEntity,
+        cascadingDeleteCause: this.cascadingDeleteCause,
+      },
+    );
+
+    const entityAboutToBeUpdated = constructionUtils.constructEntity(this.fieldsForEntity);
+    const authorizeUpdateResult = await asyncResult(
+      this.privacyPolicy.authorizeUpdateAsync(
+        this.viewerContext,
+        queryContext,
+        { previousValue: this.originalEntity, cascadingDeleteCause: this.cascadingDeleteCause },
+        entityAboutToBeUpdated,
+        this.metricsAdapter,
+      ),
+    );
+    if (!authorizeUpdateResult.ok) {
+      return authorizeUpdateResult;
+    }
+
+    await this.executeMutationValidatorsAsync(
+      this.mutationValidators.beforeCreateAndUpdate,
+      queryContext,
+      entityAboutToBeUpdated,
+      {
+        type: EntityMutationType.UPDATE,
+        previousValue: this.originalEntity,
+        cascadingDeleteCause: this.cascadingDeleteCause,
+      },
+    );
+    await this.executeMutationTriggersAsync(
+      this.mutationTriggers.beforeAll,
+      queryContext,
+      entityAboutToBeUpdated,
+      {
+        type: EntityMutationType.UPDATE,
+        previousValue: this.originalEntity,
+        cascadingDeleteCause: this.cascadingDeleteCause,
+      },
+    );
+    await this.executeMutationTriggersAsync(
+      this.mutationTriggers.beforeUpdate,
+      queryContext,
+      entityAboutToBeUpdated,
+      {
+        type: EntityMutationType.UPDATE,
+        previousValue: this.originalEntity,
+        cascadingDeleteCause: this.cascadingDeleteCause,
+      },
+    );
+
+    await this.databaseAdapter.updateWithoutReturningAsync(
+      queryContext,
+      this.entityConfiguration.idField,
+      entityAboutToBeUpdated.getID(),
+      this.updatedFields,
+    );
+
+    queryContext.appendPostCommitInvalidationCallback(async () => {
+      invalidationUtils.invalidateFieldsForTransaction(
+        queryContext,
+        this.originalEntity.getAllDatabaseFields(),
+      );
+      invalidationUtils.invalidateFieldsForTransaction(queryContext, this.fieldsForEntity);
+      await Promise.all([
+        invalidationUtils.invalidateFieldsAsync(this.originalEntity.getAllDatabaseFields()),
+        invalidationUtils.invalidateFieldsAsync(this.fieldsForEntity),
+      ]);
+    });
+
+    invalidationUtils.invalidateFieldsForTransaction(
+      queryContext,
+      this.originalEntity.getAllDatabaseFields(),
+    );
+    invalidationUtils.invalidateFieldsForTransaction(queryContext, this.fieldsForEntity);
+
+    return result(undefined);
   }
 
   private ensureStableIDField(updatedFields: Partial<TFields>): void {

--- a/packages/entity/src/EnforcingEntityUpdater.ts
+++ b/packages/entity/src/EnforcingEntityUpdater.ts
@@ -52,4 +52,20 @@ export class EnforcingEntityUpdater<
   async updateAsync(): Promise<TEntity> {
     return await enforceAsyncResult(this.entityUpdater.updateAsync());
   }
+
+  /**
+   * Commit the changes to the entity after authorizing against update privacy rules.
+   * Unlike {@link updateAsync}, this method does not reload the entity from the database
+   * after the update. This is useful for fire-and-forget writes where the caller
+   * discards the result.
+   *
+   * Authorization, validators, before-triggers, and cache invalidation still run.
+   *
+   * @throws if the entity has `afterUpdate`, `afterAll`, or `afterCommit` triggers,
+   * since those triggers would be silently skipped without a reload
+   * @throws upon authorization failure
+   */
+  async updateWithoutReloadingAsync(): Promise<void> {
+    await enforceAsyncResult(this.entityUpdater.updateWithoutReloadingAsync());
+  }
 }

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -244,6 +244,42 @@ export abstract class EntityDatabaseAdapter<
     );
   }
 
+  /**
+   * Update an object without returning the updated row.
+   *
+   * @param queryContext - query context with which to perform the update
+   * @param idField - the field in the object that is the ID
+   * @param id - the value of the ID field in the object
+   * @param object - the object to update
+   */
+  async updateWithoutReturningAsync<K extends keyof TFields>(
+    queryContext: EntityQueryContext,
+    idField: K,
+    id: any,
+    object: Readonly<Partial<TFields>>,
+  ): Promise<void> {
+    const idColumn = getDatabaseFieldForEntityField(this.entityConfiguration, idField);
+    const dbObject = transformFieldsToDatabaseObject(
+      this.entityConfiguration,
+      this.fieldTransformerMap,
+      object,
+    );
+    const updatedCount = await this.updateWithoutReturningInternalAsync(
+      queryContext.getQueryInterface(),
+      this.entityConfiguration.tableName,
+      idColumn,
+      id,
+      dbObject,
+    );
+
+    if (updatedCount === 0) {
+      // This happens when the object to update does not exist. It may have been deleted by another process.
+      throw new EntityDatabaseAdapterEmptyUpdateResultError(
+        `Empty results from database adapter update: ${this.entityConfiguration.tableName}(id = ${id})`,
+      );
+    }
+  }
+
   protected abstract updateInternalAsync(
     queryInterface: any,
     tableName: string,
@@ -251,6 +287,14 @@ export abstract class EntityDatabaseAdapter<
     id: any,
     object: object,
   ): Promise<object[]>;
+
+  protected abstract updateWithoutReturningInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number>;
 
   /**
    * Delete an object by ID.

--- a/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
+++ b/packages/entity/src/__tests__/EntityDatabaseAdapter-test.ts
@@ -87,6 +87,16 @@ class TestEntityDatabaseAdapter extends EntityDatabaseAdapter<TestFields, 'custo
     return this.updateResults;
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _tableIdField: string,
+    _id: any,
+    _object: object,
+  ): Promise<number> {
+    return this.updateResults.length;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     _tableName: string,
@@ -279,6 +289,26 @@ describe(EntityDatabaseAdapter, () => {
       await expect(adapter.updateAsync(queryContext, 'customIdField', 'wat', {})).rejects.toThrow(
         EntityDatabaseAdapterExcessiveUpdateResultError,
       );
+    });
+  });
+
+  describe('updateWithoutReturningAsync', () => {
+    it('succeeds when update count is 1', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const adapter = new TestEntityDatabaseAdapter({
+        updateResults: [{ string_field: 'hello' }],
+      });
+      await expect(
+        adapter.updateWithoutReturningAsync(queryContext, 'customIdField', 'wat', {}),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws when update count is zero', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const adapter = new TestEntityDatabaseAdapter({ updateResults: [] });
+      await expect(
+        adapter.updateWithoutReturningAsync(queryContext, 'customIdField', 'wat', {}),
+      ).rejects.toThrow(EntityDatabaseAdapterEmptyUpdateResultError);
     });
   });
 

--- a/packages/entity/src/__tests__/EntityMutator-test.ts
+++ b/packages/entity/src/__tests__/EntityMutator-test.ts
@@ -14,6 +14,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { AuthorizationResultBasedEntityLoader } from '../AuthorizationResultBasedEntityLoader.ts';
+import { EnforcingEntityUpdater } from '../EnforcingEntityUpdater.ts';
 import { EntityCompanionProvider } from '../EntityCompanionProvider.ts';
 import type { EntityConfiguration } from '../EntityConfiguration.ts';
 import { EntityConstructionUtils } from '../EntityConstructionUtils.ts';
@@ -298,6 +299,13 @@ const verifyTriggerCounts = (
 
 const createEntityMutatorFactory = (
   existingObjects: TestFields[],
+  mutationTriggersOverride?: EntityMutationTriggerConfiguration<
+    TestFields,
+    'customIdField',
+    ViewerContext,
+    TestEntity,
+    keyof TestFields
+  >,
 ): {
   privacyPolicy: TestEntityPrivacyPolicy;
   entityLoaderFactory: EntityLoaderFactory<
@@ -347,7 +355,7 @@ const createEntityMutatorFactory = (
     ViewerContext,
     TestEntity,
     keyof TestFields
-  > = {
+  > = mutationTriggersOverride ?? {
     beforeCreate: [new TestMutationTrigger()],
     afterCreate: [new TestMutationTrigger()],
     beforeUpdate: [new TestMutationTrigger()],
@@ -1043,6 +1051,148 @@ describe(EntityMutatorFactory, () => {
       );
       expect(reloadedEntity.getAllFields()).toMatchObject(existingEntity.getAllFields());
     });
+
+    it('updateWithoutReloadingAsync throws when entity has after-triggers', async () => {
+      const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestFields,
+              'customIdField',
+              ViewerContext,
+              TestEntity,
+              keyof TestFields
+            >
+          >(),
+        );
+      const queryContext = new StubQueryContextProvider().getQueryContext();
+
+      const id1 = uuidv4();
+      const { entityMutatorFactory, entityLoaderFactory } = createEntityMutatorFactory([
+        {
+          customIdField: id1,
+          stringField: 'huh',
+          testIndexedField: '4',
+          intField: 3,
+          dateField: new Date(),
+          nullableField: null,
+        },
+      ]);
+
+      const existingEntity = await enforceAsyncResult(
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1),
+      );
+
+      await expect(
+        entityMutatorFactory
+          .forUpdate(existingEntity, queryContext, /* cascadingDeleteCause */ null)
+          .setField('stringField', 'huh2')
+          .updateWithoutReloadingAsync(),
+      ).rejects.toThrow(
+        'TestEntity.updateWithoutReloadingAsync cannot be used when the entity has triggers that run after an update (afterUpdate, afterAll, afterCommit)',
+      );
+
+      // Ensure no writes happened
+      const reloadedEntity = await enforceAsyncResult(
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1),
+      );
+      expect(reloadedEntity.getField('stringField')).toEqual('huh');
+    });
+
+    it('updateWithoutReloadingAsync persists update when entity has no after-triggers', async () => {
+      const viewerContext = mock<ViewerContext>();
+      const privacyPolicyEvaluationContext =
+        instance(
+          mock<
+            EntityPrivacyPolicyEvaluationContext<
+              TestFields,
+              'customIdField',
+              ViewerContext,
+              TestEntity,
+              keyof TestFields
+            >
+          >(),
+        );
+      const queryContext = new StubQueryContextProvider().getQueryContext();
+
+      const id1 = uuidv4();
+      const id2 = uuidv4();
+      const { entityMutatorFactory, entityLoaderFactory } = createEntityMutatorFactory(
+        [
+          {
+            customIdField: id1,
+            stringField: 'huh',
+            testIndexedField: '4',
+            intField: 3,
+            dateField: new Date(),
+            nullableField: null,
+          },
+          {
+            customIdField: id2,
+            stringField: 'huh',
+            testIndexedField: '5',
+            intField: 3,
+            dateField: new Date(),
+            nullableField: null,
+          },
+        ],
+        {
+          beforeUpdate: [new TestMutationTrigger()],
+          beforeAll: [new TestMutationTrigger()],
+        },
+      );
+
+      // Test result-based API
+      const existingEntity = await enforceAsyncResult(
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1),
+      );
+
+      const updateResult = await entityMutatorFactory
+        .forUpdate(existingEntity, queryContext, /* cascadingDeleteCause */ null)
+        .setField('stringField', 'huh2')
+        .updateWithoutReloadingAsync();
+
+      expect(updateResult.ok).toBe(true);
+      expect(updateResult.value).toBeUndefined();
+
+      const reloadedEntity = await enforceAsyncResult(
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id1),
+      );
+      expect(reloadedEntity.getField('stringField')).toEqual('huh2');
+
+      // Test enforcing API
+      const existingEntity2 = await enforceAsyncResult(
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2),
+      );
+
+      await new EnforcingEntityUpdater(
+        entityMutatorFactory.forUpdate(
+          existingEntity2,
+          queryContext,
+          /* cascadingDeleteCause */ null,
+        ),
+      )
+        .setField('stringField', 'huh3')
+        .updateWithoutReloadingAsync();
+
+      const reloadedEntity2 = await enforceAsyncResult(
+        entityLoaderFactory
+          .forLoad(viewerContext, queryContext, privacyPolicyEvaluationContext)
+          .loadByIDAsync(id2),
+      );
+      expect(reloadedEntity2.getField('stringField')).toEqual('huh3');
+    });
   });
 
   describe('forDelete', () => {
@@ -1592,6 +1742,13 @@ describe(EntityMutatorFactory, () => {
     expect(entityUpdateResult.reason).toEqual(rejectionError);
     expect(entityUpdateResult.value).toBe(undefined);
 
+    const entityUpdateWithoutReloadingResult = await entityMutatorFactory
+      .forUpdate(fakeEntity, queryContext, /* cascadingDeleteCause */ null)
+      .updateWithoutReloadingAsync();
+    expect(entityUpdateWithoutReloadingResult.ok).toBe(false);
+    expect(entityUpdateWithoutReloadingResult.reason).toEqual(rejectionError);
+    expect(entityUpdateWithoutReloadingResult.value).toBe(undefined);
+
     const entityDeleteResult = await entityMutatorFactory
       .forDelete(fakeEntity, queryContext, /* cascadingDeleteCause */ null)
       .deleteAsync();
@@ -1691,6 +1848,14 @@ describe(EntityMutatorFactory, () => {
       ),
     ).thenReject(rejectionError);
     when(
+      databaseAdapterMock.updateWithoutReturningAsync(
+        anyOfClass(EntityTransactionalQueryContext),
+        anything(),
+        anything(),
+        anything(),
+      ),
+    ).thenReject(rejectionError);
+    when(
       databaseAdapterMock.deleteAsync(
         anyOfClass(EntityTransactionalQueryContext),
         anything(),
@@ -1717,6 +1882,11 @@ describe(EntityMutatorFactory, () => {
       entityMutatorFactory
         .forUpdate(fakeEntity, queryContext, /* cascadingDeleteCause */ null)
         .updateAsync(),
+    ).rejects.toEqual(rejectionError);
+    await expect(
+      entityMutatorFactory
+        .forUpdate(fakeEntity, queryContext, /* cascadingDeleteCause */ null)
+        .updateWithoutReloadingAsync(),
     ).rejects.toEqual(rejectionError);
     await expect(
       entityMutatorFactory

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -160,6 +160,37 @@ export class StubDatabaseAdapter<
     return [objectCollection[objectIndex]];
   }
 
+  protected async updateWithoutReturningInternalAsync(
+    _queryInterface: any,
+    tableName: string,
+    tableIdField: string,
+    id: any,
+    object: object,
+  ): Promise<number> {
+    // SQL does not support empty updates, mirror behavior here for better test simulation
+    if (Object.keys(object).length === 0) {
+      throw new Error(`Empty update (${tableIdField} = ${id})`);
+    }
+
+    const objectCollection = this.getObjectCollectionForTable(tableName);
+
+    const objectIndex = objectCollection.findIndex((obj) => {
+      return obj[tableIdField] === id;
+    });
+
+    // SQL updates to a nonexistent row succeed but affect 0 rows,
+    // mirror that behavior here for better test simulation
+    if (objectIndex < 0) {
+      return 0;
+    }
+
+    objectCollection[objectIndex] = {
+      ...objectCollection[objectIndex],
+      ...object,
+    };
+    return 1;
+  }
+
   protected async deleteInternalAsync(
     _queryInterface: any,
     tableName: string,


### PR DESCRIPTION
## Summary

`updateAsync` always generates `UPDATE ... RETURNING *`, then issues a second `SELECT` to reload the entity for after-triggers and to return to the caller. For fire-and-forget writes where the caller discards the result, both the `RETURNING *` clause and the reload SELECT are pure waste. This is one fewer database round trip per call.

The database adapter layer gains `updateWithoutReturningAsync`, which omits `RETURNING *` and returns the affected row count instead of the full row. Row-existence validation uses the count (0 means the row was deleted concurrently, same error as before).

The mutator layer gains `updateWithoutReloadingAsync` on both `AuthorizationResultBasedUpdateMutator` (returns `Result<void>`) and `EnforcingEntityUpdater` (returns `Promise<void>`). The naming reflects each layer's abstraction: the adapter speaks in terms of SQL's `RETURNING` clause, while the mutator speaks in terms of the entity reload.

Authorization, validators, before-triggers, and cache invalidation still run. The method throws immediately — before entering a transaction — if the entity has `afterUpdate`, `afterAll`, or `afterCommit` triggers, since silently skipping them would be dangerous.

## Test plan

- `yarn tsc && yarn lint && yarn test`