### PR TITLE
fix: expose fieldName and fieldValue on EntityInvalidFieldValueError

### DIFF
--- a/packages/entity/src/errors/EntityInvalidFieldValueError.ts
+++ b/packages/entity/src/errors/EntityInvalidFieldValueError.ts
@@ -34,6 +34,9 @@ export class EntityInvalidFieldValueError<
     return EntityErrorCode.ERR_ENTITY_INVALID_FIELD_VALUE;
   }
 
+  readonly fieldName: N;
+  readonly fieldValue: TFields[N] | undefined;
+
   constructor(
     entityClass: IEntityClass<
       TFields,
@@ -47,5 +50,7 @@ export class EntityInvalidFieldValueError<
     fieldValue?: TFields[N],
   ) {
     super(`Entity field not valid: ${entityClass.name} (${String(fieldName)} = ${fieldValue})`);
+    this.fieldName = fieldName;
+    this.fieldValue = fieldValue;
   }
 }

--- a/packages/entity/src/errors/__tests__/EntityError-test.ts
+++ b/packages/entity/src/errors/__tests__/EntityError-test.ts
@@ -34,6 +34,8 @@ describe('EntityError subclasses', () => {
     const error = new EntityInvalidFieldValueError(SimpleTestEntity, 'id', 'badValue');
     expect(error.state).toBe(EntityErrorState.PERMANENT);
     expect(error.code).toBe(EntityErrorCode.ERR_ENTITY_INVALID_FIELD_VALUE);
+    expect(error.fieldName).toBe('id');
+    expect(error.fieldValue).toBe('badValue');
   });
 
   it('EntityCacheAdapterTransientError has correct state and code', () => {


### PR DESCRIPTION
## Summary

- Makes `fieldName` and `fieldValue` public readonly properties on `EntityInvalidFieldValueError` so consumers can access them programmatically.
- Downstream code (e.g. expo/universe) needs `fieldValue` directly to construct user-facing error messages like `Invalid field value: ${fieldValue}` without leaking internal details like entity class names.
- Context: https://github.com/expo/universe/pull/26013

## Test plan

- [x] Added assertions to existing `EntityError-test.ts` verifying `error.fieldName` and `error.fieldValue` are accessible and correct
- [x] `yarn tsc` passes
- [x] `yarn test` passes