### PR TITLE
fix: handle potential infinite recursion for canViewerDeleteAsync

### DIFF
--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -9,6 +9,7 @@ import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
 import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
 import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder.ts';
 import { AlwaysAllowPrivacyPolicyRule } from '../rules/AlwaysAllowPrivacyPolicyRule.ts';
+import { canViewerDeleteAsync } from '../utils/EntityPrivacyUtils.ts';
 import type { InMemoryFullCacheStubCacheAdapter } from '../utils/__testfixtures__/StubCacheAdapter.ts';
 import { TestViewerContext } from '../utils/__testfixtures__/TestViewerContext.ts';
 import { createUnitTestEntityCompanionProvider } from '../utils/__testfixtures__/createUnitTestEntityCompanionProvider.ts';
@@ -143,6 +144,23 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     await expect(
       CategoryEntity.loader(viewerContext).loadByIDNullableAsync(categoryB.getID()),
     ).resolves.toBeNull();
+  });
+
+  it('handles cycles in canViewerDeleteAsync preflight', async () => {
+    const { CategoryEntity } = makeEntityClass(EntityEdgeDeletionBehavior.CASCADE_DELETE);
+
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new TestViewerContext(companionProvider);
+
+    const categoryA = await CategoryEntity.creator(viewerContext).createAsync();
+    const categoryB = await CategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', categoryA.getID())
+      .createAsync();
+    await CategoryEntity.updater(categoryA)
+      .setField('parent_category_id', categoryB.getID())
+      .updateAsync();
+
+    await expect(canViewerDeleteAsync(CategoryEntity, categoryA)).resolves.toBe(true);
   });
 });
 

--- a/packages/entity/src/utils/EntityPrivacyUtils.ts
+++ b/packages/entity/src/utils/EntityPrivacyUtils.ts
@@ -229,6 +229,7 @@ export async function canViewerDeleteAsync<
     sourceEntity,
     { previousValue: null, cascadingDeleteCause: null },
     queryContext,
+    new Set(),
   );
   return result.allowed;
 }
@@ -276,6 +277,7 @@ export async function getCanViewerDeleteResultAsync<
     sourceEntity,
     { previousValue: null, cascadingDeleteCause: null },
     queryContext,
+    new Set(),
   );
 }
 
@@ -310,7 +312,15 @@ async function canViewerDeleteInternalAsync<
     TSelectedFields
   >,
   queryContext: EntityQueryContext,
+  processedEntityIdentifiers: Set<string>,
 ): Promise<EntityPrivacyEvaluationResult> {
+  // prevent infinite reference cycles by short-circuiting on entities already being checked
+  // higher up in the recursion; their authorization is determined by the in-progress check
+  if (processedEntityIdentifiers.has(sourceEntity.getUniqueIdentifier())) {
+    return { allowed: true };
+  }
+  processedEntityIdentifiers.add(sourceEntity.getUniqueIdentifier());
+
   const viewerContext = sourceEntity.getViewerContext();
   const entityCompanionProvider = viewerContext.entityCompanionProvider;
   const viewerScopedCompanion = sourceEntity
@@ -434,6 +444,7 @@ async function canViewerDeleteInternalAsync<
                 entity,
                 { previousValue: null, cascadingDeleteCause: newCascadingDeleteCause },
                 queryContext,
+                processedEntityIdentifiers,
               ),
             ),
           );


### PR DESCRIPTION
# Why

In the same way that `processEntityDeletionForInboundEdgesAsync` has detection for reference cycles, this preemptive check utility method needs the same detection mechanism.

# How

Add the same detection mechanism as `processedEntityIdentifiers`

# Test Plan

Add test case for this that fails before change, succeeds after.