### PR TITLE
fix: correctness of TSMockitoExtensions isEqualWithEntityAware for SerializableKeyMaps of different length

### DIFF
--- a/packages/entity-testing-utils/src/TSMockitoExtensions.ts
+++ b/packages/entity-testing-utils/src/TSMockitoExtensions.ts
@@ -34,8 +34,11 @@ export function isEqualWithEntityAware(expected: any, actual: any): boolean {
     }
 
     if (expected instanceof SerializableKeyMap && actual instanceof SerializableKeyMap) {
+      if (expected.size !== actual.size) {
+        return false;
+      }
       for (const [key, value] of expected.entries()) {
-        if (!actual.has(key) || !isEqualWith(value, actual.get(key))) {
+        if (!actual.has(key) || !isEqualWithEntityAware(value, actual.get(key))) {
           return false;
         }
       }

--- a/packages/entity-testing-utils/src/__tests__/TSMockitoExtensions-test.ts
+++ b/packages/entity-testing-utils/src/__tests__/TSMockitoExtensions-test.ts
@@ -60,7 +60,14 @@ describe(isEqualWithEntityAware, () => {
     const map3 = new SingleFieldValueHolderMap(
       new Map([[new SingleFieldValueHolder('foo2'), 'bar']]),
     );
+    const map4 = new SingleFieldValueHolderMap(
+      new Map([
+        [new SingleFieldValueHolder('foo'), 'bar'],
+        [new SingleFieldValueHolder('extra'), 'bar'],
+      ]),
+    );
     expect(isEqualWithEntityAware(map1, map2)).toBe(true);
     expect(isEqualWithEntityAware(map1, map3)).toBe(false);
+    expect(isEqualWithEntityAware(map1, map4)).toBe(false);
   });
 });

--- a/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
+++ b/packages/entity/src/utils/__testfixtures__/TSMockitoExtensions.ts
@@ -34,8 +34,11 @@ export function isEqualWithEntityAware(expected: any, actual: any): boolean {
     }
 
     if (expected instanceof SerializableKeyMap && actual instanceof SerializableKeyMap) {
+      if (expected.size !== actual.size) {
+        return false;
+      }
       for (const [key, value] of expected.entries()) {
-        if (!actual.has(key) || !isEqualWith(value, actual.get(key))) {
+        if (!actual.has(key) || !isEqualWithEntityAware(value, actual.get(key))) {
           return false;
         }
       }


### PR DESCRIPTION
# Why

A bug exists where the ts-mockito extension entity aware matcher would report map equality even when the maps were of different lengths (assuming shorter map had all the same elements as first part of longer map).

# How

Fix by preemptively checking length. Also fix recursive call to use `isEqualWithEntityAware` in case nested objects need it.

# Test Plan

Run updated test.