### PR TITLE
chore: update renovate groups for new linter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,8 @@
       "groupName": "CI workflows"
     },
     {
-      "groupName": "eslint",
-      "matchPackageNames": ["/^eslint/"]
+      "groupName": "lint",
+      "matchPackageNames": ["/^eslint/", "/^oxlint/", "/^prettier/", "/^oxfmt/"]
     },
     {
       "groupName": "type definitions",


### PR DESCRIPTION
# Why

Now that this repo uses oxlint/oxfmt, update the renovate groups accordingly.

# How

Update groups

# Test Plan

Proofread