### PR TITLE
fix: require transactional query context for createOrGetExistingAsync utility method

### DIFF
--- a/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
+++ b/packages/entity-database-adapter-knex/src/__integration-tests__/EntityCreationUtils-test.ts
@@ -33,57 +33,6 @@ describe(createWithUniqueConstraintRecoveryAsync, () => {
   });
 
   describe.each([true, false])('is parallel creations %p', (parallel) => {
-    it('recovers when the same entity is created twice outside of transaction', async () => {
-      const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
-
-      const args = {
-        name: 'unique',
-      };
-
-      let createdEntities: [PostgresUniqueTestEntity, PostgresUniqueTestEntity];
-      if (parallel) {
-        createdEntities = await Promise.all([
-          createWithUniqueConstraintRecoveryAsync(
-            vc1,
-            PostgresUniqueTestEntity,
-            PostgresUniqueTestEntity.getByNameAsync,
-            args,
-            PostgresUniqueTestEntity.createWithNameAsync,
-            args,
-          ),
-          createWithUniqueConstraintRecoveryAsync(
-            vc1,
-            PostgresUniqueTestEntity,
-            PostgresUniqueTestEntity.getByNameAsync,
-            args,
-            PostgresUniqueTestEntity.createWithNameAsync,
-            args,
-          ),
-        ]);
-      } else {
-        createdEntities = [
-          await createWithUniqueConstraintRecoveryAsync(
-            vc1,
-            PostgresUniqueTestEntity,
-            PostgresUniqueTestEntity.getByNameAsync,
-            args,
-            PostgresUniqueTestEntity.createWithNameAsync,
-            args,
-          ),
-          await createWithUniqueConstraintRecoveryAsync(
-            vc1,
-            PostgresUniqueTestEntity,
-            PostgresUniqueTestEntity.getByNameAsync,
-            args,
-            PostgresUniqueTestEntity.createWithNameAsync,
-            args,
-          ),
-        ];
-      }
-
-      expect(createdEntities[0].getID()).toEqual(createdEntities[1].getID());
-    });
-
     it('recovers when the same entity is created twice within same transaction', async () => {
       const vc1 = new ViewerContext(createKnexIntegrationTestEntityCompanionProvider(knexInstance));
 

--- a/packages/entity/src/utils/EntityCreationUtils.ts
+++ b/packages/entity/src/utils/EntityCreationUtils.ts
@@ -46,25 +46,18 @@ export async function createOrGetExistingAsync<
     queryContext?: EntityTransactionalQueryContext,
   ) => Promise<TEntity>,
   createArgs: TCreateArgs,
-  queryContext?: EntityTransactionalQueryContext,
+  queryContext: EntityTransactionalQueryContext,
 ): Promise<TEntity> {
-  if (!queryContext) {
-    const maybeEntity = await getAsync(viewerContext, getArgs);
-    if (maybeEntity) {
-      return maybeEntity;
-    }
-  } else {
-    // This is done in a nested transaction since entity may negatively cache load results per-transaction (when configured).
-    // Without it, it would
-    // 1. load the entity in the current query context, negatively cache it
-    // 2. then try to create it in the nested transaction, which may fail due to a unique constraint error
-    // 3. then try to load the entity again in the current query context, which would return null due to negative cache
-    const maybeEntity = await queryContext.runInNestedTransactionAsync((nestedQueryContext) =>
-      getAsync(viewerContext, getArgs, nestedQueryContext),
-    );
-    if (maybeEntity) {
-      return maybeEntity;
-    }
+  // This is done in a nested transaction since entity may negatively cache load results per-transaction (when configured).
+  // Without it, it would
+  // 1. load the entity in the current query context, negatively cache it
+  // 2. then try to create it in the nested transaction, which may fail due to a unique constraint error
+  // 3. then try to load the entity again in the current query context, which would return null due to negative cache
+  const maybeEntity = await queryContext.runInNestedTransactionAsync((nestedQueryContext) =>
+    getAsync(viewerContext, getArgs, nestedQueryContext),
+  );
+  if (maybeEntity) {
+    return maybeEntity;
   }
   return await createWithUniqueConstraintRecoveryAsync(
     viewerContext,
@@ -118,12 +111,9 @@ export async function createWithUniqueConstraintRecoveryAsync<
     queryContext?: EntityTransactionalQueryContext,
   ) => Promise<TEntity>,
   createArgs: TCreateArgs,
-  queryContext?: EntityTransactionalQueryContext,
+  queryContext: EntityTransactionalQueryContext,
 ): Promise<TEntity> {
   try {
-    if (!queryContext) {
-      return await createAsync(viewerContext, createArgs);
-    }
     return await queryContext.runInNestedTransactionAsync((nestedQueryContext) =>
       createAsync(viewerContext, createArgs, nestedQueryContext),
     );

--- a/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
+++ b/packages/entity/src/utils/__tests__/EntityCreationUtils-test.ts
@@ -13,48 +13,30 @@ import { createUnitTestEntityCompanionProvider } from '../__testfixtures__/creat
 
 type TArgs = object;
 
-describe.each([true, false])('in transaction %p', (inTransaction) => {
-  describe(createOrGetExistingAsync, () => {
-    it('does not create when already exists', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
+describe(createOrGetExistingAsync, () => {
+  it('does not create when already exists', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
 
-      const entity = await SimpleTestEntity.creator(viewerContext).createAsync();
+    const entity = await SimpleTestEntity.creator(viewerContext).createAsync();
 
-      const args: TArgs = {};
+    const args: TArgs = {};
 
-      const getFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          return entity;
-        },
-      );
+    const getFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        return entity;
+      },
+    );
 
-      const createFn = jest.fn(
-        async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
-          return await SimpleTestEntity.creator(vc, queryContext).createAsync();
-        },
-      );
+    const createFn = jest.fn(
+      async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
+        return await SimpleTestEntity.creator(vc, queryContext).createAsync();
+      },
+    );
 
-      if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
-          'postgres',
-          async (queryContext) => {
-            await createOrGetExistingAsync(
-              viewerContext,
-              SimpleTestEntity,
-              getFn,
-              args,
-              createFn,
-              args,
-              queryContext,
-            );
-          },
-        );
-      } else {
+    await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+      'postgres',
+      async (queryContext) => {
         await createOrGetExistingAsync(
           viewerContext,
           SimpleTestEntity,
@@ -62,105 +44,75 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
           args,
           createFn,
           args,
+          queryContext,
         );
-      }
+      },
+    );
 
-      expect(getFn).toHaveBeenCalledTimes(1);
-      expect(createFn).toHaveBeenCalledTimes(0);
-    });
-
-    it('creates when not found', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
-
-      const args: TArgs = {};
-
-      const getFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          return null;
-        },
-      );
-
-      const createFn = jest.fn(
-        async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
-          return await SimpleTestEntity.creator(vc, queryContext).createAsync();
-        },
-      );
-
-      if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
-          'postgres',
-          async (queryContext) => {
-            await createOrGetExistingAsync(
-              viewerContext,
-              SimpleTestEntity,
-              getFn,
-              args,
-              createFn,
-              args,
-              queryContext,
-            );
-          },
-        );
-      } else {
-        await createOrGetExistingAsync(
-          viewerContext,
-          SimpleTestEntity,
-          getFn,
-          args,
-          createFn,
-          args,
-        );
-      }
-
-      expect(getFn).toHaveBeenCalledTimes(1);
-      expect(createFn).toHaveBeenCalledTimes(1);
-    });
+    expect(getFn).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledTimes(0);
   });
 
-  describe(createWithUniqueConstraintRecoveryAsync, () => {
-    it('does not call get when creation succeeds', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
+  it('creates when not found', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
 
-      const args: TArgs = {};
+    const args: TArgs = {};
 
-      const getFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          return null;
-        },
-      );
+    const getFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        return null;
+      },
+    );
 
-      const createFn = jest.fn(
-        async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
-          return await SimpleTestEntity.creator(vc, queryContext).createAsync();
-        },
-      );
+    const createFn = jest.fn(
+      async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
+        return await SimpleTestEntity.creator(vc, queryContext).createAsync();
+      },
+    );
 
-      if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
-          'postgres',
-          async (queryContext) => {
-            await createWithUniqueConstraintRecoveryAsync(
-              viewerContext,
-              SimpleTestEntity,
-              getFn,
-              args,
-              createFn,
-              args,
-              queryContext,
-            );
-          },
+    await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+      'postgres',
+      async (queryContext) => {
+        await createOrGetExistingAsync(
+          viewerContext,
+          SimpleTestEntity,
+          getFn,
+          args,
+          createFn,
+          args,
+          queryContext,
         );
-      } else {
+      },
+    );
+
+    expect(getFn).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe(createWithUniqueConstraintRecoveryAsync, () => {
+  it('does not call get when creation succeeds', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const args: TArgs = {};
+
+    const getFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        return null;
+      },
+    );
+
+    const createFn = jest.fn(
+      async (vc: ViewerContext, _args: TArgs, queryContext?: EntityTransactionalQueryContext) => {
+        return await SimpleTestEntity.creator(vc, queryContext).createAsync();
+      },
+    );
+
+    await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+      'postgres',
+      async (queryContext) => {
         await createWithUniqueConstraintRecoveryAsync(
           viewerContext,
           SimpleTestEntity,
@@ -168,57 +120,38 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
           args,
           createFn,
           args,
+          queryContext,
         );
-      }
+      },
+    );
 
-      expect(getFn).toHaveBeenCalledTimes(0);
-      expect(createFn).toHaveBeenCalledTimes(1);
-    });
+    expect(getFn).toHaveBeenCalledTimes(0);
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
 
-    it('calls get when database adapter throws EntityDatabaseAdapterUniqueConstraintError', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
+  it('calls get when database adapter throws EntityDatabaseAdapterUniqueConstraintError', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
 
-      const entity = await SimpleTestEntity.creator(viewerContext).createAsync();
+    const entity = await SimpleTestEntity.creator(viewerContext).createAsync();
 
-      const args: TArgs = {};
+    const args: TArgs = {};
 
-      const getFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          return entity;
-        },
-      );
+    const getFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        return entity;
+      },
+    );
 
-      const createFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          throw new EntityDatabaseAdapterUniqueConstraintError('wat');
-        },
-      );
+    const createFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        throw new EntityDatabaseAdapterUniqueConstraintError('wat');
+      },
+    );
 
-      if (inTransaction) {
-        await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
-          'postgres',
-          async (queryContext) => {
-            await createWithUniqueConstraintRecoveryAsync(
-              viewerContext,
-              SimpleTestEntity,
-              getFn,
-              args,
-              createFn,
-              args,
-              queryContext,
-            );
-          },
-        );
-      } else {
+    await viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+      'postgres',
+      async (queryContext) => {
         await createWithUniqueConstraintRecoveryAsync(
           viewerContext,
           SimpleTestEntity,
@@ -226,131 +159,90 @@ describe.each([true, false])('in transaction %p', (inTransaction) => {
           args,
           createFn,
           args,
+          queryContext,
         );
-      }
+      },
+    );
 
-      expect(getFn).toHaveBeenCalledTimes(1);
-      expect(createFn).toHaveBeenCalledTimes(1);
-    });
+    expect(getFn).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
 
-    it('throws an EntityNotFoundError when database adapter throws EntityDatabaseAdapterUniqueConstraintError and getFn returns null', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
+  it('throws an EntityNotFoundError when database adapter throws EntityDatabaseAdapterUniqueConstraintError and getFn returns null', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
 
-      const args: TArgs = {};
+    const args: TArgs = {};
 
-      const getFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          return null;
-        },
-      );
+    const getFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        return null;
+      },
+    );
 
-      const createFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          throw new EntityDatabaseAdapterUniqueConstraintError('wat');
-        },
-      );
+    const createFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        throw new EntityDatabaseAdapterUniqueConstraintError('wat');
+      },
+    );
 
-      if (inTransaction) {
-        await expect(
-          viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
-            'postgres',
-            async (queryContext) => {
-              return await createWithUniqueConstraintRecoveryAsync(
-                viewerContext,
-                SimpleTestEntity,
-                getFn,
-                args,
-                createFn,
-                args,
-                queryContext,
-              );
-            },
-          ),
-        ).rejects.toThrow(EntityNotFoundError);
-      } else {
-        await expect(
-          createWithUniqueConstraintRecoveryAsync(
+    await expect(
+      viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          return await createWithUniqueConstraintRecoveryAsync(
             viewerContext,
             SimpleTestEntity,
             getFn,
             args,
             createFn,
             args,
-          ),
-        ).rejects.toThrow(EntityNotFoundError);
-      }
-
-      expect(getFn).toHaveBeenCalledTimes(1);
-      expect(createFn).toHaveBeenCalledTimes(1);
-    });
-
-    it('rethrows whatever error is thrown from database adapter  if not EntityDatabaseAdapterUniqueConstraintError', async () => {
-      const companionProvider = createUnitTestEntityCompanionProvider();
-      const viewerContext = new ViewerContext(companionProvider);
-
-      const args: TArgs = {};
-
-      const getFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          return null;
+            queryContext,
+          );
         },
-      );
+      ),
+    ).rejects.toThrow(EntityNotFoundError);
 
-      const createFn = jest.fn(
-        async (
-          _vc: ViewerContext,
-          _args: TArgs,
-          _queryContext?: EntityTransactionalQueryContext,
-        ) => {
-          throw new Error('wat');
-        },
-      );
+    expect(getFn).toHaveBeenCalledTimes(1);
+    expect(createFn).toHaveBeenCalledTimes(1);
+  });
 
-      if (inTransaction) {
-        await expect(
-          viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
-            'postgres',
-            async (queryContext) => {
-              return await createWithUniqueConstraintRecoveryAsync(
-                viewerContext,
-                SimpleTestEntity,
-                getFn,
-                args,
-                createFn,
-                args,
-                queryContext,
-              );
-            },
-          ),
-        ).rejects.toThrow('wat');
-      } else {
-        await expect(
-          createWithUniqueConstraintRecoveryAsync(
+  it('rethrows whatever error is thrown from database adapter  if not EntityDatabaseAdapterUniqueConstraintError', async () => {
+    const companionProvider = createUnitTestEntityCompanionProvider();
+    const viewerContext = new ViewerContext(companionProvider);
+
+    const args: TArgs = {};
+
+    const getFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        return null;
+      },
+    );
+
+    const createFn = jest.fn(
+      async (_vc: ViewerContext, _args: TArgs, _queryContext?: EntityTransactionalQueryContext) => {
+        throw new Error('wat');
+      },
+    );
+
+    await expect(
+      viewerContext.runInTransactionForDatabaseAdapterFlavorAsync(
+        'postgres',
+        async (queryContext) => {
+          return await createWithUniqueConstraintRecoveryAsync(
             viewerContext,
             SimpleTestEntity,
             getFn,
             args,
             createFn,
             args,
-          ),
-        ).rejects.toThrow('wat');
-      }
+            queryContext,
+          );
+        },
+      ),
+    ).rejects.toThrow('wat');
 
-      expect(getFn).toHaveBeenCalledTimes(0);
-      expect(createFn).toHaveBeenCalledTimes(1);
-    });
+    expect(getFn).toHaveBeenCalledTimes(0);
+    expect(createFn).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Why

One class of issue in entity is concurrent calls to load/create methods caching stale data in dataloaders/redis when done outside a transaction (otherwise dataloaders are scoped to transaction and cache adapter is skipped). This can happen when multiple calls to blocks of code like `createOrGetExistingAsync` happen in parallel without an explicit transactional query context, within which it would negatively cache in one call and then incorrectly retrieve that negative cache from another call depending on race condition ordering.

Concretely, one such issue with `createOrGetExistingAsync` is reproducible by calling it with the same set of args:
```typescript
const [a, b] = await Promise.all([
  createOrGetExistingAsync(...args),
  createOrGetExistingAsync(...args),
]);
```
This will throw due to the ordering: both calls will miss initially, both will create, one will hit unique constraint error (handled), that one will try to re-load, but will see the negatively-cached result in dataloader.

# How

While the class of bug can happen with really any non-transactional sequence of loads/mutations, entity as a library should do its best to prevent it from occurring in blessed utility methods. The only way to make this deterministic is via requiring a transactional query context be supplied to `createOrGetExistingAsync`.

Reasoning for why this is likely the right call path. Most creations in applications should already be within transactions, and those that aren't automatically start a transaction in the mutator to run the triggers and create within the same transaction. This change makes the semantics of this method more explicit without much loss of usability and protects against the race that is likely.

# Test Plan

ToDo