### PR TITLE
fix: pick method crash when object has hasOwnProperty key

### DIFF
--- a/packages/entity/src/__tests__/entityUtils-test.ts
+++ b/packages/entity/src/__tests__/entityUtils-test.ts
@@ -98,6 +98,14 @@ describe(pick, () => {
       b: 2,
     });
   });
+
+  it('handles objects that shadow hasOwnProperty', () => {
+    const object = {
+      a: 1,
+      hasOwnProperty: false,
+    };
+    expect(pick(object, ['a'])).toEqual({ a: 1 });
+  });
 });
 
 describe(partitionArray, () => {

--- a/packages/entity/src/entityUtils.ts
+++ b/packages/entity/src/entityUtils.ts
@@ -117,7 +117,7 @@ export const pick = <T extends object, U extends keyof T>(
 ): Pick<T, U> => {
   const result = {} as Pick<T, U>;
   for (const prop of props) {
-    if (object.hasOwnProperty(prop)) {
+    if (Object.prototype.hasOwnProperty.call(object, prop)) {
       result[prop] = object[prop];
     }
   }


### PR DESCRIPTION
# Why

`pick` was calling `object.hasOwnProperty(prop)`, but if the object had a property `hasOwnProperty`, it'd be used.

# How

Fix is to use the Object prototype's method.

# Test Plan

Run added test.