### PR TITLE
feat: clean up transactional dataloader at transaction end

### DIFF
--- a/packages/entity/src/EntityQueryContext.ts
+++ b/packages/entity/src/EntityQueryContext.ts
@@ -137,6 +137,8 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
 
   private readonly preCommitCallbacks: { callback: PreCommitCallback; order: number }[] = [];
 
+  private readonly transactionEndCallbacks: (() => void)[] = [];
+
   constructor(
     queryInterface: any,
     private readonly entityQueryContextProvider: EntityQueryContextProvider,
@@ -197,6 +199,30 @@ export class EntityTransactionalQueryContext extends EntityQueryContext {
    */
   public appendPostCommitCallback(callback: PostCommitCallback): void {
     this.postCommitCallbacks.push(callback);
+  }
+
+  /**
+   * Schedule a callback to run when the transaction ends, regardless of whether it commits or rolls back.
+   * When the transaction is successful, these run after post-commit callbacks. When the transaction rolls back,
+   * these run after the rollback is complete. Use for resource cleanup tied to the transaction's
+   * lifetime (e.g. dropping per-transaction in-memory state).
+   * @param callback - synchronous cleanup callback to schedule
+   *
+   * @internal
+   */
+  public appendTransactionEndCallback(callback: () => void): void {
+    this.transactionEndCallbacks.push(callback);
+  }
+
+  /**
+   * @internal
+   */
+  public runTransactionEndCallbacks(): void {
+    const callbacks = [...this.transactionEndCallbacks];
+    this.transactionEndCallbacks.length = 0;
+    for (const callback of callbacks) {
+      callback();
+    }
   }
 
   /**

--- a/packages/entity/src/EntityQueryContextProvider.ts
+++ b/packages/entity/src/EntityQueryContextProvider.ts
@@ -50,27 +50,33 @@ export abstract class EntityQueryContextProvider {
     transactionScope: (queryContext: EntityTransactionalQueryContext) => Promise<T>,
     transactionConfig?: TransactionConfig,
   ): Promise<T> {
-    const [returnedValue, queryContext] = await this.createTransactionRunner<
-      [T, EntityTransactionalQueryContext]
-    >(transactionConfig)(async (queryInterface) => {
-      const resolvedTransactionConfig: ResolvedTransactionConfig = {
-        ...transactionConfig,
-        transactionalDataLoaderMode:
-          transactionConfig?.transactionalDataLoaderMode ??
-          this.defaultTransactionalDataLoaderMode(),
-      };
-      const queryContext = new EntityTransactionalQueryContext(
-        queryInterface,
-        this,
-        randomUUID(),
-        resolvedTransactionConfig,
-      );
-      const result = await transactionScope(queryContext);
-      await queryContext.runPreCommitCallbacksAsync();
-      return [result, queryContext];
-    });
-    await queryContext.runPostCommitCallbacksAsync();
-    return returnedValue;
+    let queryContextForCleanup: EntityTransactionalQueryContext | undefined;
+    try {
+      const [returnedValue, queryContext] = await this.createTransactionRunner<
+        [T, EntityTransactionalQueryContext]
+      >(transactionConfig)(async (queryInterface) => {
+        const resolvedTransactionConfig: ResolvedTransactionConfig = {
+          ...transactionConfig,
+          transactionalDataLoaderMode:
+            transactionConfig?.transactionalDataLoaderMode ??
+            this.defaultTransactionalDataLoaderMode(),
+        };
+        const queryContext = new EntityTransactionalQueryContext(
+          queryInterface,
+          this,
+          randomUUID(),
+          resolvedTransactionConfig,
+        );
+        queryContextForCleanup = queryContext;
+        const result = await transactionScope(queryContext);
+        await queryContext.runPreCommitCallbacksAsync();
+        return [result, queryContext];
+      });
+      await queryContext.runPostCommitCallbacksAsync();
+      return returnedValue;
+    } finally {
+      queryContextForCleanup?.runTransactionEndCallbacks();
+    }
   }
 
   /**
@@ -83,22 +89,28 @@ export abstract class EntityQueryContextProvider {
     outerQueryContext: EntityTransactionalQueryContext,
     transactionScope: (innerQueryContext: EntityNestedTransactionalQueryContext) => Promise<T>,
   ): Promise<T> {
-    const [returnedValue, innerQueryContext] = await this.createNestedTransactionRunner<
-      [T, EntityNestedTransactionalQueryContext]
-    >(outerQueryContext.getQueryInterface())(async (innerQueryInterface) => {
-      const innerQueryContext = new EntityNestedTransactionalQueryContext(
-        innerQueryInterface,
-        outerQueryContext,
-        this,
-        randomUUID(),
-        outerQueryContext.transactionConfig,
-      );
-      const result = await transactionScope(innerQueryContext);
-      await innerQueryContext.runPreCommitCallbacksAsync();
-      return [result, innerQueryContext];
-    });
-    // behavior of this call differs for nested transaction query contexts from regular transaction query contexts
-    await innerQueryContext.runPostCommitCallbacksAsync();
-    return returnedValue;
+    let innerQueryContextForCleanup: EntityNestedTransactionalQueryContext | undefined;
+    try {
+      const [returnedValue, innerQueryContext] = await this.createNestedTransactionRunner<
+        [T, EntityNestedTransactionalQueryContext]
+      >(outerQueryContext.getQueryInterface())(async (innerQueryInterface) => {
+        const innerQueryContext = new EntityNestedTransactionalQueryContext(
+          innerQueryInterface,
+          outerQueryContext,
+          this,
+          randomUUID(),
+          outerQueryContext.transactionConfig,
+        );
+        innerQueryContextForCleanup = innerQueryContext;
+        const result = await transactionScope(innerQueryContext);
+        await innerQueryContext.runPreCommitCallbacksAsync();
+        return [result, innerQueryContext];
+      });
+      // behavior of this call differs for nested transaction query contexts from regular transaction query contexts
+      await innerQueryContext.runPostCommitCallbacksAsync();
+      return returnedValue;
+    } finally {
+      innerQueryContextForCleanup?.runTransactionEndCallbacks();
+    }
   }
 }

--- a/packages/entity/src/internal/EntityDataManager.ts
+++ b/packages/entity/src/internal/EntityDataManager.ts
@@ -117,7 +117,12 @@ export class EntityDataManager<
     const dataLoaderMapForTransaction = computeIfAbsent(
       this.transactionalDataLoaders,
       queryContext.transactionId,
-      () => new Map(),
+      () => {
+        queryContext.appendTransactionEndCallback(() => {
+          this.transactionalDataLoaders.delete(queryContext.transactionId);
+        });
+        return new Map();
+      },
     );
     return computeIfAbsent(
       dataLoaderMapForTransaction,

--- a/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
+++ b/packages/entity/src/internal/__tests__/EntityDataManager-test.ts
@@ -792,6 +792,60 @@ describe(EntityDataManager, () => {
     expect(entityDataManager['transactionalDataLoaders'].size).toBe(0);
   });
 
+  it('releases transactional dataloader state when transactions end', async () => {
+    const objects = getObjects();
+    const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(
+      testEntityConfiguration,
+      objects,
+    );
+    const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+      testEntityConfiguration,
+      dataStore,
+    );
+    const cacheAdapterProvider = new InMemoryFullCacheStubCacheAdapterProvider();
+    const cacheAdapter = cacheAdapterProvider.getCacheAdapter(testEntityConfiguration);
+    const entityCache = new ReadThroughEntityCache(testEntityConfiguration, cacheAdapter);
+    const entityDataManager = new EntityDataManager(
+      databaseAdapter,
+      entityCache,
+      new StubQueryContextProvider(),
+      new NoOpEntityMetricsAdapter(),
+      TestEntity.name,
+    );
+    const provider = new StubQueryContextProvider();
+    const objectInQuestion = objects.get(testEntityConfiguration.tableName)![1]!;
+
+    await provider.runInTransactionAsync(async (queryContext) => {
+      await entityDataManager.loadManyEqualingAsync(
+        queryContext,
+        new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
+        [new SingleFieldValueHolder(objectInQuestion['customIdField'])],
+      );
+      await queryContext.runInNestedTransactionAsync(async (innerQueryContext) => {
+        await entityDataManager.loadManyEqualingAsync(
+          innerQueryContext,
+          new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
+          [new SingleFieldValueHolder(objectInQuestion['customIdField'])],
+        );
+        expect(entityDataManager['transactionalDataLoaders'].size).toBe(2);
+      });
+      expect(entityDataManager['transactionalDataLoaders'].size).toBe(1);
+    });
+    expect(entityDataManager['transactionalDataLoaders'].size).toBe(0);
+
+    await expect(
+      provider.runInTransactionAsync(async (queryContext) => {
+        await entityDataManager.loadManyEqualingAsync(
+          queryContext,
+          new SingleFieldHolder<TestFields, 'customIdField', 'customIdField'>('customIdField'),
+          [new SingleFieldValueHolder(objectInQuestion['customIdField'])],
+        );
+        throw new Error('transaction failure');
+      }),
+    ).rejects.toThrow('transaction failure');
+    expect(entityDataManager['transactionalDataLoaders'].size).toBe(0);
+  });
+
   it('does not load from cache when in transaction', async () => {
     const objects = getObjects();
     const dataStore = StubDatabaseAdapter.convertFieldObjectsToDataStore(


### PR DESCRIPTION
# Why

One way memory can grow unbounded within a single request is via transactional dataloaders. If a single request executes N transactions, each one accumulates it's own dataloader state.

Though this has the same semantics as regular dataloaders (which belong to companion provider which is scoped to request by application and discarded after response is sent), they can accumulate more.

# How

The fix is to clear the transactional dataloader at the end of the transaction (or nested transaction), no matter whether the transaction succeeded or rolled-back.

# Test Plan

Add test for condition.