### PR TITLE
feat: add count equivalent for knex loader methods

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -201,6 +201,30 @@ export class StubPostgresDatabaseAdapter<
     throw new Error('SQL fragments not supported for StubDatabaseAdapter');
   }
 
+  protected async countByFieldEqualityConjunctionInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
+    tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
+  ): Promise<number> {
+    const results = await this.fetchManyByFieldEqualityConjunctionInternalAsync(
+      queryInterface,
+      tableName,
+      tableFieldSingleValueEqualityOperands,
+      tableFieldMultiValueEqualityOperands,
+      { orderBy: undefined, offset: undefined, limit: undefined },
+    );
+    return results.length;
+  }
+
+  protected countBySQLFragmentInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: SQLFragment<TFields>,
+  ): Promise<number> {
+    throw new Error('SQL fragment count not supported for StubDatabaseAdapter');
+  }
+
   private generateRandomID(): any {
     const idSchemaField = this.entityConfiguration2.schema.get(this.entityConfiguration2.idField);
     invariant(

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -489,6 +489,81 @@ describe(StubPostgresDatabaseAdapter, () => {
     });
   });
 
+  describe('countByFieldEqualityConjunctionAsync', () => {
+    it('counts matching records', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubPostgresDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'hello',
+                  testIndexedField: 'h1',
+                  intField: 3,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'world',
+                  testIndexedField: 'h2',
+                  intField: 3,
+                  stringField: 'b',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'other',
+                  testIndexedField: 'h3',
+                  intField: 5,
+                  stringField: 'c',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const count = await databaseAdapter.countByFieldEqualityConjunctionAsync(queryContext, [
+        { fieldName: 'intField', fieldValue: 3 },
+      ]);
+      expect(count).toBe(2);
+
+      const countAll = await databaseAdapter.countByFieldEqualityConjunctionAsync(queryContext, []);
+      expect(countAll).toBe(3);
+
+      const countMultiValue = await databaseAdapter.countByFieldEqualityConjunctionAsync(
+        queryContext,
+        [{ fieldName: 'customIdField', fieldValues: ['hello', 'world'] }],
+      );
+      expect(countMultiValue).toBe(2);
+
+      const countNone = await databaseAdapter.countByFieldEqualityConjunctionAsync(queryContext, [
+        { fieldName: 'intField', fieldValue: 999 },
+      ]);
+      expect(countNone).toBe(0);
+    });
+  });
+
+  describe('countBySQLFragmentAsync', () => {
+    it('throws because it is unsupported', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        new Map(),
+      );
+      await expect(databaseAdapter.countBySQLFragmentAsync(queryContext, sql``)).rejects.toThrow(
+        'SQL fragment count not supported for StubDatabaseAdapter',
+      );
+    });
+  });
+
   describe('fetchManyBySQLFragmentAsync', () => {
     it('throws because it is unsupported', async () => {
       const queryContext = instance(mock(EntityQueryContext));

--- a/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/AuthorizationResultBasedKnexEntityLoader.ts
@@ -401,6 +401,42 @@ export class AuthorizationResultBasedKnexEntityLoader<
   }
 
   /**
+   * Count entities matching the conjunction of field equality operands.
+   * This does not perform authorization since count does not load full entities.
+   * Note that this should be used with the same caution as loadManyByFieldEqualityConjunctionAsync
+   * regarding indexing since counts can be expensive on large datasets without appropriate indexes.
+   *
+   * @returns count of entities matching the filters
+   */
+  async countByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldEqualityOperands: readonly FieldEqualityCondition<TFields, N>[],
+  ): Promise<number> {
+    for (const fieldEqualityOperand of fieldEqualityOperands) {
+      const fieldValues = isSingleValueFieldEqualityCondition(fieldEqualityOperand)
+        ? [fieldEqualityOperand.fieldValue]
+        : fieldEqualityOperand.fieldValues;
+      this.constructionUtils.validateFieldAndValues(fieldEqualityOperand.fieldName, fieldValues);
+    }
+
+    return await this.knexDataManager.countByFieldEqualityConjunctionAsync(
+      this.queryContext,
+      fieldEqualityOperands,
+    );
+  }
+
+  /**
+   * Count entities matching a SQL fragment.
+   * This does not perform authorization since count does not load full entities.
+   * Note that this should be used with the same caution as loadManyBySQL regarding indexing
+   * since counts can be expensive on large datasets without appropriate indexes.
+   *
+   * @returns count of entities matching the query
+   */
+  async countBySQLAsync(fragment: SQLFragment<Pick<TFields, TSelectedFields>>): Promise<number> {
+    return await this.knexDataManager.countBySQLFragmentAsync(this.queryContext, fragment);
+  }
+
+  /**
    * Authorization-result-based version of the EnforcingKnexEntityLoader method by the same name.
    * @returns SQL query builder for building and executing SQL queries that when executed returns entity results where result error can be UnauthorizedError.
    */

--- a/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/BasePostgresEntityDatabaseAdapter.ts
@@ -248,6 +248,73 @@ export abstract class BasePostgresEntityDatabaseAdapter<
     querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]>;
 
+  /**
+   * Count objects matching the conjunction of where clauses constructed from
+   * specified field equality operands.
+   *
+   * @param queryContext - query context with which to perform the count
+   * @param fieldEqualityOperands - list of field equality where clause operand specifications
+   * @returns count of objects matching the query
+   */
+  async countByFieldEqualityConjunctionAsync<N extends keyof TFields>(
+    queryContext: EntityQueryContext,
+    fieldEqualityOperands: readonly FieldEqualityCondition<TFields, N>[],
+  ): Promise<number> {
+    const tableFieldSingleValueOperands: TableFieldSingleValueEqualityCondition[] = [];
+    const tableFieldMultipleValueOperands: TableFieldMultiValueEqualityCondition[] = [];
+    for (const operand of fieldEqualityOperands) {
+      if (isSingleValueFieldEqualityCondition(operand)) {
+        tableFieldSingleValueOperands.push({
+          tableField: getDatabaseFieldForEntityField(this.entityConfiguration, operand.fieldName),
+          tableValue: operand.fieldValue,
+        });
+      } else {
+        tableFieldMultipleValueOperands.push({
+          tableField: getDatabaseFieldForEntityField(this.entityConfiguration, operand.fieldName),
+          tableValues: operand.fieldValues,
+        });
+      }
+    }
+
+    return await this.countByFieldEqualityConjunctionInternalAsync(
+      queryContext.getQueryInterface(),
+      this.entityConfiguration.tableName,
+      tableFieldSingleValueOperands,
+      tableFieldMultipleValueOperands,
+    );
+  }
+
+  protected abstract countByFieldEqualityConjunctionInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
+    tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
+  ): Promise<number>;
+
+  /**
+   * Count objects matching the SQL fragment.
+   *
+   * @param queryContext - query context with which to perform the count
+   * @param sqlFragment - SQLFragment for the WHERE clause of the query
+   * @returns count of objects matching the query
+   */
+  async countBySQLFragmentAsync(
+    queryContext: EntityQueryContext,
+    sqlFragment: SQLFragment<TFields>,
+  ): Promise<number> {
+    return await this.countBySQLFragmentInternalAsync(
+      queryContext.getQueryInterface(),
+      this.entityConfiguration.tableName,
+      sqlFragment,
+    );
+  }
+
+  protected abstract countBySQLFragmentInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    sqlFragment: SQLFragment<TFields>,
+  ): Promise<number>;
+
   private convertToTableQueryModifiers(
     querySelectionModifiers: PostgresQuerySelectionModifiers<TFields>,
   ): TableQuerySelectionModifiers<TFields> {

--- a/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
+++ b/packages/entity-database-adapter-knex/src/EnforcingKnexEntityLoader.ts
@@ -105,6 +105,32 @@ export class EnforcingKnexEntityLoader<
   }
 
   /**
+   * Count entities matching the conjunction of field equality operands.
+   * This does not perform authorization since count does not load full entities.
+   * Note that this should be used with the same caution as loadManyByFieldEqualityConjunctionAsync
+   * regarding indexing since counts can be expensive on large datasets without appropriate indexes.
+   *
+   * @returns count of entities matching the filters
+   */
+  async countByFieldEqualityConjunctionAsync<N extends keyof Pick<TFields, TSelectedFields>>(
+    fieldEqualityOperands: FieldEqualityCondition<TFields, N>[],
+  ): Promise<number> {
+    return await this.knexEntityLoader.countByFieldEqualityConjunctionAsync(fieldEqualityOperands);
+  }
+
+  /**
+   * Count entities matching a SQL fragment.
+   * This does not perform authorization since count does not load full entity rows.
+   * Note that this should be used with the same caution as loadManyBySQL regarding indexing
+   * since counts can be expensive on large datasets without appropriate indexes.
+   *
+   * @returns count of entities matching the query
+   */
+  async countBySQLAsync(fragment: SQLFragment<Pick<TFields, TSelectedFields>>): Promise<number> {
+    return await this.knexEntityLoader.countBySQLAsync(fragment);
+  }
+
+  /**
    * Load entities using a SQL query builder. When executed, all queries will enforce authorization and throw if not authorized.
    *
    * @example

--- a/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/PostgresEntityDatabaseAdapter.ts
@@ -1,5 +1,5 @@
 import type { EntityConfiguration, FieldTransformer, FieldTransformerMap } from '@expo/entity';
-import { getDatabaseFieldForEntityField } from '@expo/entity';
+import { getDatabaseFieldForEntityField, RESERVED_ENTITY_COUNT_QUERY_ALIAS } from '@expo/entity';
 import type { Knex } from 'knex';
 
 import type {
@@ -164,14 +164,12 @@ export class PostgresEntityDatabaseAdapter<
     return ret;
   }
 
-  protected async fetchManyByFieldEqualityConjunctionInternalAsync(
-    queryInterface: Knex,
-    tableName: string,
+  private applyFieldEqualityConjunctionWhereClause(
+    query: Knex.QueryBuilder,
     tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
     tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
-    querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
-  ): Promise<object[]> {
-    let query = queryInterface.select().from(tableName);
+  ): Knex.QueryBuilder {
+    let result = query;
 
     if (tableFieldSingleValueEqualityOperands.length > 0) {
       const whereObject: { [key: string]: any } = {};
@@ -184,11 +182,11 @@ export class PostgresEntityDatabaseAdapter<
         for (const { tableField, tableValue } of nonNullTableFieldSingleValueEqualityOperands) {
           whereObject[tableField] = tableValue;
         }
-        query = query.where(whereObject);
+        result = result.where(whereObject);
       }
       if (nullTableFieldSingleValueEqualityOperands.length > 0) {
         for (const { tableField } of nullTableFieldSingleValueEqualityOperands) {
-          query = query.whereNull(tableField);
+          result = result.whereNull(tableField);
         }
       }
     }
@@ -196,7 +194,7 @@ export class PostgresEntityDatabaseAdapter<
     if (tableFieldMultiValueEqualityOperands.length > 0) {
       for (const { tableField, tableValues } of tableFieldMultiValueEqualityOperands) {
         const nonNullTableValues = tableValues.filter((tableValue) => tableValue !== null);
-        query = query.where((builder) => {
+        result = result.where((builder) => {
           builder.whereRaw('?? = ANY(?)', [tableField, [...nonNullTableValues]]);
           // there was at least one null, allow null in this equality clause
           if (nonNullTableValues.length !== tableValues.length) {
@@ -206,8 +204,35 @@ export class PostgresEntityDatabaseAdapter<
       }
     }
 
+    return result;
+  }
+
+  protected async fetchManyByFieldEqualityConjunctionInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
+    tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
+    querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
+  ): Promise<object[]> {
+    let query = this.applyFieldEqualityConjunctionWhereClause(
+      queryInterface.select().from(tableName),
+      tableFieldSingleValueEqualityOperands,
+      tableFieldMultiValueEqualityOperands,
+    );
     query = this.applyQueryModifiersToQuery(query, querySelectionModifiers);
     return await wrapNativePostgresCallAsync(() => query);
+  }
+
+  private applySQLFragmentWhereClause(
+    query: Knex.QueryBuilder,
+    sqlFragment: SQLFragment<TFields>,
+  ): Knex.QueryBuilder {
+    return query.whereRaw(
+      sqlFragment.sql,
+      sqlFragment.getKnexBindings((fieldName) =>
+        getDatabaseFieldForEntityField(this.entityConfiguration, fieldName),
+      ),
+    );
   }
 
   protected async fetchManyBySQLFragmentInternalAsync(
@@ -216,17 +241,40 @@ export class PostgresEntityDatabaseAdapter<
     sqlFragment: SQLFragment<TFields>,
     querySelectionModifiers: TableQuerySelectionModifiers<TFields>,
   ): Promise<object[]> {
-    let query = queryInterface
-      .select()
-      .from(tableName)
-      .whereRaw(
-        sqlFragment.sql,
-        sqlFragment.getKnexBindings((fieldName) =>
-          getDatabaseFieldForEntityField(this.entityConfiguration, fieldName),
-        ),
-      );
+    let query = this.applySQLFragmentWhereClause(
+      queryInterface.select().from(tableName),
+      sqlFragment,
+    );
     query = this.applyQueryModifiersToQuery(query, querySelectionModifiers);
     return await wrapNativePostgresCallAsync(() => query);
+  }
+
+  protected async countByFieldEqualityConjunctionInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
+    tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
+  ): Promise<number> {
+    const query = this.applyFieldEqualityConjunctionWhereClause(
+      queryInterface.count('*', { as: RESERVED_ENTITY_COUNT_QUERY_ALIAS }).from(tableName),
+      tableFieldSingleValueEqualityOperands,
+      tableFieldMultiValueEqualityOperands,
+    );
+    const result = await wrapNativePostgresCallAsync(() => query);
+    return parseInt(String(result[0][RESERVED_ENTITY_COUNT_QUERY_ALIAS]), 10);
+  }
+
+  protected async countBySQLFragmentInternalAsync(
+    queryInterface: Knex,
+    tableName: string,
+    sqlFragment: SQLFragment<TFields>,
+  ): Promise<number> {
+    const query = this.applySQLFragmentWhereClause(
+      queryInterface.count('*', { as: RESERVED_ENTITY_COUNT_QUERY_ALIAS }).from(tableName),
+      sqlFragment,
+    );
+    const result = await wrapNativePostgresCallAsync(() => query);
+    return parseInt(String(result[0][RESERVED_ENTITY_COUNT_QUERY_ALIAS]), 10);
   }
 
   protected async insertInternalAsync(

--- a/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/PostgresEntityIntegration-test.ts
@@ -959,6 +959,103 @@ describe('postgres entity integration', () => {
     });
   });
 
+  describe('counting with countBySQLAsync', () => {
+    it('counts entities matching a SQL fragment', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'Alice')
+          .setField('hasACat', true)
+          .setField('hasADog', false)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'Bob')
+          .setField('hasACat', false)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'Charlie')
+          .setField('hasACat', true)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      const catOwnerCount = await PostgresTestEntity.knexLoader(vc1).countBySQLAsync(
+        sql`has_a_cat = ${true}`,
+      );
+      expect(catOwnerCount).toBe(2);
+
+      const dogOwnerCount = await PostgresTestEntity.knexLoader(vc1).countBySQLAsync(
+        sql`has_a_dog = ${true}`,
+      );
+      expect(dogOwnerCount).toBe(2);
+
+      const allCount = await PostgresTestEntity.knexLoader(vc1).countBySQLAsync(sql`TRUE`);
+      expect(allCount).toBe(3);
+
+      const noneCount = await PostgresTestEntity.knexLoader(vc1).countBySQLAsync(sql`FALSE`);
+      expect(noneCount).toBe(0);
+    });
+  });
+
+  describe('counting with countByFieldEqualityConjunctionAsync', () => {
+    it('counts entities matching field equality conditions', async () => {
+      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'hello')
+          .setField('hasACat', false)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'world')
+          .setField('hasACat', false)
+          .setField('hasADog', true)
+          .createAsync(),
+      );
+
+      await enforceAsyncResult(
+        PostgresTestEntity.creatorWithAuthorizationResults(vc1)
+          .setField('name', 'wat')
+          .setField('hasACat', false)
+          .setField('hasADog', false)
+          .createAsync(),
+      );
+
+      const count1 = await PostgresTestEntity.knexLoader(vc1).countByFieldEqualityConjunctionAsync([
+        { fieldName: 'hasACat', fieldValue: false },
+        { fieldName: 'hasADog', fieldValue: true },
+      ]);
+      expect(count1).toBe(2);
+
+      const count2 = await PostgresTestEntity.knexLoader(vc1).countByFieldEqualityConjunctionAsync([
+        { fieldName: 'hasADog', fieldValues: [true, false] },
+      ]);
+      expect(count2).toBe(3);
+
+      const count3 = await PostgresTestEntity.knexLoader(vc1).countByFieldEqualityConjunctionAsync([
+        { fieldName: 'name', fieldValue: 'hello' },
+      ]);
+      expect(count3).toBe(1);
+
+      const count4 = await PostgresTestEntity.knexLoader(vc1).countByFieldEqualityConjunctionAsync(
+        [],
+      );
+      expect(count4).toBe(3);
+    });
+  });
+
   describe('conjunction field equality loading', () => {
     it('supports single fieldValue and multiple fieldValues', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));

--- a/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/BasePostgresEntityDatabaseAdapter-test.ts
@@ -89,6 +89,23 @@ class TestEntityDatabaseAdapter extends BasePostgresEntityDatabaseAdapter<
     return this.fetchEqualityConditionResults;
   }
 
+  protected async countByFieldEqualityConjunctionInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
+    _tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
+  ): Promise<number> {
+    return 0;
+  }
+
+  protected async countBySQLFragmentInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: any,
+  ): Promise<number> {
+    return 0;
+  }
+
   protected async insertInternalAsync(
     _queryInterface: any,
     _tableName: string,

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -202,6 +202,30 @@ export class StubPostgresDatabaseAdapter<
     throw new Error('SQL fragments not supported for StubDatabaseAdapter');
   }
 
+  protected async countByFieldEqualityConjunctionInternalAsync(
+    queryInterface: any,
+    tableName: string,
+    tableFieldSingleValueEqualityOperands: TableFieldSingleValueEqualityCondition[],
+    tableFieldMultiValueEqualityOperands: TableFieldMultiValueEqualityCondition[],
+  ): Promise<number> {
+    const results = await this.fetchManyByFieldEqualityConjunctionInternalAsync(
+      queryInterface,
+      tableName,
+      tableFieldSingleValueEqualityOperands,
+      tableFieldMultiValueEqualityOperands,
+      { orderBy: undefined, offset: undefined, limit: undefined },
+    );
+    return results.length;
+  }
+
+  protected countBySQLFragmentInternalAsync(
+    _queryInterface: any,
+    _tableName: string,
+    _sqlFragment: SQLFragment<TFields>,
+  ): Promise<number> {
+    throw new Error('SQL fragment count not supported for StubDatabaseAdapter');
+  }
+
   private generateRandomID(): any {
     const idSchemaField = this.entityConfiguration2.schema.get(this.entityConfiguration2.idField);
     invariant(

--- a/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
+++ b/packages/entity-database-adapter-knex/src/internal/EntityKnexDataManager.ts
@@ -3,6 +3,7 @@ import {
   EntityDatabaseAdapterPaginationCursorInvalidError,
   EntityMetricsLoadType,
   getDatabaseFieldForEntityField,
+  timeAndLogCountEventAsync,
   timeAndLogLoadEventAsync,
 } from '@expo/entity';
 import assert from 'assert';
@@ -190,6 +191,23 @@ export class EntityKnexDataManager<
     );
   }
 
+  async countByFieldEqualityConjunctionAsync<N extends keyof TFields>(
+    queryContext: EntityQueryContext,
+    fieldEqualityOperands: readonly FieldEqualityCondition<TFields, N>[],
+  ): Promise<number> {
+    return await timeAndLogCountEventAsync(
+      this.metricsAdapter,
+      EntityMetricsLoadType.COUNT_EQUALITY_CONJUNCTION,
+      this.entityClassName,
+      queryContext,
+    )(
+      this.databaseAdapter.countByFieldEqualityConjunctionAsync(
+        queryContext,
+        fieldEqualityOperands,
+      ),
+    );
+  }
+
   async loadManyBySQLFragmentAsync(
     queryContext: EntityQueryContext,
     sqlFragment: SQLFragment<TFields>,
@@ -209,6 +227,18 @@ export class EntityKnexDataManager<
         querySelectionModifiers,
       ),
     );
+  }
+
+  async countBySQLFragmentAsync(
+    queryContext: EntityQueryContext,
+    sqlFragment: SQLFragment<TFields>,
+  ): Promise<number> {
+    return await timeAndLogCountEventAsync(
+      this.metricsAdapter,
+      EntityMetricsLoadType.COUNT_SQL,
+      this.entityClassName,
+      queryContext,
+    )(this.databaseAdapter.countBySQLFragmentAsync(queryContext, sqlFragment));
   }
 
   /**

--- a/packages/entity/src/EntityConfiguration.ts
+++ b/packages/entity/src/EntityConfiguration.ts
@@ -2,6 +2,7 @@ import invariant from 'invariant';
 
 import type { IEntityClass } from './Entity.ts';
 import type { CacheAdapterFlavor, DatabaseAdapterFlavor } from './EntityCompanionProvider.ts';
+import { RESERVED_ENTITY_COUNT_QUERY_ALIAS } from './EntityDatabaseAdapter.ts';
 import type { EntityFieldDefinition } from './EntityFieldDefinition.ts';
 import type { SerializedCompositeFieldHolder } from './internal/CompositeFieldHolder.ts';
 import { CompositeFieldHolder } from './internal/CompositeFieldHolder.ts';
@@ -183,8 +184,7 @@ export class EntityConfiguration<
 
     // external schema is a Record to typecheck that all fields have FieldDefinitions,
     // but internally the most useful representation is a map for lookups
-    EntityConfiguration.validateSchema<TFields, TIDField>(schema);
-    this.schema = new Map(Object.entries(schema));
+    this.schema = this.validateSchemaMap(new Map(Object.entries(schema)));
 
     this.cacheableKeys = EntityConfiguration.computeCacheableKeys(this.schema);
     this.compositeFieldInfo = new CompositeFieldInfo(compositeFieldDefinitions ?? []);
@@ -194,21 +194,27 @@ export class EntityConfiguration<
     this.dbToEntityFieldsKeyMapping = invertMap(this.entityToDBFieldsKeyMapping);
   }
 
-  private static validateSchema<
-    TFields extends Record<string, any>,
-    TIDField extends keyof TFields,
-  >(
-    schema: Omit<Record<keyof TFields, EntityFieldDefinition<any, false>>, TIDField> &
-      Record<TIDField, EntityFieldDefinition<any, true>>,
-  ): void {
-    const disallowedFieldsKeys = Object.getOwnPropertyNames(Object.prototype);
-    for (const disallowedFieldsKey of disallowedFieldsKeys) {
-      if (Object.hasOwn(schema, disallowedFieldsKey)) {
+  private validateSchemaMap(
+    schemaMap: ReadonlyMap<keyof TFields, EntityFieldDefinition<any, any>>,
+  ): ReadonlyMap<keyof TFields, EntityFieldDefinition<any, any>> {
+    for (const disallowedFieldName of Object.getOwnPropertyNames(Object.prototype)) {
+      if (schemaMap.has(disallowedFieldName)) {
         throw new Error(
-          `Entity field name not allowed to prevent conflicts with standard Object prototype fields: ${disallowedFieldsKey}`,
+          `Entity field name not allowed to prevent conflicts with standard Object prototype fields: ${disallowedFieldName}`,
         );
       }
     }
+
+    // check for column named RESERVED_ENTITY_COUNT_QUERY_ALIAS which is used for count queries and would cause issues if used as a column name for an entity field
+    for (const [fieldName, fieldDefinition] of schemaMap) {
+      if (fieldDefinition.columnName === RESERVED_ENTITY_COUNT_QUERY_ALIAS) {
+        throw new Error(
+          `Entity field "${String(fieldName)}" has disallowed column name "${RESERVED_ENTITY_COUNT_QUERY_ALIAS}" which is reserved for count queries. Choose a different column name.`,
+        );
+      }
+    }
+
+    return schemaMap;
   }
 
   private static computeCacheableKeys<TFields extends Record<string, any>>(

--- a/packages/entity/src/EntityDatabaseAdapter.ts
+++ b/packages/entity/src/EntityDatabaseAdapter.ts
@@ -17,6 +17,8 @@ import {
 } from './internal/EntityFieldTransformationUtils.ts';
 import type { IEntityLoadKey, IEntityLoadValue } from './internal/EntityLoadInterfaces.ts';
 
+export const RESERVED_ENTITY_COUNT_QUERY_ALIAS = '__entity_count__';
+
 /**
  * A database adapter is an interface by which entity objects can be
  * fetched, inserted, updated, and deleted from a database. This base class

--- a/packages/entity/src/__tests__/EntityConfiguration-test.ts
+++ b/packages/entity/src/__tests__/EntityConfiguration-test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from '@jest/globals';
 
 import { EntityConfiguration } from '../EntityConfiguration.ts';
+import { RESERVED_ENTITY_COUNT_QUERY_ALIAS } from '../EntityDatabaseAdapter.ts';
 import { StringField, UUIDField } from '../EntityFields.ts';
 import { CompositeFieldHolder } from '../internal/CompositeFieldHolder.ts';
 
@@ -194,6 +195,29 @@ describe(EntityConfiguration, () => {
           `Entity field name not allowed to prevent conflicts with standard Object prototype fields: ${keyName}`,
         );
       });
+    });
+
+    it('disallows RESERVED_ENTITY_COUNT_QUERY_ALIAS as a column name', () => {
+      expect(
+        () =>
+          new EntityConfiguration<{ id: string; count: string }, 'id'>({
+            idField: 'id',
+            tableName: 'blah_table',
+            schema: {
+              id: new UUIDField({
+                columnName: 'id',
+                cache: false,
+              }),
+              count: new StringField({
+                columnName: RESERVED_ENTITY_COUNT_QUERY_ALIAS,
+              }),
+            },
+            databaseAdapterFlavor: 'postgres',
+            cacheAdapterFlavor: 'redis',
+          }),
+      ).toThrow(
+        `Entity field "count" has disallowed column name "${RESERVED_ENTITY_COUNT_QUERY_ALIAS}" which is reserved for count queries. Choose a different column name.`,
+      );
     });
   });
 });

--- a/packages/entity/src/metrics/EntityMetricsUtils.ts
+++ b/packages/entity/src/metrics/EntityMetricsUtils.ts
@@ -84,6 +84,29 @@ export const timeAndLogLoadMapEventAsync =
     return result;
   };
 
+export const timeAndLogCountEventAsync =
+  (
+    metricsAdapter: IEntityMetricsAdapter,
+    loadType: EntityMetricsLoadType,
+    entityClassName: string,
+    queryContext: EntityQueryContext,
+  ) =>
+  async (promise: Promise<number>) => {
+    const startTime = Date.now();
+    const result = await promise;
+    const endTime = Date.now();
+
+    metricsAdapter.logDataManagerLoadEvent({
+      type: loadType,
+      isInTransaction: queryContext.isInTransaction(),
+      entityClassName,
+      duration: endTime - startTime,
+      count: result,
+    });
+
+    return result;
+  };
+
 export const timeAndLogMutationEventAsync =
   (
     metricsAdapter: IEntityMetricsAdapter,

--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -28,6 +28,14 @@ export enum EntityMetricsLoadType {
    * Knex loader load using loadPageAsync.
    */
   LOAD_PAGE,
+  /**
+   * Knex loader count using countBySQLAsync.
+   */
+  COUNT_SQL,
+  /**
+   * Knex loader count using countByFieldEqualityConjunctionAsync.
+   */
+  COUNT_EQUALITY_CONJUNCTION,
 }
 
 /**

--- a/packages/entity/src/metrics/__tests__/EntityMetricsUtils-test.ts
+++ b/packages/entity/src/metrics/__tests__/EntityMetricsUtils-test.ts
@@ -3,6 +3,7 @@ import { anyNumber, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 
 import type { EntityQueryContext } from '../../EntityQueryContext.ts';
 import {
+  timeAndLogCountEventAsync,
   timeAndLogLoadEventAsync,
   timeAndLogLoadMapEventAsync,
   timeAndLogMutationEventAsync,
@@ -77,6 +78,38 @@ describe(timeAndLogLoadMapEventAsync, () => {
           entityClassName: 'TestEntity',
           duration: anyNumber(),
           count: 3,
+        }),
+      ),
+    ).once();
+  });
+});
+
+describe(timeAndLogCountEventAsync, () => {
+  it('returns the count from the wrapped promise and logs', async () => {
+    const metricsAdapterMock = mock<IEntityMetricsAdapter>();
+    const metricsAdapter = instance(metricsAdapterMock);
+
+    const queryContextMock = mock<EntityQueryContext>();
+    when(queryContextMock.isInTransaction()).thenReturn(false);
+    const queryContext = instance(queryContextMock);
+
+    const result = await timeAndLogCountEventAsync(
+      metricsAdapter,
+      EntityMetricsLoadType.COUNT_SQL,
+      'TestEntity',
+      queryContext,
+    )(Promise.resolve(42));
+
+    expect(result).toBe(42);
+
+    verify(
+      metricsAdapterMock.logDataManagerLoadEvent(
+        deepEqual({
+          type: EntityMetricsLoadType.COUNT_SQL,
+          isInTransaction: false,
+          entityClassName: 'TestEntity',
+          duration: anyNumber(),
+          count: 42,
         }),
       ),
     ).once();


### PR DESCRIPTION
# Why

Looking at more ways the Expo server application needs escape hatches from entity, particularly in postgres/knex, it's:
- count
- upsert
- batch create/update/delete (and then batch count/upsert/etc)

In other PRs I'm looking into batch stuff, but it's quite complex. In the meantime, some easy wins are count and upsert.

# How

Adds count equivalents for knex loads. Note that these purposefully don't do authorization since the point of these is to not need to load the full row set, and authorization is row-based.

# Test Plan

Run tests.