### PR TITLE
fix!: replace makeKeyFn with delimiter to strengthen guarantee of proper escaping

### DIFF
--- a/packages/entity-cache-adapter-redis/README.md
+++ b/packages/entity-cache-adapter-redis/README.md
@@ -13,13 +13,7 @@ import Redis from 'ioredis';
 
 const genericRedisCacherContext = {
   redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
-  makeKeyFn(...parts: string[]): string {
-    const delimiter = ':';
-    const escapedParts = parts.map((part) =>
-      part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`)
-    );
-    return escapedParts.join(delimiter);
-  },
+  cacheKeyDelimiter: ':',
   cacheKeyPrefix: 'ent-',
   ttlSecondsPositive: 86400, // 1 day
   ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -86,10 +86,15 @@ export interface GenericRedisCacheContext {
   redisClient: IRedis;
 
   /**
-   * Create a key string for key parts (cache key prefix, versions, entity name, etc).
-   * Most commonly a simple `parts.join(':')`. See integration test for example.
+   * Delimiter used to join the parts of a Redis cache key (cache key prefix,
+   * versions, entity name, field values, etc). Typically `:`.
+   *
+   * The cacher escapes occurrences of this delimiter (and the escape character `\`)
+   * within each part before joining, so the encoding is injective regardless of
+   * what the parts contain. This prevents a value that happens to contain the
+   * delimiter from colliding with a different (key, value) pair.
    */
-  makeKeyFn: (...parts: string[]) => string;
+  cacheKeyDelimiter: string;
 
   /**
    * Prefix prepended to all entity cache keys. Useful for adding a short, human-readable
@@ -212,14 +217,18 @@ export class GenericRedisCacher<
     TLoadValue extends IEntityLoadValue<TSerializedLoadValue>,
   >(key: TLoadKey, value: TLoadValue, cacheKeyVersion: number): string {
     const cacheKeyType = key.getLoadMethodType();
-    const parts = key.createCacheKeyPartsForLoadValue(this.entityConfiguration, value);
-    return this.context.makeKeyFn(
+    const keyAndValueParts = key.createCacheKeyPartsForLoadValue(this.entityConfiguration, value);
+    const allParts = [
       this.context.cacheKeyPrefix,
       cacheKeyType,
       this.entityConfiguration.tableName,
-      `v3.${cacheKeyVersion}`,
-      ...parts,
-    );
+      `v4.${cacheKeyVersion}`,
+      ...keyAndValueParts,
+    ];
+    const delimiter = this.context.cacheKeyDelimiter;
+    return allParts
+      .map((part) => part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`))
+      .join(delimiter);
   }
 
   public makeCacheKeyForStorage<

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/BatchedRedisCacheAdapter-integration-test.ts
@@ -68,13 +68,7 @@ describe(GenericRedisCacher, () => {
   beforeAll(() => {
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-full-integration-test.ts
@@ -26,13 +26,7 @@ describe(GenericRedisCacher, () => {
   beforeAll(() => {
     genericRedisCacheContext = {
       redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/GenericRedisCacher-integration-test.ts
@@ -20,13 +20,7 @@ describe(GenericRedisCacher, () => {
   beforeAll(() => {
     genericRedisCacheContext = {
       redisClient: new Redis(new URL(process.env['REDIS_URL']!).toString()),
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__integration-tests__/errors-test.ts
@@ -17,13 +17,7 @@ describe(GenericRedisCacher, () => {
   beforeAll(() => {
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -1,8 +1,11 @@
 import {
   CacheStatus,
+  CompositeFieldHolder,
+  CompositeFieldValueHolder,
   EntityConfiguration,
   SingleFieldHolder,
   SingleFieldValueHolder,
+  StringField,
   UUIDField,
 } from '@expo/entity';
 import { describe, expect, it } from '@jest/globals';
@@ -13,6 +16,8 @@ import { GenericRedisCacher, RedisCacheInvalidationStrategy } from '../GenericRe
 
 type BlahFields = {
   id: string;
+  fieldA: string;
+  fieldB: string;
 };
 
 const entityConfiguration = new EntityConfiguration<BlahFields, 'id'>({
@@ -21,6 +26,8 @@ const entityConfiguration = new EntityConfiguration<BlahFields, 'id'>({
   cacheKeyVersion: 2,
   schema: {
     id: new UUIDField({ columnName: 'id', cache: true }),
+    fieldA: new StringField({ columnName: 'field_a', cache: true }),
+    fieldB: new StringField({ columnName: 'field_b', cache: true }),
   },
   databaseAdapterFlavor: 'postgres',
   cacheAdapterFlavor: 'redis',
@@ -41,7 +48,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mockRedisClient),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -83,7 +90,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mock<Redis>()),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -118,7 +125,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mockRedisClient),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -134,10 +141,12 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
 
-      await genericCacher.cacheManyAsync(new Map([[cacheKey, { id: 'wat' }]]));
+      const value = { id: 'wat', fieldA: 'a', fieldB: 'b' };
+
+      await genericCacher.cacheManyAsync(new Map([[cacheKey, value]]));
 
       expect(redisResults.get(cacheKey)).toMatchObject({
-        value: JSON.stringify({ id: 'wat' }),
+        value: JSON.stringify(value),
         code: 'EX',
         ttl: 1,
       });
@@ -163,7 +172,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mockRedisClient),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -197,7 +206,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mockRedisClient),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -212,10 +221,38 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
       expect(cacheKeys).toHaveLength(1);
-      expect(cacheKeys[0]).toBe('hello-:single:blah:v3.2:id:wat');
+      expect(cacheKeys[0]).toBe('hello-:single:blah:v4.2:id:wat');
 
       await genericCacher.invalidateManyAsync(cacheKeys);
       verify(mockRedisClient.del(...cacheKeys)).once();
+    });
+
+    it('does not collapse composite cache keys with delimiter-bearing parts', () => {
+      const genericCacher = new GenericRedisCacher(
+        {
+          redisClient: instance(mock<Redis>()),
+          cacheKeyPrefix: 'hello-',
+          cacheKeyDelimiter: ':',
+          ttlSecondsPositive: 1,
+          ttlSecondsNegative: 2,
+          invalidationConfig: {
+            invalidationStrategy: RedisCacheInvalidationStrategy.CURRENT_CACHE_KEY_VERSION,
+          },
+        },
+        entityConfiguration,
+      );
+
+      const compositeFieldHolder = new CompositeFieldHolder<BlahFields, 'id'>(['fieldA', 'fieldB']);
+      const cacheKey1 = genericCacher['makeCacheKeyForStorage'](
+        compositeFieldHolder,
+        new CompositeFieldValueHolder({ fieldA: 'a:b', fieldB: 'c' }),
+      );
+      const cacheKey2 = genericCacher['makeCacheKeyForStorage'](
+        compositeFieldHolder,
+        new CompositeFieldValueHolder({ fieldA: 'a', fieldB: 'b:c' }),
+      );
+
+      expect(cacheKey1).not.toEqual(cacheKey2);
     });
 
     it('invalidates correctly with RedisCacheInvalidationStrategy.SURROUNDING_CACHE_KEY_VERSIONS', async () => {
@@ -225,7 +262,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mockRedisClient),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -240,9 +277,9 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
       expect(cacheKeys).toHaveLength(3);
-      expect(cacheKeys[0]).toBe('hello-:single:blah:v3.1:id:wat');
-      expect(cacheKeys[1]).toBe('hello-:single:blah:v3.2:id:wat');
-      expect(cacheKeys[2]).toBe('hello-:single:blah:v3.3:id:wat');
+      expect(cacheKeys[0]).toBe('hello-:single:blah:v4.1:id:wat');
+      expect(cacheKeys[1]).toBe('hello-:single:blah:v4.2:id:wat');
+      expect(cacheKeys[2]).toBe('hello-:single:blah:v4.3:id:wat');
 
       await genericCacher.invalidateManyAsync(cacheKeys);
       verify(mockRedisClient.del(...cacheKeys)).once();
@@ -255,7 +292,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mockRedisClient),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,
@@ -278,10 +315,10 @@ describe(GenericRedisCacher, () => {
         new SingleFieldValueHolder('wat'),
       );
       expect(cacheKeys).toHaveLength(4);
-      expect(cacheKeys[0]).toBe('hello-:single:blah:v3.2:id:wat');
-      expect(cacheKeys[1]).toBe('hello-:single:blah:v3.3:id:wat');
-      expect(cacheKeys[2]).toBe('hello-:single:blah:v3.4:id:wat');
-      expect(cacheKeys[3]).toBe('hello-:single:blah:v3.5:id:wat');
+      expect(cacheKeys[0]).toBe('hello-:single:blah:v4.2:id:wat');
+      expect(cacheKeys[1]).toBe('hello-:single:blah:v4.3:id:wat');
+      expect(cacheKeys[2]).toBe('hello-:single:blah:v4.4:id:wat');
+      expect(cacheKeys[3]).toBe('hello-:single:blah:v4.5:id:wat');
 
       await genericCacher.invalidateManyAsync(cacheKeys);
       verify(mockRedisClient.del(...cacheKeys)).once();
@@ -291,7 +328,7 @@ describe(GenericRedisCacher, () => {
       const genericCacher = new GenericRedisCacher(
         {
           redisClient: instance(mock<Redis>()),
-          makeKeyFn: (...parts) => parts.join(':'),
+          cacheKeyDelimiter: ':',
           cacheKeyPrefix: 'hello-',
           ttlSecondsPositive: 1,
           ttlSecondsNegative: 2,

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCacheInconsistency-test.ts
@@ -114,13 +114,7 @@ describe('Entity cache inconsistency', () => {
     });
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityCachePushSafety-test.ts
@@ -114,13 +114,7 @@ describe('Lack of entity cache push safety with RedisCacheInvalidationStrategy.C
     });
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes
@@ -206,13 +200,7 @@ describe('Entity cache push safety with RedisCacheInvalidationStrategy.SURROUNDI
     });
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityEdgesIntegration-test.ts
@@ -52,13 +52,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
     });
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntityIntegrity-test.ts
@@ -103,13 +103,7 @@ describe('Entity integrity', () => {
     });
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
+++ b/packages/entity-full-integration-tests/src/__integration-tests__/EntitySelfReferentialEdgesIntegration-test.ts
@@ -191,13 +191,7 @@ describe('EntityMutator.processEntityDeletionForInboundEdgesAsync', () => {
     });
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(...parts: string[]): string {
-        const delimiter = ':';
-        const escapedParts = parts.map((part) =>
-          part.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`),
-        );
-        return escapedParts.join(delimiter);
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -82,9 +82,7 @@ describe(RedisSecondaryEntityCache, () => {
   beforeAll(() => {
     genericRedisCacheContext = {
       redisClient,
-      makeKeyFn(): string {
-        throw new Error('should not be used by this test');
-      },
+      cacheKeyDelimiter: ':',
       cacheKeyPrefix: 'test-',
       ttlSecondsPositive: 86400, // 1 day
       ttlSecondsNegative: 600, // 10 minutes


### PR DESCRIPTION
# Why

Since cache key construction function is application-supplyable, there's potential that it doesn't escape properly, causing potential cache collisions.

# How

Change the API to only allow specifying the delimiter, and hoist code into the package to handle delimiter escape.

# Test Plan

Run new test to ensure no collisions on something that would've previously collided.