### PR TITLE
fix: fix behavior of AuthorizationResultBasedEntityAssociationLoader when field value is empty string

### DIFF
--- a/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
+++ b/packages/entity/src/AuthorizationResultBasedEntityAssociationLoader.ts
@@ -64,7 +64,7 @@ export class AuthorizationResultBasedEntityAssociationLoader<
     Result<null extends TFields[TIdentifyingField] ? TAssociatedEntity | null : TAssociatedEntity>
   > {
     const associatedEntityID = this.entity.getField(fieldIdentifyingAssociatedEntity);
-    if (!associatedEntityID) {
+    if (associatedEntityID === null || associatedEntityID === undefined) {
       return result(null) as Result<
         null extends TFields[TIdentifyingField] ? TAssociatedEntity | null : TAssociatedEntity
       >;

--- a/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
+++ b/packages/entity/src/__tests__/AuthorizationResultBasedEntityAssociationLoader-test.ts
@@ -36,6 +36,24 @@ describe(AuthorizationResultBasedEntityAssociationLoader, () => {
       );
       expect(loadedOther2).toBeNull();
     });
+
+    it('does not treat falsy non-null association values as missing', async () => {
+      const companionProvider = createUnitTestEntityCompanionProvider();
+      const viewerContext = new TestViewerContext(companionProvider);
+      const testEntity = await enforceAsyncResult(
+        TestEntity.creatorWithAuthorizationResults(viewerContext)
+          .setField('stringField', '')
+          .createAsync(),
+      );
+
+      await expect(
+        enforceAsyncResult(
+          testEntity
+            .associationLoaderWithAuthorizationResults()
+            .loadAssociatedEntityAsync('stringField', TestEntity),
+        ),
+      ).rejects.toThrow('Entity field not valid');
+    });
   });
 
   describe('loadManyAssociatedEntitiesAsync', () => {


### PR DESCRIPTION
# Why

The bug is that if the column in the current entity that contains the referenced entity's `id` is an empty string, the load method would erroneously return null. This correct the behavior to correctly try to load the entity by ID, which correctly fails since the field is invalid.

# How

Fix check.

# Test Plan

Add new test.