### PR TITLE
fix: skip when AllowIfAllSubRulesAllowPrivacyPolicyRule is empty

### DIFF
--- a/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
+++ b/packages/entity/src/rules/AllowIfAllSubRulesAllowPrivacyPolicyRule.ts
@@ -35,6 +35,9 @@ export class AllowIfAllSubRulesAllowPrivacyPolicyRule<
     >,
     entity: TEntity,
   ): Promise<RuleEvaluationResult> {
+    if (this.subRules.length === 0) {
+      return RuleEvaluationResult.SKIP;
+    }
     const results = await Promise.all(
       this.subRules.map((subRule) =>
         subRule.evaluateAsync(viewerContext, queryContext, evaluationContext, entity),

--- a/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
+++ b/packages/entity/src/rules/__tests__/AllowIfAllSubRulesAllowPrivacyPolicyRule-test.ts
@@ -62,3 +62,15 @@ describePrivacyPolicyRule(
     ],
   },
 );
+
+describePrivacyPolicyRule(new AllowIfAllSubRulesAllowPrivacyPolicyRule([]), {
+  skipCases: [
+    {
+      viewerContext: instance(mock(ViewerContext)),
+      queryContext: instance(mock(EntityQueryContext)),
+      evaluationContext:
+        instance(mock<EntityPrivacyPolicyRuleEvaluationContext<any, any, any, any, any>>()),
+      entity: anything(),
+    },
+  ],
+});


### PR DESCRIPTION
# Why

In places where a rule list is dynamically composed, it's likely possible for this list to be empty. Due to the way it's written, it would erroneously allow in this case.

# How

Add check for case and skip.

# Test Plan

Add test.