### PR TITLE
Add resolveGrantDecision permission-resolution helper

### DIFF
--- a/packages/entity/src/GrantResolution.ts
+++ b/packages/entity/src/GrantResolution.ts
@@ -1,0 +1,66 @@
+/**
+ * A small, pure helper for resolving whether a subject holds a required permission over a
+ * resource that lives in a containment hierarchy (e.g. resource -> parent -> root).
+ *
+ * It is intentionally dependency-free and total: the caller supplies the already-gathered
+ * data (the resource's ancestry, the permissions the subject holds keyed by resource, and
+ * whether the target resource opts out of inheritance for this permission), and this function
+ * applies the resolution rule. Keeping the rule separate from data gathering makes it trivial
+ * to unit-test and reuse across different storage/permission models.
+ */
+
+export interface GrantResolutionInput {
+  /**
+   * Resource keys ordered from the target resource up to the root ancestor,
+   * e.g. ['document:<id>', 'folder:<id>', 'root:<id>']. Index 0 is the target being accessed.
+   */
+  readonly ancestryResourceKeys: readonly string[];
+
+  /**
+   * Whether the target resource (ancestryResourceKeys[0]) opts out of inheritance for the
+   * required permission. When true, only a permission held directly on the target satisfies;
+   * permissions inherited from ancestors do not.
+   */
+  readonly targetInheritanceDisabledForRequiredPermission: boolean;
+
+  /**
+   * The permissions the subject holds on each resource key, already expanded through any
+   * implication closure. resourceKey -> set of permission names.
+   */
+  readonly heldPermissionsByResourceKey: ReadonlyMap<string, ReadonlySet<string>>;
+
+  /** The permission the action requires. */
+  readonly requiredPermission: string;
+}
+
+/**
+ * Returns true iff the subject holds the required permission on the target or, unless
+ * inheritance is disabled for the target, any of its ancestors.
+ *
+ * Pure, total, and deterministic: no I/O, no throwing.
+ */
+export function resolveGrantDecision(input: GrantResolutionInput): boolean {
+  const {
+    ancestryResourceKeys,
+    targetInheritanceDisabledForRequiredPermission,
+    heldPermissionsByResourceKey,
+    requiredPermission,
+  } = input;
+
+  if (ancestryResourceKeys.length === 0) {
+    return false;
+  }
+
+  const matchKeys = targetInheritanceDisabledForRequiredPermission
+    ? ancestryResourceKeys.slice(0, 1) // target only, inheritance disabled
+    : ancestryResourceKeys; // target and its ancestors
+
+  for (const resourceKey of matchKeys) {
+    const held = heldPermissionsByResourceKey.get(resourceKey);
+    if (held !== undefined && held.has(requiredPermission)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/entity/src/__tests__/GrantResolution-test.ts
+++ b/packages/entity/src/__tests__/GrantResolution-test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { resolveGrantDecision } from '../GrantResolution.ts';
+
+describe(resolveGrantDecision, () => {
+  const ancestry = ['document:d', 'folder:f', 'root:r'];
+
+  it('denies when the subject holds no permissions', () => {
+    expect(
+      resolveGrantDecision({
+        ancestryResourceKeys: ancestry,
+        targetInheritanceDisabledForRequiredPermission: false,
+        heldPermissionsByResourceKey: new Map(),
+        requiredPermission: 'write',
+      })
+    ).toBe(false);
+  });
+
+  it('allows a permission held directly on the target', () => {
+    expect(
+      resolveGrantDecision({
+        ancestryResourceKeys: ancestry,
+        targetInheritanceDisabledForRequiredPermission: false,
+        heldPermissionsByResourceKey: new Map([['document:d', new Set(['write'])]]),
+        requiredPermission: 'write',
+      })
+    ).toBe(true);
+  });
+
+  it('allows a permission inherited from an ancestor', () => {
+    expect(
+      resolveGrantDecision({
+        ancestryResourceKeys: ancestry,
+        targetInheritanceDisabledForRequiredPermission: false,
+        heldPermissionsByResourceKey: new Map([['root:r', new Set(['write'])]]),
+        requiredPermission: 'write',
+      })
+    ).toBe(true);
+  });
+
+  it('does not match a different permission', () => {
+    expect(
+      resolveGrantDecision({
+        ancestryResourceKeys: ancestry,
+        targetInheritanceDisabledForRequiredPermission: false,
+        heldPermissionsByResourceKey: new Map([['root:r', new Set(['read'])]]),
+        requiredPermission: 'write',
+      })
+    ).toBe(false);
+  });
+
+  describe('when inheritance is disabled for the target', () => {
+    it('ignores permissions inherited from ancestors', () => {
+      expect(
+        resolveGrantDecision({
+          ancestryResourceKeys: ancestry,
+          targetInheritanceDisabledForRequiredPermission: true,
+          heldPermissionsByResourceKey: new Map([
+            ['folder:f', new Set(['write'])],
+            ['root:r', new Set(['write'])],
+          ]),
+          requiredPermission: 'write',
+        })
+      ).toBe(false);
+    });
+
+    it('still honors a permission held directly on the target', () => {
+      expect(
+        resolveGrantDecision({
+          ancestryResourceKeys: ancestry,
+          targetInheritanceDisabledForRequiredPermission: true,
+          heldPermissionsByResourceKey: new Map([['document:d', new Set(['write'])]]),
+          requiredPermission: 'write',
+        })
+      ).toBe(true);
+    });
+  });
+
+  it('denies when the ancestry is empty', () => {
+    expect(
+      resolveGrantDecision({
+        ancestryResourceKeys: [],
+        targetInheritanceDisabledForRequiredPermission: false,
+        heldPermissionsByResourceKey: new Map([['document:d', new Set(['write'])]]),
+        requiredPermission: 'write',
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/entity/src/index.ts
+++ b/packages/entity/src/index.ts
@@ -80,3 +80,5 @@ export * from './utils/mergeEntityMutationTriggerConfigurations.ts';
 export * from './utils/collections/maps.ts';
 export * from './utils/collections/SerializableKeyMap.ts';
 export * from './utils/collections/sets.ts';
+
+export * from './GrantResolution.ts';


### PR DESCRIPTION
# Why

A small reusable helper for a common authorization shape: deciding whether a subject holds a permission on a resource that lives in a containment hierarchy (resource → parent → root), with an optional per-resource opt-out from inheritance.

# How

Adds `resolveGrantDecision`, a pure, dependency-free function. The caller gathers the data (the resource's ancestry, the permissions held keyed by resource, and whether the target opts out of inheritance for the required permission) and this function applies the resolution rule. Keeping the rule separate from data gathering keeps it easy to unit-test and to reuse across different storage and permission models.

# Test Plan

Unit tests cover direct grants, inherited grants, a non-matching permission, the inheritance opt-out (both directions), and the empty-ancestry case.
