### PR TITLE
feat: validate GenericRedisCacheContext

### DIFF
--- a/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
+++ b/packages/entity-cache-adapter-redis/src/GenericRedisCacher.ts
@@ -79,6 +79,27 @@ export type GenericRedisCacheInvalidationConfig =
       cacheKeyVersionsToInvalidateFn: (cacheKeyVersion: number) => readonly number[];
     };
 
+function validateGenericRedisCacheContext(context: GenericRedisCacheContext): void {
+  if (context.cacheKeyDelimiter.length === 0) {
+    throw new Error('GenericRedisCacheContext.cacheKeyDelimiter must be a non-empty string');
+  }
+  if (context.cacheKeyDelimiter.includes('\\')) {
+    throw new Error(
+      `GenericRedisCacheContext.cacheKeyDelimiter must not contain the escape character "\\" (got ${JSON.stringify(context.cacheKeyDelimiter)})`,
+    );
+  }
+  if (!Number.isInteger(context.ttlSecondsPositive) || context.ttlSecondsPositive <= 0) {
+    throw new Error(
+      `GenericRedisCacheContext.ttlSecondsPositive must be a positive integer (got ${context.ttlSecondsPositive})`,
+    );
+  }
+  if (!Number.isInteger(context.ttlSecondsNegative) || context.ttlSecondsNegative <= 0) {
+    throw new Error(
+      `GenericRedisCacheContext.ttlSecondsNegative must be a positive integer (got ${context.ttlSecondsNegative})`,
+    );
+  }
+}
+
 export interface GenericRedisCacheContext {
   /**
    * Instance of ioredis.Redis
@@ -127,7 +148,9 @@ export class GenericRedisCacher<
   constructor(
     private readonly context: GenericRedisCacheContext,
     private readonly entityConfiguration: EntityConfiguration<TFields, TIDField>,
-  ) {}
+  ) {
+    validateGenericRedisCacheContext(context);
+  }
 
   public async loadManyAsync(
     keys: readonly string[],
@@ -259,12 +282,19 @@ export class GenericRedisCacher<
         ).map((cacheKeyVersion) =>
           this.makeCacheKeyForCacheKeyVersion(key, value, cacheKeyVersion),
         );
-      case RedisCacheInvalidationStrategy.CUSTOM:
-        return this.context.invalidationConfig
-          .cacheKeyVersionsToInvalidateFn(this.entityConfiguration.cacheKeyVersion)
-          .map((cacheKeyVersion) =>
-            this.makeCacheKeyForCacheKeyVersion(key, value, cacheKeyVersion),
+      case RedisCacheInvalidationStrategy.CUSTOM: {
+        const cacheKeyVersions = this.context.invalidationConfig.cacheKeyVersionsToInvalidateFn(
+          this.entityConfiguration.cacheKeyVersion,
+        );
+        if (cacheKeyVersions.length === 0) {
+          throw new Error(
+            `GenericRedisCacheContext.invalidationConfig.cacheKeyVersionsToInvalidateFn returned an empty list for cacheKeyVersion ${this.entityConfiguration.cacheKeyVersion}; this would silently disable invalidation`,
           );
+        }
+        return cacheKeyVersions.map((cacheKeyVersion) =>
+          this.makeCacheKeyForCacheKeyVersion(key, value, cacheKeyVersion),
+        );
+      }
     }
   }
 }

--- a/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
+++ b/packages/entity-cache-adapter-redis/src/__tests__/GenericRedisCacher-test.ts
@@ -340,5 +340,89 @@ describe(GenericRedisCacher, () => {
       );
       await genericCacher.invalidateManyAsync([]);
     });
+
+    it('throws when CUSTOM strategy returns an empty cacheKeyVersions list', () => {
+      const genericCacher = new GenericRedisCacher(
+        {
+          redisClient: instance(mock<Redis>()),
+          cacheKeyDelimiter: ':',
+          cacheKeyPrefix: 'hello-',
+          ttlSecondsPositive: 1,
+          ttlSecondsNegative: 2,
+          invalidationConfig: {
+            invalidationStrategy: RedisCacheInvalidationStrategy.CUSTOM,
+            cacheKeyVersionsToInvalidateFn: () => [],
+          },
+        },
+        entityConfiguration,
+      );
+      expect(() =>
+        genericCacher['makeCacheKeysForInvalidation'](
+          new SingleFieldHolder('id'),
+          new SingleFieldValueHolder('wat'),
+        ),
+      ).toThrow(/empty list/);
+    });
+  });
+
+  describe('GenericRedisCacheContext validation', () => {
+    const validContext = {
+      redisClient: instance(mock<Redis>()),
+      cacheKeyDelimiter: ':',
+      cacheKeyPrefix: 'hello-',
+      ttlSecondsPositive: 1,
+      ttlSecondsNegative: 2,
+      invalidationConfig: {
+        invalidationStrategy: RedisCacheInvalidationStrategy.CURRENT_CACHE_KEY_VERSION as const,
+      },
+    };
+
+    it('throws when cacheKeyDelimiter is empty', () => {
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, cacheKeyDelimiter: '' }, entityConfiguration),
+      ).toThrow(/cacheKeyDelimiter must be a non-empty string/);
+    });
+
+    it('throws when cacheKeyDelimiter contains the escape character', () => {
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, cacheKeyDelimiter: '\\' }, entityConfiguration),
+      ).toThrow(/must not contain the escape character/);
+    });
+
+    it('throws when ttlSecondsPositive is not a positive integer', () => {
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, ttlSecondsPositive: 0 }, entityConfiguration),
+      ).toThrow(/ttlSecondsPositive must be a positive integer/);
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, ttlSecondsPositive: -1 }, entityConfiguration),
+      ).toThrow(/ttlSecondsPositive must be a positive integer/);
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, ttlSecondsPositive: 1.5 }, entityConfiguration),
+      ).toThrow(/ttlSecondsPositive must be a positive integer/);
+    });
+
+    it('throws when ttlSecondsNegative is not a positive integer', () => {
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, ttlSecondsNegative: 0 }, entityConfiguration),
+      ).toThrow(/ttlSecondsNegative must be a positive integer/);
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, ttlSecondsNegative: -1 }, entityConfiguration),
+      ).toThrow(/ttlSecondsNegative must be a positive integer/);
+      expect(
+        () =>
+          new GenericRedisCacher({ ...validContext, ttlSecondsNegative: 1.5 }, entityConfiguration),
+      ).toThrow(/ttlSecondsNegative must be a positive integer/);
+    });
+
+    it('accepts a valid context', () => {
+      expect(() => new GenericRedisCacher(validContext, entityConfiguration)).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
# Why

#601 exposed another validation gap in assumptions made about cache keys. We need certain assumptions to be true, namely:
- delimiter is nonzero-length (otherwise issue #601 fixes still would exist)
- delimiter doesn't include escape character (otherwise escape breaks)
- ttlSecondsPositive and negative are positive integers
- cacheKeyVersionsToInvalidateFn returns > 0 versions (otherwise silently doesn't invalidate)

# How

Add validation.

# Test Plan

Add test.