### PR TITLE
chore: update comment for IEntityMetricsAdapter for implementors

### DIFF
--- a/packages/entity/src/metrics/IEntityMetricsAdapter.ts
+++ b/packages/entity/src/metrics/IEntityMetricsAdapter.ts
@@ -183,6 +183,10 @@ export interface EntityMetricsAuthorizationEvent {
 /**
  * An interface for gathering metrics about the Entity framework. Information about
  * entity load and mutation operations is piped to an instance of this adapter.
+ *
+ * Method implementations of this interface must not throw exceptions since they are called
+ * in critical paths of entity loading and mutation, and thrown exceptions would cause entity
+ * operations to fail at points not tested by unit tests of the adapter implementation.
  */
 export interface IEntityMetricsAdapter {
   /**


### PR DESCRIPTION
# Why

Just a comment update to make it clearer that IEntityMetricsAdapter implementations must not throw since it'll cause adverse effects for the library.

In a follow-up, it may be good to defend against this, but it's not a straightforward fix.

# How

Update comment.

# Test Plan

Proofread.