### PR TITLE
chore: treat typedoc warnings as errors to keep evergreen

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -8,6 +8,7 @@
     "entryPoints": ["src/index.ts"]
   },
   "out": "doc",
+  "treatWarningsAsErrors": true,
   "highlightLanguages": [
     "bash",
     "console",


### PR DESCRIPTION
# Why

#671 fixed some. This changes the CI so that we don't have to periodically fix these. Instead, CI will fail on warnings.

# How

Add setting.

# Test Plan

CI