### PR TITLE
fix: prevent collision in companion when entities share same name or same table name

### DIFF
--- a/packages/entity/src/EntityCompanionProvider.ts
+++ b/packages/entity/src/EntityCompanionProvider.ts
@@ -127,11 +127,13 @@ export interface EntityCompanionDefinition<
  */
 export class EntityCompanionProvider {
   private readonly companionDefinitionMap: Map<
-    string,
+    IEntityClass<any, any, any, any, any, any>,
     EntityCompanionDefinition<any, any, any, any, any, any>
   > = new Map();
-  private readonly companionMap: Map<string, EntityCompanion<any, any, any, any, any, any>> =
-    new Map();
+  private readonly companionMap: Map<
+    IEntityClass<any, any, any, any, any, any>,
+    EntityCompanion<any, any, any, any, any, any>
+  > = new Map();
   private readonly tableDataCoordinatorMap: Map<string, EntityTableDataCoordinator<any, any>> =
     new Map();
 
@@ -192,14 +194,14 @@ export class EntityCompanionProvider {
   ): EntityCompanion<TFields, TIDField, TViewerContext, TEntity, TPrivacyPolicy, TSelectedFields> {
     const entityCompanionDefinition = computeIfAbsent(
       this.companionDefinitionMap,
-      entityClass.name,
+      entityClass,
       () => entityClass.defineCompanionDefinition(),
     );
     const tableDataCoordinator = this.getTableDataCoordinatorForEntity(
       entityCompanionDefinition.entityConfiguration,
       entityClass.name,
     );
-    return computeIfAbsent(this.companionMap, entityClass.name, () => {
+    return computeIfAbsent(this.companionMap, entityClass, () => {
       return new EntityCompanion(
         this,
         entityCompanionDefinition,
@@ -228,7 +230,12 @@ export class EntityCompanionProvider {
     entityConfiguration: EntityConfiguration<TFields, TIDField>,
     entityClassName: string,
   ): EntityTableDataCoordinator<TFields, TIDField> {
-    return computeIfAbsent(this.tableDataCoordinatorMap, entityConfiguration.tableName, () => {
+    const tableDataCoordinatorKey = [
+      entityConfiguration.databaseAdapterFlavor,
+      entityConfiguration.cacheAdapterFlavor,
+      entityConfiguration.tableName,
+    ].join('\0');
+    return computeIfAbsent(this.tableDataCoordinatorMap, tableDataCoordinatorKey, () => {
       const entityDatabaseAdapterFlavor = this.databaseAdapterFlavors.get(
         entityConfiguration.databaseAdapterFlavor,
       );

--- a/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
+++ b/packages/entity/src/__tests__/EntityCompanionProvider-test.ts
@@ -7,6 +7,10 @@ import { EntityConfiguration } from '../EntityConfiguration.ts';
 import { StringField } from '../EntityFields.ts';
 import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
 import type { ViewerContext } from '../ViewerContext.ts';
+import { NoOpEntityMetricsAdapter } from '../metrics/NoOpEntityMetricsAdapter.ts';
+import { InMemoryFullCacheStubCacheAdapterProvider } from '../utils/__testfixtures__/StubCacheAdapter.ts';
+import { StubDatabaseAdapterProvider } from '../utils/__testfixtures__/StubDatabaseAdapterProvider.ts';
+import { StubQueryContextProvider } from '../utils/__testfixtures__/StubQueryContextProvider.ts';
 import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
 
 type BlahFields = {
@@ -23,6 +27,19 @@ const blahConfiguration = new EntityConfiguration<BlahFields, 'hello'>({
     }),
   },
   databaseAdapterFlavor: 'postgres',
+  cacheAdapterFlavor: 'redis',
+});
+
+const blahOtherDatabaseConfiguration = new EntityConfiguration<BlahFields, 'hello'>({
+  idField: 'hello',
+  tableName: 'wat',
+  schema: {
+    hello: new StringField({
+      columnName: 'hello',
+      cache: false,
+    }),
+  },
+  databaseAdapterFlavor: 'other-postgres',
   cacheAdapterFlavor: 'redis',
 });
 
@@ -64,11 +81,88 @@ class NoOpTest1PrivacyPolicy extends EntityPrivacyPolicy<
   ViewerContext,
   Blah1Entity
 > {}
+
 class NoOpTest2PrivacyPolicy extends EntityPrivacyPolicy<
   BlahFields,
   'hello',
   ViewerContext,
   Blah2Entity
+> {}
+
+class BlahOtherDatabaseEntity extends Entity<BlahFields, 'hello', ViewerContext> {
+  static defineCompanionDefinition(): EntityCompanionDefinition<
+    BlahFields,
+    'hello',
+    ViewerContext,
+    BlahOtherDatabaseEntity,
+    NoOpOtherDatabasePrivacyPolicy
+  > {
+    return {
+      entityClass: BlahOtherDatabaseEntity,
+      entityConfiguration: blahOtherDatabaseConfiguration,
+      privacyPolicyClass: NoOpOtherDatabasePrivacyPolicy,
+    };
+  }
+}
+
+class NoOpOtherDatabasePrivacyPolicy extends EntityPrivacyPolicy<
+  BlahFields,
+  'hello',
+  ViewerContext,
+  BlahOtherDatabaseEntity
+> {}
+
+const DuplicateNameEntityOne = class DuplicateNameEntity extends Entity<
+  BlahFields,
+  'hello',
+  ViewerContext
+> {
+  static defineCompanionDefinition(): EntityCompanionDefinition<
+    BlahFields,
+    'hello',
+    ViewerContext,
+    InstanceType<typeof DuplicateNameEntityOne>,
+    DuplicateNamePrivacyPolicyOne
+  > {
+    return {
+      entityClass: DuplicateNameEntityOne,
+      entityConfiguration: blahConfiguration,
+      privacyPolicyClass: DuplicateNamePrivacyPolicyOne,
+    };
+  }
+};
+
+const DuplicateNameEntityTwo = class DuplicateNameEntity extends Entity<
+  BlahFields,
+  'hello',
+  ViewerContext
+> {
+  static defineCompanionDefinition(): EntityCompanionDefinition<
+    BlahFields,
+    'hello',
+    ViewerContext,
+    InstanceType<typeof DuplicateNameEntityTwo>,
+    DuplicateNamePrivacyPolicyTwo
+  > {
+    return {
+      entityClass: DuplicateNameEntityTwo,
+      entityConfiguration: blahConfiguration,
+      privacyPolicyClass: DuplicateNamePrivacyPolicyTwo,
+    };
+  }
+};
+
+class DuplicateNamePrivacyPolicyOne extends EntityPrivacyPolicy<
+  BlahFields,
+  'hello',
+  ViewerContext,
+  InstanceType<typeof DuplicateNameEntityOne>
+> {}
+class DuplicateNamePrivacyPolicyTwo extends EntityPrivacyPolicy<
+  BlahFields,
+  'hello',
+  ViewerContext,
+  InstanceType<typeof DuplicateNameEntityTwo>
 > {}
 
 describe(EntityCompanionProvider, () => {
@@ -78,5 +172,52 @@ describe(EntityCompanionProvider, () => {
     const companion2 = entityCompanionProvider.getCompanionForEntity(Blah2Entity);
     expect(companion1).not.toEqual(companion2);
     expect(companion1['tableDataCoordinator']).toEqual(companion2['tableDataCoordinator']);
+  });
+
+  it('caches companions by class identity instead of class name', () => {
+    expect(DuplicateNameEntityOne.name).toEqual(DuplicateNameEntityTwo.name);
+
+    const entityCompanionProvider = createUnitTestEntityCompanionProvider();
+    const companion1 = entityCompanionProvider.getCompanionForEntity(DuplicateNameEntityOne);
+    const companion2 = entityCompanionProvider.getCompanionForEntity(DuplicateNameEntityTwo);
+
+    expect(companion1).not.toEqual(companion2);
+    expect(companion1.entityCompanionDefinition.entityClass).toBe(DuplicateNameEntityOne);
+    expect(companion2.entityCompanionDefinition.entityClass).toBe(DuplicateNameEntityTwo);
+  });
+
+  it('does not share table data coordinators across database adapter flavors', () => {
+    const entityCompanionProvider = new EntityCompanionProvider(
+      new NoOpEntityMetricsAdapter(),
+      new Map([
+        [
+          'postgres',
+          {
+            adapterProvider: new StubDatabaseAdapterProvider(),
+            queryContextProvider: new StubQueryContextProvider(),
+          },
+        ],
+        [
+          'other-postgres',
+          {
+            adapterProvider: new StubDatabaseAdapterProvider(),
+            queryContextProvider: new StubQueryContextProvider(),
+          },
+        ],
+      ]),
+      new Map([
+        [
+          'redis',
+          {
+            cacheAdapterProvider: new InMemoryFullCacheStubCacheAdapterProvider(),
+          },
+        ],
+      ]),
+    );
+
+    const companion1 = entityCompanionProvider.getCompanionForEntity(Blah1Entity);
+    const companion2 = entityCompanionProvider.getCompanionForEntity(BlahOtherDatabaseEntity);
+
+    expect(companion1['tableDataCoordinator']).not.toEqual(companion2['tableDataCoordinator']);
   });
 });


### PR DESCRIPTION
# Why

There's nothing preventing two entity classes from sharing the same class name. While not common in practice, this preemptively defends against the issue of collisions in companion maps.

Secondarily, table data coordinators could collide, even if they have different flavors of database and cache adapters. Since those are used to construct the coordinator, include their flavors in the map key.

# How

Update key generation code.

# Test Plan

Run new tests.