### PR TITLE
fix: correct cycle guard behavior for deletion

### DIFF
--- a/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityMutator.ts
@@ -804,6 +804,14 @@ export class AuthorizationResultBasedDeleteMutator<
     processedEntityIdentifiersFromTransitiveDeletions: Set<string>,
     skipDatabaseDeletion: boolean,
   ): Promise<Result<void>> {
+    // prevent infinite reference cycles AND avoid re-running deletion side effects
+    // (authorization, validators, triggers, DB delete, invalidation) for an entity that
+    // is already being deleted higher up the cascade stack
+    if (processedEntityIdentifiersFromTransitiveDeletions.has(this.entity.getUniqueIdentifier())) {
+      return result();
+    }
+    processedEntityIdentifiersFromTransitiveDeletions.add(this.entity.getUniqueIdentifier());
+
     const authorizeDeleteResult = await asyncResult(
       this.privacyPolicy.authorizeDeleteAsync(
         this.viewerContext,
@@ -928,12 +936,6 @@ export class AuthorizationResultBasedDeleteMutator<
     queryContext: EntityTransactionalQueryContext,
     processedEntityIdentifiers: Set<string>,
   ): Promise<void> {
-    // prevent infinite reference cycles by keeping track of entities already processed
-    if (processedEntityIdentifiers.has(entity.getUniqueIdentifier())) {
-      return;
-    }
-    processedEntityIdentifiers.add(entity.getUniqueIdentifier());
-
     const companionDefinition = this.companionProvider.getCompanionForEntity(
       entity.constructor as IEntityClass<
         TFields,

--- a/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
+++ b/packages/entity/src/__tests__/EntitySelfReferentialEdges-test.ts
@@ -5,6 +5,7 @@ import type { EntityCompanionDefinition } from '../EntityCompanionProvider.ts';
 import { EntityConfiguration } from '../EntityConfiguration.ts';
 import { EntityEdgeDeletionBehavior } from '../EntityFieldDefinition.ts';
 import { UUIDField } from '../EntityFields.ts';
+import { EntityMutationTrigger } from '../EntityMutationTriggerConfiguration.ts';
 import { EntityPrivacyPolicy } from '../EntityPrivacyPolicy.ts';
 import { CacheStatus } from '../internal/ReadThroughEntityCache.ts';
 import { SingleFieldHolder, SingleFieldValueHolder } from '../internal/SingleFieldHolder.ts';
@@ -144,6 +145,79 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE', () => {
     await expect(
       CategoryEntity.loader(viewerContext).loadByIDNullableAsync(categoryB.getID()),
     ).resolves.toBeNull();
+  });
+
+  it('fires delete-side-effects exactly once per entity in a cycle', async () => {
+    const afterDeleteCallsById: string[] = [];
+
+    class CountingTrigger extends EntityMutationTrigger<
+      CategoryFields,
+      'id',
+      TestViewerContext,
+      any
+    > {
+      async executeAsync(
+        _vc: TestViewerContext,
+        _qc: any,
+        entity: { getID(): string },
+      ): Promise<void> {
+        afterDeleteCallsById.push(entity.getID());
+      }
+    }
+
+    class TriggeredCategoryEntity extends Entity<CategoryFields, 'id', TestViewerContext> {
+      static defineCompanionDefinition(): EntityCompanionDefinition<
+        CategoryFields,
+        'id',
+        TestViewerContext,
+        TriggeredCategoryEntity,
+        CategoryPrivacyPolicy
+      > {
+        return {
+          entityClass: TriggeredCategoryEntity,
+          entityConfiguration: configuration,
+          privacyPolicyClass: CategoryPrivacyPolicy,
+          mutationTriggers: {
+            afterDelete: [new CountingTrigger()],
+          },
+        };
+      }
+    }
+
+    const configuration = new EntityConfiguration<CategoryFields, 'id'>({
+      idField: 'id',
+      tableName: 'categories',
+      inboundEdges: [TriggeredCategoryEntity],
+      schema: {
+        id: new UUIDField({ columnName: 'id', cache: true }),
+        parent_category_id: new UUIDField({
+          columnName: 'parent_category_id',
+          cache: true,
+          association: {
+            associatedEntityClass: TriggeredCategoryEntity,
+            edgeDeletionBehavior: EntityEdgeDeletionBehavior.CASCADE_DELETE,
+          },
+        }),
+      },
+      databaseAdapterFlavor: 'postgres',
+      cacheAdapterFlavor: 'redis',
+    });
+
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new TestViewerContext(companionProvider);
+
+    const initialA = await TriggeredCategoryEntity.creator(viewerContext).createAsync();
+    const categoryB = await TriggeredCategoryEntity.creator(viewerContext)
+      .setField('parent_category_id', initialA.getID())
+      .createAsync();
+    const categoryA = await TriggeredCategoryEntity.updater(initialA)
+      .setField('parent_category_id', categoryB.getID())
+      .updateAsync();
+
+    await TriggeredCategoryEntity.deleter(categoryA).deleteAsync();
+
+    expect(afterDeleteCallsById.filter((id) => id === categoryA.getID())).toHaveLength(1);
+    expect(afterDeleteCallsById.filter((id) => id === categoryB.getID())).toHaveLength(1);
   });
 
   it('handles cycles in canViewerDeleteAsync preflight', async () => {
@@ -320,11 +394,11 @@ describe('EntityEdgeDeletionBehavior.CASCADE_DELETE_INVALIDATE_CACHE', () => {
     const companionProvider = createUnitTestEntityCompanionProvider();
     const viewerContext = new TestViewerContext(companionProvider);
 
-    const categoryA = await CategoryEntity.creator(viewerContext).createAsync();
+    const initialCategoryA = await CategoryEntity.creator(viewerContext).createAsync();
     const categoryB = await CategoryEntity.creator(viewerContext)
-      .setField('parent_category_id', categoryA.getID())
+      .setField('parent_category_id', initialCategoryA.getID())
       .createAsync();
-    await CategoryEntity.updater(categoryA)
+    const categoryA = await CategoryEntity.updater(initialCategoryA)
       .setField('parent_category_id', categoryB.getID())
       .updateAsync();
 


### PR DESCRIPTION
# Why

There is a bug in self-referential (or transitively-self-referential) cascade cycle detection.

From claude:
```
In AuthorizationResultBasedDeleteMutator:

- deleteInternalAsync (line 802) runs the authorize check, calls
processEntityDeletionForInboundEdgesAsync, runs validators/triggers, deletes the row, and schedules
invalidation callbacks and afterCommit triggers.
- The cycle guard is at the top of processEntityDeletionForInboundEdgesAsync (line 932) — if
(processedEntityIdentifiers.has(entity.getUniqueIdentifier())) return;.

Trace a cycle (A↔B cascade-delete):
1. deleteInternalAsync(A, visited=∅) → runs authorize+triggers+DB delete for A →
processEntityDeletionForInboundEdgesAsync(A, visited=∅), marks A visited, finds B, calls
deleteInternalAsync(B, visited={A}).
2. deleteInternalAsync(B, visited={A}) → runs authorize+triggers+DB delete for B →
processEntityDeletionForInboundEdgesAsync(B, visited={A}), marks B visited, finds A, calls deleteInternalAsync(A,
visited={A,B}).
3. deleteInternalAsync(A, visited={A,B}) → runs authorize+triggers+DB delete for A again → only when it gets into
processEntityDeletionForInboundEdgesAsync does the visited check finally short-circuit.

So beforeDelete/afterDelete/beforeAll/afterAll, the database delete, the post-commit invalidation, and
afterCommit triggers all fire twice for A. The DB delete is idempotent (row's already gone) but triggers
with side effects (emit events, write audit rows, etc.) double-fire.
```

# How

Fix is to move cycle detection to to of `deleteInternalAsync`, thus guarding all checks for already-run entities.

# Test Plan

- Run new test
- Existing test was passing due a stale entity being passed into deleter. The why is a bit nuanced. Here's claude:

```
The original test setup

  const categoryA = await CategoryEntity.creator(viewerContext).createAsync();
  const categoryB = await CategoryEntity.creator(viewerContext)
    .setField('parent_category_id', categoryA.getID())
    .createAsync();
  await CategoryEntity.updater(categoryA)
    .setField('parent_category_id', categoryB.getID())
    .updateAsync();

  After these three statements, the database state is:
  - A: {id: uuidA, parent_category_id: uuidB} (after update)
  - B: {id: uuidB, parent_category_id: uuidA}

  But the local variable categoryA still holds the original entity instance from line 1, where
  parent_category_id was null. updateAsync() returns a new entity, but that return value is discarded — the
  local categoryA was never rebound. So categoryA.getAllDatabaseFields() in the test returns {id: uuidA,
  parent_category_id: null}.

  Why the test passed before the fix

  When the test calls CategoryEntity.deleter(categoryA).deleteAsync(), the outermost mutator's this.entity
  is the stale categoryA (with parent_category_id = null).

  Trace through the OLD cycle behavior for CASCADE_DELETE_INVALIDATE_CACHE_ONLY (so skipDatabaseDeletion =
  true on cascade calls):

  1. Outer A mutator runs. this.entity = stale A. Traverses inbound edges of A, finds B.
  2. Middle B mutator runs (cascade). this.entity = freshly-loaded B from DB (correct fields). Traverses
  inbound edges of B, finds A → cascades to A again.
  3. Inner A mutator runs (cycle re-entry). this.entity = freshly-loaded A from DB, with parent_category_id
  = uuidB (the post-update value).

  3. Under the OLD code, the cycle guard at the top of processEntityDeletionForInboundEdgesAsync stops the
  traversal from recursing further, but the inner deleteInternalAsync still runs validators, triggers, and
  registers a post-commit invalidation callback using this freshly-loaded A's fields.

  After commit, the post-commit invalidation callbacks fire:
  - Outer A registers invalidation for {id: uuidA, parent_category_id: null} → invalidates (id, uuidA) only
  (null isn't a cache key).
  - Middle B registers invalidation for {id: uuidB, parent_category_id: uuidA} → invalidates (id, uuidB) and
   (parent_category_id, uuidA).
  - Inner A registers invalidation for {id: uuidA, parent_category_id: uuidB} → invalidates (id, uuidA) and
  (parent_category_id, uuidB).

  The test asserts that (parent_category_id, uuidB) is invalidated, and it was — because of the inner A's
  fresh-loaded fields. The OLD bug (running deletion side effects twice) was accidentally compensating for
  the stale entity reference held by the test.

  Why the test failed after the fix

  With the cycle guard moved to the top of deleteInternalAsync, the inner A call returns immediately without
   registering any invalidation. Only the outer A's invalidation runs, with the stale parent_category_id =
  null, so (parent_category_id, uuidB) is never invalidated → still HIT → assertion fails.

  This isn't a regression in real-world usage. In real code, callers don't keep stale references after
  updating, because:
  - The idiomatic pattern is const x = await Entity.updater(x)...updateAsync() (rebinding).
  - Non-cycle deletions of stale references already produced incomplete invalidation in the OLD code — the
  cascade re-load only happened to "rescue" the cycle path.

  After the fix, cycle and non-cycle paths behave consistently: the entity instance the caller hands to
  deleter() is the source of truth for what gets invalidated.

  The test edit

  const initialCategoryA = await CategoryEntity.creator(viewerContext).createAsync();
  const categoryB = await CategoryEntity.creator(viewerContext)
    .setField('parent_category_id', initialCategoryA.getID())
    .createAsync();
  const categoryA = await CategoryEntity.updater(initialCategoryA)
    .setField('parent_category_id', categoryB.getID())
    .updateAsync();

  categoryA now binds to the return value of updateAsync(), so it carries the post-update fields. The cycle
  behavior remains under test — the assertion that both (parent_category_id, uuidA) and (parent_category_id,
   uuidB) are MISS still verifies that the cascade correctly invalidated B's and A's cache keys. The fix to
  the test reflects correct API usage, and the cycle handling is independently confirmed by the new fires
  delete-side-effects exactly once per entity in a cycle test.
```