### PR TITLE
feat: expose full transaction config on EntityTransactionalQueryContext

### DIFF
--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -49,6 +49,9 @@ export enum TransactionalDataLoaderMode {
   DISABLED = 'DISABLED',
 }
 
+/**
+ * Configuration options for running a transaction. This includes the isolation level and DataLoader mode for the transaction.
+ */
 export type TransactionConfig = {
   /**
    * Transaction isolation level. When omitted, the database default is used (typically READ_COMMITTED).
@@ -59,6 +62,13 @@ export type TransactionConfig = {
    */
   transactionalDataLoaderMode?: TransactionalDataLoaderMode;
 };
+
+/**
+ * Resolved transaction configuration with all default values filled in.
+ * This is the configuration that is actually used for a transaction after applying defaults.
+ */
+export type ResolvedTransactionConfig = Pick<TransactionConfig, 'isolationLevel'> &
+  Required<Pick<TransactionConfig, 'transactionalDataLoaderMode'>>;
 
 /**
  * Entity framework representation of transactional and non-transactional database
@@ -134,9 +144,25 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
      * @internal
      */
     readonly transactionId: string,
-    public readonly transactionalDataLoaderMode: TransactionalDataLoaderMode,
+    public readonly transactionConfig: ResolvedTransactionConfig,
   ) {
     super(queryInterface);
+  }
+
+  /**
+   * DataLoader mode for this transaction set at time of transaction creation, controlling DataLoader caching and batching behavior within the transaction.
+   */
+  get transactionalDataLoaderMode(): TransactionalDataLoaderMode {
+    return this.transactionConfig.transactionalDataLoaderMode;
+  }
+
+  /**
+   * Transaction isolation level for this transaction set at time of transaction creation.
+   * This controls the visibility of changes made by concurrent transactions.
+   * When undefined, the database default isolation level is used (typically READ_COMMITTED).
+   */
+  get isolationLevel(): TransactionIsolationLevel | undefined {
+    return this.transactionConfig.isolationLevel;
   }
 
   /**
@@ -249,9 +275,9 @@ export class EntityNestedTransactionalQueryContext extends EntityTransactionalQu
     readonly parentQueryContext: EntityTransactionalQueryContext,
     entityQueryContextProvider: EntityQueryContextProvider,
     transactionId: string,
-    transactionalDataLoaderMode: TransactionalDataLoaderMode,
+    transactionConfig: ResolvedTransactionConfig,
   ) {
-    super(queryInterface, entityQueryContextProvider, transactionId, transactionalDataLoaderMode);
+    super(queryInterface, entityQueryContextProvider, transactionId, transactionConfig);
     parentQueryContext.childQueryContexts.push(this);
   }
 

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import type { TransactionConfig } from './EntityQueryContext.ts';
+import type { ResolvedTransactionConfig, TransactionConfig } from './EntityQueryContext.ts';
 import {
   EntityNestedTransactionalQueryContext,
   EntityNonTransactionalQueryContext,
@@ -53,11 +53,17 @@ export abstract class EntityQueryContextProvider {
     const [returnedValue, queryContext] = await this.createTransactionRunner<
       [T, EntityTransactionalQueryContext]
     >(transactionConfig)(async (queryInterface) => {
+      const resolvedTransactionConfig: ResolvedTransactionConfig = {
+        ...transactionConfig,
+        transactionalDataLoaderMode:
+          transactionConfig?.transactionalDataLoaderMode ??
+          this.defaultTransactionalDataLoaderMode(),
+      };
       const queryContext = new EntityTransactionalQueryContext(
         queryInterface,
         this,
         randomUUID(),
-        transactionConfig?.transactionalDataLoaderMode ?? this.defaultTransactionalDataLoaderMode(),
+        resolvedTransactionConfig,
       );
       const result = await transactionScope(queryContext);
       await queryContext.runPreCommitCallbacksAsync();
@@ -85,7 +91,7 @@ export abstract class EntityQueryContextProvider {
         outerQueryContext,
         this,
         randomUUID(),
-        outerQueryContext.transactionalDataLoaderMode,
+        outerQueryContext.transactionConfig,
       );
       const result = await transactionScope(innerQueryContext);
       await innerQueryContext.runPreCommitCallbacksAsync();

--- a/packages/entity/src/__tests__/EntityQueryContext-test.ts
+++ b/packages/entity/src/__tests__/EntityQueryContext-test.ts
@@ -203,6 +203,90 @@ describe(EntityQueryContext, () => {
         },
       );
     });
+
+    it('exposes isolationLevel on the query context', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          assert(queryContext.isInTransaction());
+          expect(queryContext.isolationLevel).toBe(TransactionIsolationLevel.SERIALIZABLE);
+        },
+        { isolationLevel: TransactionIsolationLevel.SERIALIZABLE },
+      );
+
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          assert(queryContext.isInTransaction());
+          expect(queryContext.isolationLevel).toBe(TransactionIsolationLevel.REPEATABLE_READ);
+        },
+        { isolationLevel: TransactionIsolationLevel.REPEATABLE_READ },
+      );
+
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          assert(queryContext.isInTransaction());
+          expect(queryContext.isolationLevel).toBeUndefined();
+        },
+      );
+    });
+
+    it('exposes the full resolved transactionConfig on the query context', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          assert(queryContext.isInTransaction());
+          expect(queryContext.transactionConfig).toEqual({
+            isolationLevel: TransactionIsolationLevel.SERIALIZABLE,
+            transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED,
+          });
+        },
+        {
+          isolationLevel: TransactionIsolationLevel.SERIALIZABLE,
+          transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED,
+        },
+      );
+
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          assert(queryContext.isInTransaction());
+          expect(queryContext.transactionConfig).toEqual({
+            transactionalDataLoaderMode: TransactionalDataLoaderMode.ENABLED,
+          });
+        },
+      );
+    });
+
+    it('propagates transactionConfig to nested transactions', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new ViewerContext(companionProvider);
+
+      await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          assert(queryContext.isInTransaction());
+          await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+            expect(innerQueryContext.transactionConfig).toEqual(queryContext.transactionConfig);
+            expect(innerQueryContext.isolationLevel).toBe(TransactionIsolationLevel.SERIALIZABLE);
+            expect(innerQueryContext.transactionalDataLoaderMode).toBe(
+              TransactionalDataLoaderMode.DISABLED,
+            );
+          });
+        },
+        {
+          isolationLevel: TransactionIsolationLevel.SERIALIZABLE,
+          transactionalDataLoaderMode: TransactionalDataLoaderMode.DISABLED,
+        },
+      );
+    });
   });
 
   describe('global defaultTransactionalDataLoaderMode', () => {


### PR DESCRIPTION
# Why

In the Expo server application, it would be helpful to have a function that takes a transactional query context and asserts that it is in a specific isolation mode.

# How

Expose transaction config as a public readonly property, as well as two getters for convenience access (and to not break existing code).

# Test Plan

Run new tests. `yarn tsc`