### PR TITLE
fix: fix possible composite key collision in StubDatabaseAdapter test utility

### DIFF
--- a/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/StubPostgresDatabaseAdapter.ts
@@ -75,7 +75,7 @@ export class StubPostgresDatabaseAdapter<
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
     const results = StubPostgresDatabaseAdapter.uniqBy(tableTuples, (tuple) =>
-      tuple.join(':'),
+      JSON.stringify(tuple),
     ).reduce(
       (acc, tableTuple) => {
         return acc.concat(

--- a/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
+++ b/packages/entity-database-adapter-knex-testing-utils/src/__tests__/StubPostgresDatabaseAdapter-test.ts
@@ -174,6 +174,55 @@ describe(StubPostgresDatabaseAdapter, () => {
       const id2Results = results.get(new SingleFieldValueHolder('id2'));
       expect(id2Results?.[0]).toMatchObject({ customIdField: 'id2', stringField: 'test2' });
     });
+
+    it('does not collapse distinct composite tuples that stringify with the same delimiter join', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubPostgresDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubPostgresDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'id1',
+                  testIndexedField: 'b',
+                  intField: 5,
+                  stringField: 'a:b',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'id2',
+                  testIndexedField: 'b:c',
+                  intField: 10,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const results = await databaseAdapter.fetchManyWhereAsync(
+        queryContext,
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'testIndexedField']),
+        [
+          new CompositeFieldValueHolder({ stringField: 'a:b', testIndexedField: 'c' }),
+          new CompositeFieldValueHolder({ stringField: 'a', testIndexedField: 'b:c' }),
+        ],
+      );
+
+      expect(
+        results.get(new CompositeFieldValueHolder({ stringField: 'a:b', testIndexedField: 'c' })),
+      ).toHaveLength(0);
+      expect(
+        results.get(new CompositeFieldValueHolder({ stringField: 'a', testIndexedField: 'b:c' })),
+      ).toHaveLength(1);
+    });
   });
 
   describe('fetchOneWhereAsync', () => {

--- a/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
+++ b/packages/entity-database-adapter-knex/src/__tests__/fixtures/StubPostgresDatabaseAdapter.ts
@@ -76,7 +76,7 @@ export class StubPostgresDatabaseAdapter<
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
     const results = StubPostgresDatabaseAdapter.uniqBy(tableTuples, (tuple) =>
-      tuple.join(':'),
+      JSON.stringify(tuple),
     ).reduce(
       (acc, tableTuple) => {
         return acc.concat(

--- a/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
+++ b/packages/entity-testing-utils/src/StubDatabaseAdapter.ts
@@ -63,7 +63,9 @@ export class StubDatabaseAdapter<
     tableTuples: (readonly any[])[],
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
-    const results = StubDatabaseAdapter.uniqBy(tableTuples, (tuple) => tuple.join(':')).reduce(
+    const results = StubDatabaseAdapter.uniqBy(tableTuples, (tuple) =>
+      JSON.stringify(tuple),
+    ).reduce(
       (acc, tableTuple) => {
         return acc.concat(
           objectCollection.filter((obj) => {

--- a/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/StubDatabaseAdapter-test.ts
@@ -117,6 +117,55 @@ describe(StubDatabaseAdapter, () => {
         results2.get(new CompositeFieldValueHolder({ stringField: 'not-in-db', intField: 5 })),
       ).toHaveLength(0);
     });
+
+    it('does not collapse distinct composite tuples that stringify with the same delimiter join', async () => {
+      const queryContext = instance(mock(EntityQueryContext));
+      const databaseAdapter = new StubDatabaseAdapter<TestFields, 'customIdField'>(
+        testEntityConfiguration,
+        StubDatabaseAdapter.convertFieldObjectsToDataStore(
+          testEntityConfiguration,
+          new Map([
+            [
+              testEntityConfiguration.tableName,
+              [
+                {
+                  customIdField: 'id1',
+                  testIndexedField: 'b',
+                  intField: 5,
+                  stringField: 'a:b',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+                {
+                  customIdField: 'id2',
+                  testIndexedField: 'b:c',
+                  intField: 10,
+                  stringField: 'a',
+                  dateField: new Date(),
+                  nullableField: null,
+                },
+              ],
+            ],
+          ]),
+        ),
+      );
+
+      const results = await databaseAdapter.fetchManyWhereAsync(
+        queryContext,
+        new CompositeFieldHolder<TestFields, 'customIdField'>(['stringField', 'testIndexedField']),
+        [
+          new CompositeFieldValueHolder({ stringField: 'a:b', testIndexedField: 'c' }),
+          new CompositeFieldValueHolder({ stringField: 'a', testIndexedField: 'b:c' }),
+        ],
+      );
+
+      expect(
+        results.get(new CompositeFieldValueHolder({ stringField: 'a:b', testIndexedField: 'c' })),
+      ).toHaveLength(0);
+      expect(
+        results.get(new CompositeFieldValueHolder({ stringField: 'a', testIndexedField: 'b:c' })),
+      ).toHaveLength(1);
+    });
   });
 
   describe('fetchOneWhereAsync', () => {

--- a/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
+++ b/packages/entity/src/utils/__testfixtures__/StubDatabaseAdapter.ts
@@ -63,7 +63,9 @@ export class StubDatabaseAdapter<
     tableTuples: (readonly any[])[],
   ): Promise<object[]> {
     const objectCollection = this.getObjectCollectionForTable(tableName);
-    const results = StubDatabaseAdapter.uniqBy(tableTuples, (tuple) => tuple.join(':')).reduce(
+    const results = StubDatabaseAdapter.uniqBy(tableTuples, (tuple) =>
+      JSON.stringify(tuple),
+    ).reduce(
       (acc, tableTuple) => {
         return acc.concat(
           objectCollection.filter((obj) => {


### PR DESCRIPTION
# Why

The stub adapters were doing a simple `:` join, so it was possible for two rows to collide in the stub adapter during tests, if value has the delimiter.

# How

Fix is to use JSON.stringify so that only truly same rows map to the same thing.

# Test Plan

Run new tests.