### PR TITLE
fix: update cache key generation for secondary caches

### DIFF
--- a/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
+++ b/packages/entity-secondary-cache-redis/src/RedisSecondaryEntityCache.ts
@@ -14,8 +14,21 @@ export class RedisSecondaryEntityCache<
   constructor(
     entityConfiguration: EntityConfiguration<TFields, TIDField>,
     genericRedisCacheContext: GenericRedisCacheContext,
-    constructRedisKey: (params: Readonly<TLoadParams>) => string,
+    cacheKeyNamespace: string,
+    constructRedisKeyParts: (params: Readonly<TLoadParams>) => readonly string[],
   ) {
+    const constructRedisKey = (params: Readonly<TLoadParams>): string => {
+      const cacheKeyParts = [
+        genericRedisCacheContext.cacheKeyPrefix,
+        'secondary',
+        cacheKeyNamespace,
+        ...constructRedisKeyParts(params),
+      ];
+      const delimiter = genericRedisCacheContext.cacheKeyDelimiter;
+      const escape = (s: string): string =>
+        s.replaceAll('\\', '\\\\').replaceAll(delimiter, `\\${delimiter}`);
+      return cacheKeyParts.map(escape).join(delimiter);
+    };
     super(new GenericRedisCacher(genericRedisCacheContext, entityConfiguration), constructRedisKey);
   }
 }

--- a/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
+++ b/packages/entity-secondary-cache-redis/src/__integration-tests__/RedisSecondaryEntityCache-integration-test.ts
@@ -112,7 +112,8 @@ describe(RedisSecondaryEntityCache, () => {
       new RedisSecondaryEntityCache(
         redisTestEntityConfiguration,
         genericRedisCacheContext,
-        (loadParams) => `test-key-${loadParams.id}`,
+        'test-namespace',
+        (loadParams) => ['test-key', loadParams.id],
       ),
       EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(RedisTestEntity, viewerContext),
       RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
@@ -152,7 +153,8 @@ describe(RedisSecondaryEntityCache, () => {
       new RedisSecondaryEntityCache(
         redisTestEntityConfiguration,
         genericRedisCacheContext,
-        (loadParams) => `test-key-${loadParams.id}`,
+        'test-namespace',
+        (loadParams) => ['test-key', loadParams.id],
       ),
       EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(RedisTestEntity, viewerContext),
       RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
@@ -162,5 +164,40 @@ describe(RedisSecondaryEntityCache, () => {
     const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
     expect(results.size).toBe(1);
     expect(results.get(loadParams)).toBe(null);
+  });
+
+  it('does not collapse cache keys with delimiter-bearing parts and uses namespace', async () => {
+    const viewerContext = new TestViewerContext(
+      createRedisIntegrationTestEntityCompanionProvider(genericRedisCacheContext),
+    );
+
+    const id = 'id-with-delimiter-' + genericRedisCacheContext.cacheKeyDelimiter;
+
+    const createdEntity = await RedisTestEntity.creator(viewerContext)
+      .setField('id', id)
+      .setField('name', 'wat')
+      .createAsync();
+
+    const secondaryCacheLoader = new TestSecondaryRedisCacheLoader(
+      new RedisSecondaryEntityCache(
+        redisTestEntityConfiguration,
+        genericRedisCacheContext,
+        'test-namespace',
+        (loadParams) => ['test-key', loadParams.id],
+      ),
+      EntitySecondaryCacheLoader.getConstructionUtilsForEntityClass(RedisTestEntity, viewerContext),
+      RedisTestEntity.loaderWithAuthorizationResults(viewerContext),
+    );
+
+    const loadParams = { id };
+    const results = await secondaryCacheLoader.loadManyAsync([loadParams]);
+    expect(results.size).toBe(1);
+    expect(nullthrows(results.get(loadParams)).enforceValue().getID()).toEqual(
+      createdEntity.getID(),
+    );
+
+    const redisKey = `${genericRedisCacheContext.cacheKeyPrefix}:secondary:test-namespace:test-key:id-with-delimiter-\\${genericRedisCacheContext.cacheKeyDelimiter}`;
+    const redisValues = await genericRedisCacheContext.redisClient.mget(redisKey);
+    expect(redisValues[0]).toBeTruthy();
   });
 });

--- a/packages/entity-secondary-cache-redis/src/__testfixtures__/RedisTestEntity.ts
+++ b/packages/entity-secondary-cache-redis/src/__testfixtures__/RedisTestEntity.ts
@@ -5,7 +5,6 @@ import {
   EntityConfiguration,
   EntityPrivacyPolicy,
   StringField,
-  UUIDField,
 } from '@expo/entity';
 
 export type RedisTestEntityFields = {
@@ -53,7 +52,7 @@ export const redisTestEntityConfiguration = new EntityConfiguration<RedisTestEnt
   idField: 'id',
   tableName: 'redis_test_entities',
   schema: {
-    id: new UUIDField({
+    id: new StringField({
       columnName: 'id',
       cache: false,
     }),

--- a/packages/entity/src/GenericSecondaryEntityCache.ts
+++ b/packages/entity/src/GenericSecondaryEntityCache.ts
@@ -16,8 +16,8 @@ export abstract class GenericSecondaryEntityCache<
   TLoadParams,
 > implements ISecondaryEntityCache<TFields, TLoadParams> {
   constructor(
-    protected readonly cacher: IEntityGenericCacher<TFields, TIDField>,
-    protected readonly constructCacheKey: (params: Readonly<TLoadParams>) => string,
+    private readonly cacher: IEntityGenericCacher<TFields, TIDField>,
+    private readonly constructCacheKey: (params: Readonly<TLoadParams>) => string,
   ) {}
 
   public async loadManyThroughAsync(


### PR DESCRIPTION
# Why

Similar to #601, it was possible for a misconfigured application to have collisions in cache keys for secondary caches. Because they likely share the same redis instance at the application level, these keys need similar treatment for separating them logically from normal loader keys plus consistent delimiter escaping.

# How

Hoist final key creation from application level to library level and apply consistent delimiter escaping and namespacing.

# Test Plan

Run new test.